### PR TITLE
XIVY-8621 Lazy permissions tree > 10

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestManyRoles.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestManyRoles.java
@@ -50,12 +50,12 @@ class WebTestManyRoles {
   @Test
   void manyRolesLoadLimit_userDetail() {
     Navigation.toUserDetail("foo");
-    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-2").shouldBe(size(101));
+    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-2").shouldBe(size(21));
     $$("#rolesOfUserForm\\:rolesTree .ui-node-level-2").last()
             .shouldHave(text("Please use the search to find a specific role ("), text("more roles)"));
     $("#rolesOfUserForm\\:rolesTree\\:globalFilter").sendKeys("role-");
-    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").shouldBe(size(101));
+    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").shouldBe(size(21));
     $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").last()
-            .shouldHave(text("The current search has more than 100 results."));
+            .shouldHave(text("The current search has more than 20 results."));
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestPermission.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestPermission.java
@@ -2,8 +2,8 @@ package ch.ivyteam.enginecockpit.security;
 
 import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
 import static com.codeborne.selenide.CollectionCondition.size;
-import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.Condition.attribute;
+import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
+import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.Selenide;
 
@@ -52,40 +53,37 @@ class WebTestPermission {
   }
 
   @Test
-  void duplicatedPortalPermissions() {
+  void duplicatedPortalPermissions_onlyShownOnce() {
     Navigation.toUsers();
     Tab.SECURITY_SYSTEM.switchToDefault();
     Navigation.toUserDetail("demo");
 
     Selenide.executeJavaScript("window.scrollTo(0,document.body.scrollHeight);");
 
-    $(By.id("permissionsForm:permissionTable:globalFilter")).sendKeys("CaseWriteName");
-    var table = $(By.id("permissionsForm:permissionTable"));
-    table.findAll("tbody tr").shouldHave(size(2));
+    $(By.id("permissionsForm:permissionTable:globalFilter")).shouldBe(enabled).sendKeys("CaseWriteName");
+    $(By.id("permissionsForm:permissionTable"))
+            .shouldHave(Condition.text("CaseWriteName"))
+            .findAll("tbody tr").shouldHave(size(1));
     $(By.id("permissionsForm:permissionTable:0:grantPermissionBtn")).click();
     $(By.id("permissionsForm:permissionTable_node_0")).find(".permission-icon > i")
-            .shouldHave(attribute("title", "Permission granted"));
-    $(By.id("permissionsForm:permissionTable_node_1")).find(".permission-icon > i")
             .shouldHave(attribute("title", "Permission granted"));
 
     $(By.id("permissionsForm:permissionTable:0:unGrantPermissionBtn")).click();
     $(By.id("permissionsForm:permissionTable_node_0")).find(".permission-icon > i")
             .shouldNot(exist);
-    $(By.id("permissionsForm:permissionTable_node_1")).find(".permission-icon > i")
-            .shouldNot(exist);
   }
 
   @Test
-  void expandCollapsePermissionTree() {
+  void collapsePermissionTree() {
     Navigation.toRoles();
     Tab.SECURITY_SYSTEM.switchToDefault();
     Navigation.toRoleDetail("boss");
 
+    getVisibleTreeNodes().shouldBe(size(1));
+    $(By.id("permissionsForm:permissionTable_node_0")).find(".ui-treetable-toggler").should(exist).click();
     getVisibleTreeNodes().shouldBe(size(4));
     $(By.id("permissionsForm:permissionTable:collapseAll")).shouldBe(visible).click();
     getVisibleTreeNodes().shouldBe(size(1));
-    $(By.id("permissionsForm:permissionTable:expandAll")).shouldBe(visible).click();
-    getVisibleTreeNodes().shouldBe(sizeGreaterThan(50));
   }
 
   private ElementsCollection getVisibleTreeNodes() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
@@ -84,7 +84,7 @@ public class UserDetailBean {
     userSynch = new UserSynch(securityContext, userName);
     this.user = new User(iUser);
     this.emailSettings = new EmailSettings(iUser, new EmailNotificationConfigurator(securityContext).settings());
-    roleDataModel = new RoleDataModel(new SecuritySystem(securityContext), false);
+    roleDataModel = new RoleDataModel(new SecuritySystem(securityContext), false, 20);
     startedCases = CaseQuery.create().where().isBusinessCase().and().creatorId()
             .isEqual(iUser.getSecurityMemberId()).executor().count();
     workingOn = TaskQuery.create().where().state().isEqual(TaskState.CREATED)

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/RoleDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/RoleDataModel.java
@@ -13,16 +13,22 @@ import ch.ivyteam.ivy.security.ISecurityContext;
 
 public class RoleDataModel extends TreeView<Object> {
   private static final int ROLE_CHILDREN_LIMIT = 100;
-  private ISecurityContext securityContext;
-  private boolean showMember;
-  private List<Role> roles;
+  private final int showChildLimit;
+  private final ISecurityContext securityContext;
+  private final boolean showMember;
+  private final List<Role> roles;
 
   public RoleDataModel(SecuritySystem securitySystem, boolean showMember) {
+    this (securitySystem, showMember, ROLE_CHILDREN_LIMIT);
+  }
+
+  public RoleDataModel(SecuritySystem securitySystem, boolean showMember, int showChildLimit) {
+    this.showChildLimit = showChildLimit;
     this.securityContext = securitySystem.getSecurityContext();
     this.showMember = showMember;
     this.roles = securityContext.roles().all().stream()
-              .map(role -> new Role(role))
-              .collect(Collectors.toList());
+            .map(role -> new Role(role))
+            .collect(Collectors.toList());
     this.filter = "";
     reloadTree();
   }
@@ -33,11 +39,11 @@ public class RoleDataModel extends TreeView<Object> {
     this.filter = filter;
     filteredTreeNode = new DefaultTreeNode<>("Filtered roles", null, null);
     roles.stream().filter(role -> StringUtils.containsIgnoreCase(role.getName(), filter))
-            .limit(ROLE_CHILDREN_LIMIT)
+            .limit(showChildLimit)
             .forEach(role -> new DefaultTreeNode<>("role", role, filteredTreeNode));
-    if (filteredTreeNode.getChildCount() >= ROLE_CHILDREN_LIMIT) {
+    if (filteredTreeNode.getChildCount() >= showChildLimit) {
       new DefaultTreeNode<>("dummy",
-              new Role("The current search has more than " + ROLE_CHILDREN_LIMIT + " results."),
+              new Role("The current search has more than " + showChildLimit + " results."),
               filteredTreeNode);
     }
   }
@@ -114,10 +120,10 @@ public class RoleDataModel extends TreeView<Object> {
 
     private int addRolesToTree(List<IRole> rolesToAdd, boolean isMember) {
       super.getChildren().addAll(rolesToAdd.stream()
-              .limit(ROLE_CHILDREN_LIMIT)
+              .limit(showChildLimit)
               .map(child -> new LazyRoleTreeNode(child, isMember, this))
               .collect(Collectors.toList()));
-      return rolesToAdd.size() - ROLE_CHILDREN_LIMIT;
+      return rolesToAdd.size() - showChildLimit;
     }
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/AbstractPermission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/AbstractPermission.java
@@ -2,14 +2,12 @@ package ch.ivyteam.enginecockpit.security.permission;
 
 public abstract class AbstractPermission {
   private String name;
-  private String path;
   private long id;
   private boolean grant;
   private boolean deny;
 
-  protected AbstractPermission(String name, String path, long id, boolean grant, boolean deny) {
+  protected AbstractPermission(String name, long id, boolean grant, boolean deny) {
     this.name = name;
-    this.path = path + "/" + name;
     this.id = id;
     this.grant = grant;
     this.deny = deny;
@@ -17,10 +15,6 @@ public abstract class AbstractPermission {
 
   public String getName() {
     return name;
-  }
-
-  public String getPath() {
-    return path;
   }
 
   public long getId() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/Permission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/Permission.java
@@ -11,9 +11,8 @@ public class Permission extends AbstractPermission {
   private IPermission iPermission;
   private PermissionBean bean;
 
-  public Permission(IPermissionAccess access, String path, PermissionBean bean) {
+  public Permission(IPermissionAccess access, PermissionBean bean) {
     super(access.getPermission().getName(),
-            path,
             access.getPermission().getId(),
             access.isGranted(),
             access.isDenied());
@@ -77,26 +76,26 @@ public class Permission extends AbstractPermission {
 
   @Override
   public void grant() {
-    bean.getSecurityDescriptor().grantPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.grant(iPermission);
   }
 
   @Override
   public void ungrant() {
-    bean.getSecurityDescriptor().ungrantPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.ungrant(iPermission);
   }
 
   @Override
   public void deny() {
-    bean.getSecurityDescriptor().denyPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.deny(iPermission);
   }
 
   @Override
   public void undeny() {
-    bean.getSecurityDescriptor().undenyPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.undeny(iPermission);
+  }
+
+  public IPermission permission() {
+    return iPermission;
   }
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionBean.java
@@ -1,13 +1,13 @@
 package ch.ivyteam.enginecockpit.security.permission;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
 import org.apache.commons.lang3.StringUtils;
+import org.primefaces.event.NodeExpandEvent;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
 
@@ -29,9 +29,8 @@ public class PermissionBean extends TreeView<AbstractPermission> {
   private String securitySystemName;
   private String member;
   private SecurityContext securityContext;
-
-  private Map<Long, Permission> permissionMap;
-  private Map<Long, PermissionGroup> permissionGroupMap;
+  private ISecurityMember securityMember;
+  private ISecurityDescriptor securityDescriptor;
 
   public String getSecuritySystem() {
     return securitySystemName;
@@ -63,93 +62,189 @@ public class PermissionBean extends TreeView<AbstractPermission> {
       ResponseHelper.notFound("Security System '" + securitySystemName + "' not found");
       return;
     }
+    securityMember = securityContext.members().find(member);
+    securityDescriptor = ISystemDatabasePersistencyService.instance().transaction().executeAndGet(tx -> securityContext.getSecurityDescriptor(tx));
     reloadTree();
   }
 
   @Override
   protected void buildTree() {
-    permissionMap = new HashMap<>();
-    permissionGroupMap = new HashMap<>();
-    var iMember = getSecurityMember();
-    var securityDescriptor = getSecurityDescriptor();
     var rootPermissionGroup = securityDescriptor.getSecurityDescriptorType().getRootPermissionGroup();
-    var permission = new PermissionGroup(securityDescriptor.getPermissionGroupAccess(rootPermissionGroup, iMember), "", this);
-    var node = new DefaultTreeNode<AbstractPermission>(permission, rootTreeNode);
-    permissionGroupMap.put(permission.getId(), permission);
-    node.setExpanded(true);
-    loadChildrenPermissions(node, securityDescriptor, rootPermissionGroup, iMember);
-  }
-
-  @SuppressWarnings("unused")
-  private void loadChildrenPermissions(TreeNode<AbstractPermission> node, ISecurityDescriptor securityDescriptor,
-          IPermissionGroup permissionGroup, ISecurityMember securityMember) {
-    var permissionGroupAccess = securityDescriptor
-            .getPermissionGroupAccess(permissionGroup, securityMember);
-    for (var iPermission : permissionGroupAccess.getPermissionGroup().getPermissions()) {
-      var access = securityDescriptor.getPermissionAccess(iPermission, securityMember);
-      if (access.getPermission() != null) {
-        var permission = permissionMap.get(access.getPermission().getId());
-        if (permission == null) {
-          permission = new Permission(access, node.getData().getPath(), this);
-          permissionMap.put(permission.getId(), permission);
-        }
-        new DefaultTreeNode<>(permission, node);
-      }
-    }
-
-    for (var childGroup : permissionGroupAccess.getPermissionGroup().getChildGroups()) {
-      var childGroupAccess = securityDescriptor.getPermissionGroupAccess(childGroup,
-              securityMember);
-      if (childGroupAccess.getPermissionGroup() != null) {
-        var permission = new PermissionGroup(childGroupAccess, node.getData().getPath(), this);
-        var childNode = new DefaultTreeNode<AbstractPermission>(permission, node);
-        permissionGroupMap.put(permission.getId(), permission);
-        loadChildrenPermissions(childNode, securityDescriptor, childGroup, securityMember);
-      }
-    }
+    var permission = new PermissionGroup(securityDescriptor.getPermissionGroupAccess(rootPermissionGroup, securityMember), this);
+    addPermissionNode(rootTreeNode, permission);
   }
 
   @Override
-  @SuppressWarnings("unused")
+  public void setFilter(String filter) {
+    if (StringUtils.isBlank(filter))
+    {
+      if (StringUtils.isNotBlank(this.filter)) {
+        reloadTree();
+      }
+      return;
+    }
+    filteredTreeNode = new DefaultTreeNode<AbstractPermission>("Filtered tree", null, null);
+    var rootPermissionGroup = securityDescriptor.getSecurityDescriptorType().getRootPermissionGroup();
+    rootPermissionGroup.getAllPermissions().stream()
+            .filter(permission -> StringUtils.containsIgnoreCase(permission.getName(), filter))
+            .map(permission -> {
+              var access = securityDescriptor.getPermissionAccess(permission, securityMember);
+              return new Permission(access, this);
+            })
+            .forEach(permission -> addPermissionNode(filteredTreeNode, permission));
+    this.filter = filter;
+  }
+
+  @Override
   protected void filterNode(TreeNode<AbstractPermission> node) {
-    var permission = node.getData();
-    if (StringUtils.containsIgnoreCase(permission.getName(), filter)) {
-      new DefaultTreeNode<>(permission, filteredTreeNode);
+    // do nothing
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void nodeExpand(NodeExpandEvent event) {
+    var node = event.getTreeNode();
+    node.getChildren().clear();
+    loadChildren(node);
+  }
+
+  private void loadChildren(TreeNode<AbstractPermission> node) {
+    var group = (PermissionGroup) node.getData();
+    group.permissionGroup().getChildGroups().forEach(childGroup -> {
+      var access = securityDescriptor.getPermissionGroupAccess(childGroup, securityMember);
+      addPermissionNode(node, new PermissionGroup(access, this));
+    });
+    group.permissionGroup().getPermissions().forEach(childPermission -> {
+      var access = securityDescriptor.getPermissionAccess(childPermission, securityMember);
+      addPermissionNode(node, new Permission(access, this));
+    });
+  }
+
+  @SuppressWarnings("unused")
+  private void addPermissionNode(TreeNode<AbstractPermission> parent, AbstractPermission permission) {
+    var node = new DefaultTreeNode<>(permission, parent);
+    if (permission instanceof PermissionGroup && !node.isExpanded()) {
+      new DefaultTreeNode<>(new PermissionGroup("loading..."), node);
     }
   }
 
-  public void reSetRootPermissionGroup() {
-    reSetPermissionGroup(getSecurityDescriptor().getSecurityDescriptorType()
-            .getRootPermissionGroup());
+  public void grant(IPermission iPermission) {
+    securityDescriptor.grantPermission(iPermission, securityMember);
+    reloadPermissionTree(iPermission);
   }
 
-  private void reSetPermissionGroup(IPermissionGroup iPermissionGroup) {
-    var permissionGroupAccess = getSecurityDescriptor().getPermissionGroupAccess(iPermissionGroup, getSecurityMember());
-    var permissionGroup = permissionGroupMap.get(iPermissionGroup.getId());
+  public void grant(IPermissionGroup iPermissionGroup) {
+    securityDescriptor.grantPermissions(iPermissionGroup, securityMember);
+    reloadPermissionTree(iPermissionGroup);
+  }
+
+  public void ungrant(IPermission iPermission) {
+    securityDescriptor.ungrantPermission(iPermission, securityMember);
+    reloadPermissionTree(iPermission);
+  }
+
+  public void ungrant(IPermissionGroup iPermissionGroup) {
+    securityDescriptor.ungrantPermissions(iPermissionGroup, securityMember);
+    reloadPermissionTree(iPermissionGroup);
+  }
+
+  public void deny(IPermission iPermission) {
+    securityDescriptor.denyPermission(iPermission, securityMember);
+    reloadPermissionTree(iPermission);
+  }
+
+  public void deny(IPermissionGroup iPermissionGroup) {
+    securityDescriptor.denyPermissions(iPermissionGroup, securityMember);
+    reloadPermissionTree(iPermissionGroup);
+  }
+
+  public void undeny(IPermission iPermission) {
+    securityDescriptor.undenyPermission(iPermission, securityMember);
+    reloadPermissionTree(iPermission);
+  }
+
+  public void undeny(IPermissionGroup iPermissionGroup) {
+    securityDescriptor.undenyPermissions(iPermissionGroup, securityMember);
+    reloadPermissionTree(iPermissionGroup);
+  }
+
+  public void reloadPermissionTree(IPermission iPermission) {
+    if (StringUtils.isBlank(filter)) {
+      reloadPermissionsUp(searchPermissionNode(rootTreeNode.getChildren(), iPermission.getId()));
+    } else {
+      var permissionNode = searchPermissionNode(filteredTreeNode.getChildren(), iPermission.getId());
+      reSetPermission((Permission) permissionNode.getData());
+    }
+  }
+
+  public void reloadPermissionTree(IPermissionGroup iPermissionGroup) {
+    reloadPermissionsUpAndDown(searchPermissionNode(rootTreeNode.getChildren(), iPermissionGroup.getId()));
+  }
+
+  private void reloadPermissionsUp(TreeNode<AbstractPermission> permissionNode) {
+    reSetPermission((Permission) permissionNode.getData());
+    reloadPermissionGroupsUp(permissionNode.getParent());
+  }
+
+  private void reloadPermissionsUpAndDown(TreeNode<AbstractPermission> permissionGroupNode) {
+    reSetPermissionGroup((PermissionGroup) permissionGroupNode.getData());
+    reloadPermissionGroupsUp(permissionGroupNode.getParent());
+    reloadPermissionsDown(permissionGroupNode.getChildren());
+  }
+
+  private void reloadPermissionsDown(List<TreeNode<AbstractPermission>> children) {
+    if (children.isEmpty()) {
+      return;
+    }
+    for (var child : children) {
+      if (child.getData() instanceof Permission permission) {
+        reSetPermission(permission);
+      }
+      if (child.getData() instanceof PermissionGroup permissionGroup) {
+        reSetPermissionGroup(permissionGroup);
+      }
+      reloadPermissionsDown(child.getChildren());
+    }
+  }
+
+  private void reloadPermissionGroupsUp(TreeNode<AbstractPermission> permissionGroupNode) {
+    if (permissionGroupNode.getData() == null) {
+      return;
+    }
+    reSetPermissionGroup((PermissionGroup) permissionGroupNode.getData());
+    reloadPermissionGroupsUp(permissionGroupNode.getParent());
+  }
+
+  public TreeNode<AbstractPermission> searchPermissionNode(List<TreeNode<AbstractPermission>> children, long permissionId) {
+    for (var child : children) {
+      if (child.getData().getId() == permissionId) {
+        return child;
+      }
+      var search = searchPermissionNode(child.getChildren(), permissionId);
+      if (search != null) {
+        return search;
+      }
+    }
+    return null;
+  }
+
+  private void reSetPermissionGroup(PermissionGroup permissionGroup) {
+    if (permissionGroup.permissionGroup() == null) {
+      return;
+    }
+    var permissionGroupAccess = securityDescriptor.getPermissionGroupAccess(permissionGroup.permissionGroup(), securityMember);
     permissionGroup.setDeny(permissionGroupAccess.isDeniedAllPermissions());
     permissionGroup.setGrant(permissionGroupAccess.isGrantedAllPermissions());
     permissionGroup.setSomeDeny(permissionGroupAccess.isDeniedAnyPermission());
     permissionGroup.setSomeGrant(permissionGroupAccess.isGrantedAnyPermission());
-    iPermissionGroup.getPermissions().stream().forEach(p -> reSetPermission(p));
-    iPermissionGroup.getChildGroups().stream().forEach(g -> reSetPermissionGroup(g));
   }
 
-  private void reSetPermission(IPermission iPermission) {
-    var permissionAccess = getSecurityDescriptor().getPermissionAccess(iPermission,
-            getSecurityMember());
-    var permission = permissionMap.get(iPermission.getId());
+  private void reSetPermission(Permission permission) {
+    var permissionAccess = securityDescriptor.getPermissionAccess(permission.permission(), securityMember);
     permission.setGrant(permissionAccess.isGranted());
     permission.setDeny(permissionAccess.isDenied());
     permission.setExplicit(permissionAccess.isExplicit());
     permission.setPermissionHolder(
             Optional.ofNullable(permissionAccess.getPermissionHolder()).map(r -> r.getName()).orElse(null));
-  }
-
-  public ISecurityDescriptor getSecurityDescriptor() {
-    return ISystemDatabasePersistencyService.instance().transaction().executeAndGet(tx -> securityContext.getSecurityDescriptor(tx));
-  }
-
-  public ISecurityMember getSecurityMember() {
-    return securityContext.members().find(member);
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionGroup.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionGroup.java
@@ -9,9 +9,8 @@ public class PermissionGroup extends AbstractPermission {
   private PermissionBean bean;
   private IPermissionGroup permissionGroup;
 
-  public PermissionGroup(IPermissionGroupAccess groupAccess, String path, PermissionBean bean) {
+  public PermissionGroup(IPermissionGroupAccess groupAccess, PermissionBean bean) {
     super(groupAccess.getPermissionGroup().getName(),
-            path,
             groupAccess.getPermissionGroup().getId(),
             groupAccess.isGrantedAllPermissions(),
             groupAccess.isDeniedAllPermissions());
@@ -19,6 +18,10 @@ public class PermissionGroup extends AbstractPermission {
     this.someGrant = groupAccess.isGrantedAnyPermission();
     this.bean = bean;
     this.permissionGroup = groupAccess.getPermissionGroup();
+  }
+
+  public PermissionGroup(String dummy) {
+    super(dummy, -1, false, false);
   }
 
   @Override
@@ -66,26 +69,26 @@ public class PermissionGroup extends AbstractPermission {
 
   @Override
   public void grant() {
-    bean.getSecurityDescriptor().grantPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.grant(permissionGroup);
   }
 
   @Override
   public void ungrant() {
-    bean.getSecurityDescriptor().ungrantPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.ungrant(permissionGroup);
   }
 
   @Override
   public void deny() {
-    bean.getSecurityDescriptor().denyPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.deny(permissionGroup);
   }
 
   @Override
   public void undeny() {
-    bean.getSecurityDescriptor().undenyPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.undeny(permissionGroup);
+  }
+
+  public IPermissionGroup permissionGroup() {
+    return permissionGroup;
   }
 
 }

--- a/engine-cockpit/webContent/includes/components/security/permissions.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/permissions.xhtml
@@ -26,9 +26,6 @@
               <p:ajax event="keyup" delay="300" update="@form:permissionTable" />
             </p:inputText>
           </span>
-          <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
-            actionListener="#{permissionBean.expandAllNodes}" update="permissionTable" title="Expand all"
-            styleClass="p-ml-1 p-col-fixed ui-button-secondary rounded-button ui-button-outlined expand-all" />
           <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
             actionListener="#{permissionBean.collapseAllNodes}" update="permissionTable" title="Collapse all"
             styleClass="p-ml-1 p-col-fixed ui-button-secondary rounded-button ui-button-outlined" />
@@ -36,7 +33,7 @@
       </f:facet>
       
       <p:column headerText="All Permissions">
-        <h:outputText value="#{permission.name}" title="#{permission.path}">
+        <h:outputText value="#{permission.name}">
           <i class="si si-#{permission.group ? 'folder-empty' : 'lock-1'} table-icon"></i>
         </h:outputText>
       </p:column>
@@ -59,7 +56,7 @@
         </h:outputText>
       </p:column>
   
-      <p:column headerText="Grant" styleClass="table-btn-2">
+      <p:column headerText="Grant" styleClass="table-btn-2" style="text-align: center;">
         <p:commandButton id="grantPermissionBtn" type="button" icon="si si-add" title="Grant"
           styleClass="rounded-button" disabled="#{permission.grantDisabled}">
           <p:ajax update="@form" listener="#{permission.grant}" />
@@ -70,7 +67,7 @@
         </p:commandButton>
       </p:column>
   
-      <p:column headerText="Deny" styleClass="table-btn-2">
+      <p:column headerText="Deny" styleClass="table-btn-2" style="text-align: center;">
         <p:commandButton id="denyPermissionBtn" type="button" icon="si si-add" title="Deny"
           styleClass="rounded-button" disabled="#{permission.denyDisabled}">
           <p:ajax update="@form" listener="#{permission.deny}" />

--- a/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
@@ -51,7 +51,7 @@
         </p:treeNode>
         <p:treeNode type="dummy" rendered="#{node.type == 'dummy'}">
           <h:outputText value="#{role.name}"
-            title="For performance reasons only the first 100 roles are loaded. Use the search to find a specific role.">
+            title="For performance reasons only the first 20 roles are loaded. Use the search to find a specific role.">
             <i class="si si-navigation-menu-horizontal table-icon"></i>
           </h:outputText>
         </p:treeNode>


### PR DESCRIPTION
- Decrease number of roles in user detail view (from 100 to 20)

- Load permission tree lazy
  - Remove expand all from permission tree
  - Filter only permissions (no permission groups)
  - Remove path of permission
    - No longer needed as the filter no longer shows permissions twice (once from portal and once from core but was the same)