### PR TITLE
XIVY-8621 Lazy permissions tree > 8

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestPermission.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestPermission.java
@@ -4,6 +4,7 @@ import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -49,24 +50,21 @@ public class WebTestPermission {
   }
 
   @Test
-  void duplicatedPortalPermissions() {
+  void duplicatedPortalPermissions_onlyShowOnce() {
     Navigation.toUsers();
     Tab.switchToTab("demo-portal");
     Navigation.toUserDetail("demo");
 
     $(By.id("permissionsForm:globalFilter")).sendKeys("CaseWriteName");
-    var table = $(By.id("permissionsForm:permissionTable"));
-    table.findAll("tbody tr").shouldHave(size(2));
+    $(By.id("permissionsForm:permissionTable"))
+            .shouldHave(text("CaseWriteName"))
+            .findAll("tbody tr").shouldHave(size(1));
     $(By.id("permissionsForm:permissionTable:0:grantPermissionBtn")).click();
     $(By.id("permissionsForm:permissionTable_node_0")).find(".permission-icon > i")
-            .shouldHave(attribute("title", "Permission granted"));
-    $(By.id("permissionsForm:permissionTable_node_1")).find(".permission-icon > i")
             .shouldHave(attribute("title", "Permission granted"));
 
     $(By.id("permissionsForm:permissionTable:0:unGrantPermissionBtn")).click();
     $(By.id("permissionsForm:permissionTable_node_0")).find(".permission-icon > i")
-            .shouldNot(exist);
-    $(By.id("permissionsForm:permissionTable_node_1")).find(".permission-icon > i")
             .shouldNot(exist);
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoles.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoles.java
@@ -59,11 +59,11 @@ public class WebTestRoles
   void testManyRolesLoadLimit_userDetail()
   {
     Navigation.toUserDetail("foo");
-    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-2").shouldBe(size(101));
+    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-2").shouldBe(size(21));
     $$("#rolesOfUserForm\\:rolesTree .ui-node-level-2").last().shouldHave(text("Please use the search to find a specific role ("), text("more roles)"));
     $("#rolesOfUserForm .table-search-input-withicon").sendKeys("role-");
-    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").shouldBe(size(101));
-    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").last().shouldHave(text("The current search has more than 100 results."));
+    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").shouldBe(size(21));
+    $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").last().shouldHave(text("The current search has more than 20 results."));
   }
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/model/AbstractPermission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/model/AbstractPermission.java
@@ -3,15 +3,13 @@ package ch.ivyteam.enginecockpit.model;
 public abstract class AbstractPermission
 {
   private String name;
-  private String path;
   private long id;
   private boolean grant;
   private boolean deny;
 
-  protected AbstractPermission(String name, String path, long id, boolean grant, boolean deny)
+  protected AbstractPermission(String name, long id, boolean grant, boolean deny)
   {
     this.name = name;
-    this.path = path + "/" + name;
     this.id = id;
     this.grant = grant;
     this.deny = deny;
@@ -22,11 +20,6 @@ public abstract class AbstractPermission
     return name;
   }
   
-  public String getPath()
-  {
-    return path;
-  }
-
   public long getId()
   {
     return id;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/model/Permission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/model/Permission.java
@@ -13,10 +13,9 @@ public class Permission extends AbstractPermission
   private IPermission iPermission;
   private PermissionBean bean;
 
-  public Permission(IPermissionAccess access, String path, PermissionBean bean)
+  public Permission(IPermissionAccess access, PermissionBean bean)
   {
     super(access.getPermission().getName(),
-            path,
             access.getPermission().getId(),
             access.isGranted(),
             access.isDenied());
@@ -91,29 +90,30 @@ public class Permission extends AbstractPermission
   @Override
   public void grant()
   {
-    bean.getSecurityDescriptor().grantPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.grant(iPermission);
   }
 
   @Override
   public void ungrant()
   {
-    bean.getSecurityDescriptor().ungrantPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.ungrant(iPermission);
   }
 
   @Override
   public void deny()
   {
-    bean.getSecurityDescriptor().denyPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.deny(iPermission);
   }
 
   @Override
   public void undeny()
   {
-    bean.getSecurityDescriptor().undenyPermission(iPermission, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.undeny(iPermission);
+  }
+  
+  public IPermission permission() 
+  {
+    return iPermission;
   }
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/model/PermissionGroup.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/model/PermissionGroup.java
@@ -11,10 +11,9 @@ public class PermissionGroup extends AbstractPermission
   private PermissionBean bean;
   private IPermissionGroup permissionGroup;
 
-  public PermissionGroup(IPermissionGroupAccess groupAccess, String path, PermissionBean bean)
+  public PermissionGroup(IPermissionGroupAccess groupAccess, PermissionBean bean)
   {
     super(groupAccess.getPermissionGroup().getName(),
-            path,
             groupAccess.getPermissionGroup().getId(),
             groupAccess.isGrantedAllPermissions(),
             groupAccess.isDeniedAllPermissions());
@@ -22,6 +21,10 @@ public class PermissionGroup extends AbstractPermission
     this.someGrant = groupAccess.isGrantedAnyPermission();
     this.bean = bean;
     this.permissionGroup = groupAccess.getPermissionGroup();
+  }
+  
+  public PermissionGroup(String dummy) {
+    super(dummy, -1, false, false);
   }
 
   @Override
@@ -79,29 +82,30 @@ public class PermissionGroup extends AbstractPermission
   @Override
   public void grant()
   {
-    bean.getSecurityDescriptor().grantPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.grant(permissionGroup);
   }
 
   @Override
   public void ungrant()
   {
-    bean.getSecurityDescriptor().ungrantPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.ungrant(permissionGroup);
   }
 
   @Override
   public void deny()
   {
-    bean.getSecurityDescriptor().denyPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.deny(permissionGroup);
   }
 
   @Override
   public void undeny()
   {
-    bean.getSecurityDescriptor().undenyPermissions(permissionGroup, bean.getSecurityMember());
-    bean.reSetRootPermissionGroup();
+    bean.undeny(permissionGroup);
+  }
+  
+  public IPermissionGroup permissionGroup() 
+  {
+    return permissionGroup;
   }
   
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDataModel.java
@@ -15,16 +15,23 @@ import ch.ivyteam.ivy.security.ISecurityContext;
 public class RoleDataModel
 {
   private static final int ROLE_CHILDREN_LIMIT = 100;
-  private ISecurityContext securityContext;
+  private final int showChildLimit;
+  private final ISecurityContext securityContext;
+  private final boolean showMember;
+  private final List<Role> roles;
   private String filter;
-  private boolean showMember;
   
-  private List<Role> roles;
   private TreeNode treeRootNode;
   private TreeNode filteredTreeRootNode;
 
   public RoleDataModel(IApplication app, boolean showMember)
   {
+    this(app, showMember, ROLE_CHILDREN_LIMIT);
+  }
+
+  public RoleDataModel(IApplication app, boolean showMember, int showChildLimit)
+  {
+    this.showChildLimit = showChildLimit;
     this.securityContext = app.getSecurityContext();
     this.showMember = showMember;
     this.roles = app.getSecurityContext().getRoles().stream()
@@ -39,11 +46,11 @@ public class RoleDataModel
     this.filter = filter;
     filteredTreeRootNode = new DefaultTreeNode("Filtered roles", null);
     roles.stream().filter(role -> StringUtils.containsIgnoreCase(role.getName(), filter))
-            .limit(ROLE_CHILDREN_LIMIT)
+            .limit(showChildLimit)
             .forEach(role -> new DefaultTreeNode("role", role, filteredTreeRootNode));
-    if (filteredTreeRootNode.getChildCount() >= ROLE_CHILDREN_LIMIT)
+    if (filteredTreeRootNode.getChildCount() >= showChildLimit)
     {
-      new DefaultTreeNode("dummy", new Role("The current search has more than " + ROLE_CHILDREN_LIMIT + " results."), filteredTreeRootNode);
+      new DefaultTreeNode("dummy", new Role("The current search has more than " + showChildLimit + " results."), filteredTreeRootNode);
     }
   }
 
@@ -141,10 +148,10 @@ public class RoleDataModel
     private int addRolesToTree(List<IRole> rolesToAdd, boolean member)
     {
       super.getChildren().addAll(rolesToAdd.stream()
-              .limit(ROLE_CHILDREN_LIMIT)
+              .limit(showChildLimit)
               .map(child -> new LazyRoleTreeNode(child, member, this))
               .collect(Collectors.toList()));
-      return rolesToAdd.size() - ROLE_CHILDREN_LIMIT;
+      return rolesToAdd.size() - showChildLimit;
     }
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
@@ -58,7 +58,7 @@ public class UserDetailBean
       var iUser = getSecurityContext().users().find(userName);
       this.user = new User(iUser);
       this.emailSettings = new EmailSettings(iUser, managerBean.getSelectedIApplication().getDefaultEMailNotifcationSettings());
-      roleDataModel = new RoleDataModel(managerBean.getSelectedIApplication(), false);
+      roleDataModel = new RoleDataModel(managerBean.getSelectedIApplication(), false, 20);
     }
   }
 

--- a/engine-cockpit/webContent/includes/components/security/permissions.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/permissions.xhtml
@@ -24,10 +24,10 @@
     </div>
   </div>
   <p:treeTable id="permissionTable" value="#{permissionBean.permissions}" var="permission">
-  	<p:ajax event="expand" listener="#{treeEventBean.nodeExpand}"/>
+    <p:ajax event="expand" listener="#{permissionBean.nodeExpand}" />
   	<p:ajax event="collapse" listener="#{treeEventBean.nodeCollapse}"/>
     <p:column headerText="All Permissions">
-      <h:outputText value="#{permission.name}" title="#{permission.path}">
+      <h:outputText value="#{permission.name}">
         <i class="material-icons table-icon">#{permission.group ? 'folder' : 'vpn_key'}</i>
       </h:outputText>
     </p:column>

--- a/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
@@ -40,7 +40,7 @@
       </p:treeNode>
       <p:treeNode type="dummy" rendered="#{node.type == 'dummy'}">
         <h:outputText value="#{role.name}"
-          title="For performance reasons only the first 100 roles are loaded. Use the search to find a specific role.">
+          title="For performance reasons only the first 20 roles are loaded. Use the search to find a specific role.">
           <i class="material-icons table-icon">more_horiz</i>
         </h:outputText>
       </p:treeNode>


### PR DESCRIPTION
- Decrease number of roles in user detail view (from 100 to 20)
- Load permission tree lazy
  - Filter only permissions (no permission groups)
  - Remove path of permission
    - No longer needed as the filter no longer shows permissions twice (once from portal and once from core but was the same)