### PR TITLE
Fix dead links on rest client by removing ManagerBean dependency

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseDetail.java
@@ -30,7 +30,7 @@ import ch.ivyteam.enginecockpit.util.Tab;
 import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
-public class WebTestDatabaseDetail {
+class WebTestDatabaseDetail {
   private static final String DATABASE_NAME = "test-db";
 
   @BeforeEach
@@ -43,8 +43,8 @@ public class WebTestDatabaseDetail {
   }
 
   @Test
-  void testDetailOpen() {
-    assertCurrentUrlContains("databasedetail.xhtml?databaseName=" + DATABASE_NAME);
+  void detailOpen() {
+    assertCurrentUrlContains("databasedetail.xhtml?app=" + Tab.DEFAULT_APP + "&env=Default&name=" + DATABASE_NAME);
     $$(".card").shouldHave(size(4));
     $("#databaseConfigurationForm\\:name").shouldBe(exactText(DATABASE_NAME));
 
@@ -54,7 +54,7 @@ public class WebTestDatabaseDetail {
   }
 
   @Test
-  void testDatabaseTestConnection() {
+  void databaseTestConnection() {
     assertDatabaseTestConnection("Error");
 
     Navigation.toDatabaseDetail("realdb");
@@ -75,7 +75,7 @@ public class WebTestDatabaseDetail {
   }
 
   @Test
-  void testSaveAndResetChanges() {
+  void saveAndResetChanges() {
     setConfiguration("url", "org.postgresql.Driver", "testUser", "13");
     Selenide.refresh();
     checkConfiguration("url", "org.postgresql.Driver", "testUser", "13");

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseHistory.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseHistory.java
@@ -21,7 +21,7 @@ import ch.ivyteam.enginecockpit.util.Tab;
 import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
-public class WebTestDatabaseHistory {
+class WebTestDatabaseHistory {
 
   @BeforeEach
   void beforeEach() {
@@ -38,7 +38,7 @@ public class WebTestDatabaseHistory {
   }
 
   @Test
-  void testConnectionAndHistory() {
+  void connectionAndHistory() {
     new Table(By.id("databaseConnectionForm:databaseConnectionsTable"))
             .firstColumnShouldBe(sizeGreaterThan(0));
     new Table(By.id("databaseExecHistoryForm:databaseExecHistoryTable"))

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestRestClientDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestRestClientDetail.java
@@ -23,7 +23,7 @@ import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Tab;
 
 @IvyWebTest
-public class WebTestRestClientDetail {
+class WebTestRestClientDetail {
   private static final String RESTCLIENT_NAME = "test-rest";
 
   @BeforeEach
@@ -39,8 +39,8 @@ public class WebTestRestClientDetail {
   }
 
   @Test
-  void testDetailOpen() {
-    assertCurrentUrlContains("restclientdetail.xhtml?restClientName=" + RESTCLIENT_NAME);
+  void detailOpen() {
+    assertCurrentUrlContains("restclientdetail.xhtml?app=" + Tab.DEFAULT_APP + "&env=Default&name=" + RESTCLIENT_NAME);
     $$(".card").shouldHave(size(2));
     $("#restClientConfigurationForm\\:name").shouldBe(exactText(RESTCLIENT_NAME));
 
@@ -50,7 +50,7 @@ public class WebTestRestClientDetail {
   }
 
   @Test
-  void testRestTestConnection() {
+  void restTestConnection() {
     setUrl("localhost");
     setUserName("");
     testAndAssertConnection("Invalid Url");
@@ -77,7 +77,7 @@ public class WebTestRestClientDetail {
   }
 
   @Test
-  void testSaveAndResetChanges() {
+  void saveAndResetChanges() {
     setConfiguration("url", "testUser");
     Selenide.refresh();
     checkConfiguration("url", "testUser");
@@ -126,5 +126,4 @@ public class WebTestRestClientDetail {
     $("#restClientConfigurationForm\\:resetRestConfirmYesBtn").click();
     $("#restClientConfigurationForm\\:restConfigMsg_container").shouldBe(text("Rest configuration reset"));
   }
-
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebserviceDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebserviceDetail.java
@@ -50,8 +50,8 @@ class WebTestWebserviceDetail {
   }
 
   @Test
-  void testDetailOpen() {
-    assertCurrentUrlContains("webservicedetail.xhtml?webserviceId=");
+  void detailOpen() {
+    assertCurrentUrlContains("webservicedetail.xhtml?app=" + Tab.DEFAULT_APP + "&env=Default&id=");
     $$(".card").shouldHave(size(3));
     $("#webserviceConfigurationForm\\:name").shouldBe(exactText(WEBSERVICE_NAME));
 
@@ -61,7 +61,7 @@ class WebTestWebserviceDetail {
   }
 
   @Test
-  void testSaveAndResetChanges() {
+  void saveAndResetChanges() {
     setConfiguration("testUser");
     Selenide.refresh();
     checkConfiguration("testUser");
@@ -97,7 +97,7 @@ class WebTestWebserviceDetail {
   }
 
   @Test
-  void testWsEndpointTestConnection() {
+  void wsEndpointTestConnection() {
     setEndPoint("http://test-webservices.ivyteam.io:8080/notfound");
     Selenide.refresh();
     testAndAssertConnection("Status 404");
@@ -126,7 +126,7 @@ class WebTestWebserviceDetail {
   }
 
   @Test
-  void testEditEndpointsInvalid() {
+  void editEndpointsInvalid() {
     new Table(By.id("webservcieEndPointForm:webserviceEndpointTable"), "", "data-rk")
             .clickButtonForEntry("SampleWebServiceSoap", "editEndpointBtn");
     $("#webservcieEndPointForm\\:defaultInput").clear();
@@ -135,7 +135,7 @@ class WebTestWebserviceDetail {
   }
 
   @Test
-  void testSetAndResetEndpoints() {
+  void setAndResetEndpoints() {
     setEndPoint("default", "first", "second");
     Selenide.refresh();
     checkEndPoint("default", "first", "second");
@@ -147,7 +147,7 @@ class WebTestWebserviceDetail {
   }
 
   @Test
-  void testSetAndResetEndpoints_noFallbacks() {
+  void setAndResetEndpoints_noFallbacks() {
     setEndPoint("default");
     Selenide.refresh();
     checkEndPoint("default");

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -196,7 +196,7 @@ public class Navigation {
   public static void toDatabaseDetail(String databaseName) {
     Navigation.toDatabases();
     $$(Tab.APP.activePanelCss + " .database-name").find(text(databaseName)).shouldBe(visible).click();
-    assertCurrentUrlContains("databasedetail.xhtml?databaseName=" + databaseName);
+    assertCurrentUrlContains("databasedetail.xhtml?app=" + Tab.DEFAULT_APP + "&env=Default&name=" + databaseName);
     menuShouldBeActive(SERVICES_DATABASES_MENU);
   }
 
@@ -209,7 +209,7 @@ public class Navigation {
   public static void toRestClientDetail(String restClientName) {
     Navigation.toRestClients();
     $$(Tab.APP.activePanelCss + " .restclient-name").find(text(restClientName)).shouldBe(visible).click();
-    assertCurrentUrlContains("restclientdetail.xhtml?restClientName=" + restClientName);
+    assertCurrentUrlContains("restclientdetail.xhtml?app=" + Tab.DEFAULT_APP + "&env=Default&name=" + restClientName);
     menuShouldBeActive(SERVICES_RESTCLIENTS_MENU);
   }
 
@@ -222,7 +222,7 @@ public class Navigation {
   public static void toWebserviceDetail(String webserviceName) {
     Navigation.toWebservices();
     $$(Tab.APP.activePanelCss + " .webservice-name").find(text(webserviceName)).shouldBe(visible).click();
-    assertCurrentUrlContains("webservicedetail.xhtml?webserviceId=");
+    assertCurrentUrlContains("webservicedetail.xhtml?app=" + Tab.DEFAULT_APP + "&env=Default&id=");
     menuShouldBeActive(SERVICES_WEBSERVICES_MENU);
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 
 public class Tab {
 
+  public static String DEFAULT_APP = isDesigner() ? DESIGNER : "test";
+
   public static final Tab SECURITY_SYSTEM = new Tab(
           "li.security-system-tab > a",
           "li.security-system-tab",
@@ -27,7 +29,8 @@ public class Tab {
           "li.application-tab",
           "li.application-tab.ui-state-active",
           ".ui-tabs-panel:not(.ui-helper-hidden)",
-          tab -> tab.switchToTab(isDesigner() ? DESIGNER : "test"));
+          tab -> tab.switchToTab(DEFAULT_APP));
+  
 
   private final String tab;
   private final String li;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/DatabaseDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/DatabaseDto.java
@@ -35,6 +35,10 @@ public class DatabaseDto implements IService {
     return name;
   }
 
+  public String getViewUrl(String app, String env) {
+    return "databasedetail.xhtml?app=" + app + "&env=" + env + "&name=" + name;
+  }
+
   public String getUrl() {
     return url;
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientDto.java
@@ -42,6 +42,10 @@ public class RestClientDto implements IService {
     return name;
   }
 
+  public String getViewUrl(String app, String env) {
+    return "restclientdetail.xhtml?app=" + app + "&env=" + env + "&name=" + name;
+  }
+
   public String getUrl() {
     return url;
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/Webservice.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/Webservice.java
@@ -63,6 +63,10 @@ public class Webservice implements IService {
     return description;
   }
 
+  public String getViewUrl(String app, String env) {
+    return "webservicedetail.xhtml?app=" + app + "&env=" + env + "&id=" + genId;
+  }
+
   public String getWsdlUrl() {
     return wsdlUrl;
   }

--- a/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
@@ -35,7 +35,7 @@
     <p:panelGrid columns="2" columnClasses="p-col-12 p-md-3 p-lg-3, p-col-12 p-md-9 p-lg-9" layout="flex"
       styleClass="grey-label-panel ui-fluid">
       <label>Name</label>
-      <h:outputText id="name" value="#{databaseDetailBean.databaseName}" />
+      <h:outputText id="name" value="#{databaseDetailBean.name}" />
   
       <p:outputLabel for="url" value="Url" />
       <p:inputText id="url" value="#{databaseDetailBean.database.url}" />

--- a/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
@@ -37,7 +37,7 @@
       <h:outputText id="uuid" value="#{restClientDetailBean.restClient.uniqueId}" />
   
       <label>Name</label>
-      <h:outputText id="name" value="#{restClientDetailBean.restClientName}" />
+      <h:outputText id="name" value="#{restClientDetailBean.name}" />
   
       <p:outputLabel for="decription" value="Description" />
       <h:outputText id="decription" value="#{restClientDetailBean.restClient.description}" />

--- a/engine-cockpit/webContent/view/databasedetail.xhtml
+++ b/engine-cockpit/webContent/view/databasedetail.xhtml
@@ -4,9 +4,9 @@
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:cc="http://java.sun.com/jsf/composite/composite">
 <h:body>
   <f:metadata>
-    <f:viewParam name="databaseName" value="#{databaseDetailBean.databaseName}" />
-    <f:viewParam name="applicationName" value="#{managerBean.selectedApplicationName}" />
-    <f:viewParam name="environment" value="#{managerBean.selectedEnvironment}" />
+    <f:viewParam name="app" value="#{databaseDetailBean.app}" />
+    <f:viewParam name="env" value="#{databaseDetailBean.env}" />
+    <f:viewParam name="name" value="#{databaseDetailBean.name}" />
     <f:viewAction action="#{databaseDetailBean.onload}" />
   </f:metadata>
 
@@ -17,7 +17,7 @@
       <li>/</li>
       <li><a href="databases.xhtml">Databases</a></li>
       <li>/</li>
-      <li><a href="databasedetail.xhtml?databaseName=#{databaseDetailBean.databaseName}">#{databaseDetailBean.databaseName}</a></li>
+      <li><a href="#{databaseDetailBean.viewUrl}">#{databaseDetailBean.name}</a></li>
       <cc:BreadcrumbInfos />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/databases.xhtml
+++ b/engine-cockpit/webContent/view/databases.xhtml
@@ -39,7 +39,7 @@
               
               <p:column headerText="Name" sortBy="#{database.name}" filterBy="#{database.name}"
                 styleClass="database-name-column">
-                <a href="databasedetail.xhtml?databaseName=#{database.name}">
+                <a href="#{database.getViewUrl(app.name, managerBean.selectedEnvironment)}">
                   <h:outputText value="#{database.name}" styleClass="database-name">
                     <i class="si si-database table-icon"></i>
                   </h:outputText>

--- a/engine-cockpit/webContent/view/restclientdetail.xhtml
+++ b/engine-cockpit/webContent/view/restclientdetail.xhtml
@@ -4,9 +4,9 @@
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:cc="http://java.sun.com/jsf/composite/composite">
 <h:body>
   <f:metadata>
-    <f:viewParam name="restClientName" value="#{restClientDetailBean.restClientName}" />
-    <f:viewParam name="applicationName" value="#{managerBean.selectedApplicationName}" />
-    <f:viewParam name="environment" value="#{managerBean.selectedEnvironment}" />
+    <f:viewParam name="app" value="#{restClientDetailBean.app}" />
+    <f:viewParam name="env" value="#{restClientDetailBean.env}" />
+    <f:viewParam name="name" value="#{restClientDetailBean.name}" />
     <f:viewAction action="#{restClientDetailBean.onload}" />
   </f:metadata>
 
@@ -17,7 +17,7 @@
       <li>/</li>
       <li><a href="restclients.xhtml">Rest Clients</a></li>
       <li>/</li>
-      <li><a href="restclientdetail.xhtml?restClientName=#{restClientDetailBean.restClientName}">#{restClientDetailBean.restClientName}</a></li>
+      <li><a href="#{restClientDetailBean.viewUrl}">#{restClientDetailBean.name}</a></li>
       <cc:BreadcrumbInfos />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/restclients.xhtml
+++ b/engine-cockpit/webContent/view/restclients.xhtml
@@ -39,7 +39,7 @@
               
               <p:column headerText="Name" sortBy="#{restclient.name}" filterBy="#{restclient.name}"
                 styleClass="restclient-name-column">
-                <a href="restclientdetail.xhtml?restClientName=#{restclient.name}">
+                <a href="#{restclient.getViewUrl(app.name, managerBean.selectedEnvironment)}">
                   <h:outputText value="#{restclient.name}" styleClass="restclient-name">
                     <i class="si si-network-share table-icon"></i>
                   </h:outputText>

--- a/engine-cockpit/webContent/view/webservicedetail.xhtml
+++ b/engine-cockpit/webContent/view/webservicedetail.xhtml
@@ -4,9 +4,9 @@
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:cc="http://java.sun.com/jsf/composite/composite">
 <h:body>
   <f:metadata>
-    <f:viewParam name="webserviceId" value="#{webserviceDetailBean.webserviceId}" />
-    <f:viewParam name="applicationName" value="#{managerBean.selectedApplicationName}" />
-    <f:viewParam name="environment" value="#{managerBean.selectedEnvironment}" />
+    <f:viewParam name="app" value="#{webserviceDetailBean.app}" />
+    <f:viewParam name="env" value="#{webserviceDetailBean.env}" />
+    <f:viewParam name="id" value="#{webserviceDetailBean.id}" />
     <f:viewAction action="#{webserviceDetailBean.onload}" />
   </f:metadata>
 
@@ -17,7 +17,7 @@
       <li>/</li>
       <li><a href="webservices.xhtml">Web Service</a></li>
       <li>/</li>
-      <li><a href="webservicedetail.xhtml?webserviceId=#{webserviceDetailBean.webserviceId}">#{webserviceDetailBean.webservice.name}</a></li>
+      <li><a href="#{webserviceDetailBean.viewUrl}">#{webserviceDetailBean.webservice.name}</a></li>
       <cc:BreadcrumbInfos />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/webservices.xhtml
+++ b/engine-cockpit/webContent/view/webservices.xhtml
@@ -39,7 +39,7 @@
               
               <p:column headerText="Name" sortBy="#{webservice.name}" filterBy="#{webservice.name}"
                 styleClass="webservice-name-column">
-                <a href="webservicedetail.xhtml?webserviceId=#{webservice.genId}">
+                <a href="#{webservice.getViewUrl(app.name, managerBean.selectedEnvironment)}">
                   <h:outputText value="#{webservice.name}" styleClass="webservice-name">
                     <i class="si si-network-arrow table-icon"></i>
                   </h:outputText>


### PR DESCRIPTION
The problem is that we have state on ManagerBean and if you navigate the wrong way or calling urls directly you get in trouble with this state!

Do you know why this has been implemented with ManagerBean? Having smater urls? But in cost of state problems and "not founds"... ?!