### PR TITLE
XIVY-9898 View for sessions

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
@@ -101,6 +101,8 @@ public class WebDocuScreenshot {
     takeScreenshot("monitor-slow-requests", new Dimension(SCREENSHOT_WIDTH, 800));
     WebTestTrafficGraph.prepareScreenshot();
     takeScreenshot("monitor-traffic-graph", new Dimension(SCREENSHOT_WIDTH, 800));
+    Navigation.toSessions();
+    takeScreenshot("monitor-sessions", new Dimension(SCREENSHOT_WIDTH, 1000));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestSessions.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestSessions.java
@@ -1,0 +1,79 @@
+package ch.ivyteam.enginecockpit.monitor;
+
+import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
+import static com.codeborne.selenide.CollectionCondition.textsInAnyOrder;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import com.axonivy.ivy.webtest.IvyWebTest;
+import com.axonivy.ivy.webtest.engine.EngineUrl;
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.Selenide;
+
+import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
+import ch.ivyteam.enginecockpit.util.Navigation;
+import ch.ivyteam.enginecockpit.util.Table;
+
+@IvyWebTest
+class WebTestSessions {
+
+  private static final String SESSION_USER = "foo";
+
+  private static final By TABLE_ID = By.id("form:sessionTable");
+  private Table table;
+
+  @BeforeAll
+  static void beforeAll() {
+    login();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    Navigation.toSessions();
+    table = new Table(TABLE_ID, true);
+  }
+
+  @Test
+  void view() {
+    $("h2").shouldHave(text("Sessions"));
+    table.firstColumnShouldBe(textsInAnyOrder("admin", "admin"));
+  }
+
+  @Test
+  void liveStats() {
+    EngineCockpitUtil.assertLiveStats(List.of("Sessions"));
+  }
+
+  @Test
+  void killSession() {
+    openAnotherSession();
+    table.search("foo");
+    table.firstColumnShouldBe(textsInAnyOrder(SESSION_USER));
+    table.clickButtonForEntry(SESSION_USER, "killSession");
+    table.firstColumnShouldBe(CollectionCondition.empty);
+  }
+
+  private void openAnotherSession() {
+    $(".layout-topbar-actions .help-link a").shouldBe(visible).click();
+    Selenide.switchTo().window(1);
+    if (EngineUrl.isDesigner()) {
+      Selenide.open(EngineUrl.create().app("default-workflow").path("faces/login.xhtml").toUrl());
+    } else {
+      Selenide.open(EngineUrl.create().app("test").path("login").toUrl());
+    }
+    $("#loginForm\\:userName").shouldBe(visible).sendKeys(SESSION_USER);
+    $("#loginForm\\:password").shouldBe(visible).sendKeys(SESSION_USER);
+    $("#loginForm\\:login").click();
+    $("#sessionUserName").shouldHave(text(SESSION_USER));
+    Selenide.switchTo().window(0);
+    Selenide.refresh();
+  }
+}

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestLicence.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestLicence.java
@@ -1,11 +1,9 @@
 package ch.ivyteam.enginecockpit.system;
 
 import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
-import static com.codeborne.selenide.CollectionCondition.textsInAnyOrder;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.text;
-import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 
 import java.io.IOException;
@@ -14,20 +12,14 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
-import com.axonivy.ivy.webtest.engine.EngineUrl;
-import com.codeborne.selenide.Selenide;
 
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
-import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
 class WebTestLicence {
-
-  private static final String SESSION_USER = "foo";
 
   @BeforeEach
   void beforeEach() {
@@ -54,40 +46,5 @@ class WebTestLicence {
   @Test
   void liveStats() {
     EngineCockpitUtil.assertLiveStats(List.of("Sessions"));
-  }
-
-  @Test
-  void killSession() {
-    openAnotherSession();
-    $("#layout-config-button").shouldBe(visible).click();
-    var table = new Table(By.cssSelector("#layout-config .ui-datatable"));
-    var adminUser = EngineUrl.isDesigner() ? "Developer" : "admin";
-    table.firstColumnShouldBe(textsInAnyOrder(adminUser, SESSION_USER));
-    table.clickButtonForEntry(SESSION_USER, "killSession");
-    table.firstColumnShouldBe(textsInAnyOrder(adminUser));
-    assertOtherSession();
-  }
-
-  private void openAnotherSession() {
-    $(".layout-topbar-actions .help-link a").shouldBe(visible).click();
-    Selenide.switchTo().window(1);
-    if (EngineUrl.isDesigner()) {
-      Selenide.open(EngineUrl.create().app(EngineUrl.DESIGNER).path("faces/login.xhtml").toUrl());
-    } else {
-      Selenide.open(EngineUrl.create().app("test").path("login").toUrl());
-    }
-    $("#loginForm\\:userName").shouldBe(visible).sendKeys(SESSION_USER);
-    $("#loginForm\\:password").shouldBe(visible).sendKeys(SESSION_USER);
-    $("#loginForm\\:login").click();
-    $("#sessionUserName").shouldHave(text(SESSION_USER));
-    Selenide.switchTo().window(0);
-    Selenide.refresh();
-  }
-
-  private void assertOtherSession() {
-    Selenide.switchTo().window(1);
-    Selenide.refresh();
-    $("#sessionUserName").shouldHave(text("Unknown User"));
-    Selenide.switchTo().window(0);
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -46,6 +46,7 @@ public class Navigation {
   private static final String MONITOR_ENGINE_MEMORY_MENU = "#menuform\\:sr_monitor_engine_memory";
   private static final String MONITOR_ENGINE_MBEANS_MENU = "#menuform\\:sr_monitor_engine_mbeans";
   private static final String MONITOR_ENGINE_CACHE_MENU = "#menuform\\:sr_monitor_engine_cache";
+  private static final String MONITOR_ENGINE_SESSION_MENU = "#menuform\\:sr_monitor_engine_sessions";
   private static final String MONITOR_PERFORMANCE_MENU = "#menuform\\:sr_monitor_performance";
   private static final String MONITOR_PERFORMANCE_PROCESS_EXECUTION_MENU = "#menuform\\:sr_monitor_performance_process_execution";
   private static final String MONITOR_PERFORMANCE_TRACES_MENU = "#menuform\\:sr_monitor_performance_traces";
@@ -298,6 +299,12 @@ public class Navigation {
     toSubSubMenu(MONITOR_MENU, MONITOR_ENGINE_MENU, MONITOR_ENGINE_CACHE_MENU);
     assertCurrentUrlContains("monitorCache.xhtml");
     menuShouldBeActive(MONITOR_ENGINE_CACHE_MENU);
+  }
+
+  public static void toSessions() {
+    toSubSubMenu(MONITOR_MENU, MONITOR_ENGINE_MENU, MONITOR_ENGINE_SESSION_MENU);
+    assertCurrentUrlContains("monitor-sessions.xhtml");
+    menuShouldBeActive(MONITOR_ENGINE_SESSION_MENU);
   }
 
   public static void toMBeans() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionBean.java
@@ -1,0 +1,128 @@
+package ch.ivyteam.enginecockpit.monitor.session;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import javax.servlet.http.HttpSession;
+
+import org.ocpsoft.prettytime.PrettyTime;
+
+import ch.ivyteam.enginecockpit.security.model.SecuritySystem;
+import ch.ivyteam.enginecockpit.security.model.User;
+import ch.ivyteam.ivy.security.ISecurityContext;
+import ch.ivyteam.ivy.security.ISecurityContextRepository;
+import ch.ivyteam.ivy.security.ISessionInternal;
+
+@ManagedBean
+@ViewScoped
+public class SessionBean {
+
+  private List<SessionDto> filteredSessions;
+  private List<SessionDto> sessions = readData();
+  private String filter;
+
+  public List<SessionDto> getSessions() {
+    return sessions;
+  }
+
+  public List<SessionDto> readData() {
+    return ISecurityContextRepository.instance().all()
+            .stream()
+            .flatMap(s -> s.sessions().all().stream())
+            .filter(s -> !s.isSessionUserSystemUser())
+            .map(s -> new SessionDto((ISessionInternal) s))
+            .toList();
+  }
+
+  public List<SessionDto> getFilteredSessions() {
+    return filteredSessions;
+  }
+
+  public void setFilteredSessions(List<SessionDto> filteredSessions) {
+    this.filteredSessions = filteredSessions;
+  }
+
+  public String getFilter() {
+    return filter;
+  }
+
+  public void setFilter(String filter) {
+    this.filter = filter;
+  }
+
+  public void killSession(SessionDto session) {
+    var ses = session.session;
+    ses.getSecurityContext().sessions().destroy(ses.getIdentifier(), "ENGINE-COCKPIT");
+    sessions = readData();
+  }
+
+  public static class SessionDto {
+
+    private ISessionInternal session;
+
+    private SessionDto(ISessionInternal session) {
+      this.session = session;
+    }
+
+    public Date getCreatedAt() {
+      return Date.from(session.createdAt());
+    }
+
+    public String getSince() {
+      var pretty = new PrettyTime(session.createdAt());
+      return pretty.format(Instant.now());
+    }
+
+    public String getId() {
+      return String.valueOf(session.getIdentifier());
+    }
+
+    public String getUser() {
+      return session.getSessionUser() == null ? "unauthenticated" : session.getSessionUser().getName();
+    }
+
+    public String getUserLink() {
+      return session.getSessionUser() == null ? "" : new User(session.getSessionUser()).getViewUrl(session.getSecurityContext().getName());
+    }
+
+    public boolean isUserInternal() {
+      return session.isSessionUserSystemUser() || session.isSessionUserUnknown();
+    }
+
+    public String getAuthMode() {
+      return session.getAuthenticationMode();
+    }
+
+    public String getSecuritySystem() {
+      return session.getSecurityContext().getName();
+    }
+
+    public String getSecuritySystemLink() {
+      return new SecuritySystem(session.getSecurityContext()).getLink();
+    }
+
+    public boolean isSecuritySystemInternal() {
+      return ISecurityContext.SYSTEM.equals(session.getSecurityContext().getName());
+    }
+
+    public String getCause() {
+      return session.creationReason();
+    }
+
+    public Set<HttpSession> getHttpSessions() {
+      return session.getHttpSessions();
+    }
+
+    public int getHttpSessionCount() {
+      return session.getHttpSessions().size();
+    }
+
+    public boolean canKill() {
+      return !session.isSessionUserSystemUser();
+    }
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/LicenceBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/LicenceBean.java
@@ -167,21 +167,6 @@ public class LicenceBean extends StepStatus {
     reloadLicenceMessages();
   }
 
-  public List<UserSession> getActiveSessions() {
-    return securityManager.getSessions().stream()
-            .filter(s -> !s.isSessionUserUnknown())
-            .filter(s -> !s.isSessionUserSystemUser())
-            .map(s -> new UserSession(s))
-            .distinct()
-            .collect(Collectors.toList());
-  }
-
-  public void killSession(String session) {
-    securityManager.getSessions().stream()
-            .filter(s -> StringUtils.equals(s.getSessionUserName(), session))
-            .forEach(s -> s.logoutSessionUser());
-  }
-
   private String calculateSessions() {
     int licensedSessions = securityManager.getLicensedSessions();
     var sessionLimit = getValueFromProperty(SESSION_LIMIT);

--- a/engine-cockpit/webContent/includes/template/sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/sidebar.xhtml
@@ -64,6 +64,8 @@
               <p:menuitem id="sr_monitor_engine_jvm" value="JVM" icon="si si-coffee-cup" url="monitorJvm.xhtml" />
               <p:menuitem id="sr_monitor_engine_memory" value="Memory" icon="si si-analytics-board-graph-line"
                 url="monitorMemory.xhtml" />
+              <p:menuitem id="sr_monitor_engine_sessions" value="Sessions" icon="si si-analytics-graph-line"
+                url="monitor-sessions.xhtml" />
               <p:menuitem id="sr_monitor_engine_cache" value="Cache" icon="si si-monitor-heart-beat-search"
                 url="monitorCache.xhtml" />
               <p:menuitem id="sr_monitor_engine_mbeans" value="MBeans" icon="si si-graph-statistics-coffee"

--- a/engine-cockpit/webContent/view/licence.xhtml
+++ b/engine-cockpit/webContent/view/licence.xhtml
@@ -38,20 +38,6 @@
     <ui:define name="live-stats">
       <cc:Sidebar>
         <cc:LiveStats monitor="#{sessionMonitorBean.sessionsMonitor}" id="sessions" />
-
-        <p:dataTable value="#{licenceBean.activeSessions}" var="activeSession" style="margin-top: 20px;"
-          paginator="true" rows="5" paginatorPosition="bottom" paginatorAlwaysVisible="false">
-          <p:column headerText="Session" sortBy="#{activeSession.name}" sortOrder="desc">
-            <h:outputText value="#{activeSession.name}" styleClass="activeSessionUser" />
-          </p:column>
-          <p:column headerText="Active" style="width: 80px; text-align: center;" sortBy="#{activeSession.count}">
-            <h:outputText value="#{activeSession.count}" />
-          </p:column>
-          <p:column styleClass="table-btn-1">
-            <p:commandButton id="killSession" title="Kill session" icon="si si-logout-1"
-              actionListener="#{licenceBean.killSession(activeSession.name)}" styleClass="ui-button-danger rounded-button" />
-          </p:column>
-        </p:dataTable>
       </cc:Sidebar>
     </ui:define>
   </ui:composition>

--- a/engine-cockpit/webContent/view/monitor-sessions.xhtml
+++ b/engine-cockpit/webContent/view/monitor-sessions.xhtml
@@ -1,0 +1,112 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html"
+  xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+  xmlns:ic="http://ivyteam.ch/jsf/component"
+  xmlns:p="http://primefaces.org/ui"
+  xmlns:pe="http://primefaces.org/ui/extensions"
+  xmlns:cc="http://java.sun.com/jsf/composite/composite">
+<h:body>
+  <ui:composition template="../includes/template/charts-template.xhtml">
+
+    <ui:define name="breadcrumb">
+      <li><span>Monitor</span></li>
+      <li>/</li>
+      <li><span>Engine</span></li>
+      <li>/</li>
+      <li><a href="monitor-sessions.xhtml">Sessions</a></li>
+    </ui:define>
+
+    <ui:define name="topbar-items">
+      <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}monitor.html#sessions" />
+    </ui:define>
+
+    <ui:define name="content">
+      <div class="card">
+        <div class="p-d-flex p-ai-center p-mb-3">
+          <i class="p-pr-3 si si-analytics-graph-line card-title-icon"></i>
+          <h2 class="p-m-0">Sessions</h2>
+        </div>
+        <h:form id="form" style="overflow: auto;">
+          <p:dataTable var="ses" value="#{sessionBean.sessions}"
+            widgetVar="sessionTable" styleClass="ui-fluid"
+            filteredValue="#{sessionBean.filteredSessions}"
+            id="sessionTable" style="min-width: 950px;">
+            <f:facet name="header">
+              <div class="ui-input-icon-left filter-container">
+                <i class="pi pi-search"/>
+                <p:inputText id="globalFilter" onkeyup="PF('sessionTable').filter()" placeholder="Search" value="#{sessionBean.filter}" />
+              </div>
+            </f:facet>
+            
+            <p:column headerText="User" sortBy="#{ses.user}" filterBy="#{ses.user}">
+              <h:outputLink value="#{ses.userLink}" rendered="#{!ses.isUserInternal()}">
+                <h:outputText value="#{ses.user}" styleClass=""/>
+              </h:outputLink>
+              <h:outputText value="#{ses.user}" rendered="#{ses.isUserInternal()}" styleClass=""/>
+            </p:column>
+            
+            <p:column headerText="Created" sortBy="#{ses.createdAt}" filterBy="#{ses.createdAt}">
+              <h:outputText value="#{ses.createdAt}">
+                <f:convertDateTime type="both" dateStyle="short" timeStyle="short" />
+              </h:outputText>
+            </p:column>
+            
+            <p:column headerText="Since" sortBy="#{ses.since}" filterBy="#{ses.since}">
+              <h:outputText value="#{ses.createdAt}">
+                <f:converter converterId="org.ocpsoft.PrettyTimeConverter"/>
+              </h:outputText>
+            </p:column>
+            
+            <p:column headerText="System" sortBy="#{ses.securitySystem}" filterBy="#{ses.securitySystem}">
+              <h:outputLink value="#{ses.securitySystemLink}" rendered="#{!ses.isSecuritySystemInternal()}">#{ses.securitySystem}</h:outputLink>
+              <h:outputText value="#{ses.securitySystem}" rendered="#{ses.isSecuritySystemInternal()}" />
+            </p:column>
+
+            <p:column headerText="Cause" sortBy="#{ses.cause}" filterBy="#{ses.cause}">
+              <h:outputText value="#{ses.cause}" />
+            </p:column>
+            
+            <p:column headerText="Auth" sortBy="#{ses.authMode}" filterBy="#{ses.authMode}">
+              <h:outputText value="#{ses.authMode}" />
+            </p:column>
+            
+            <p:column headerText="Id" sortBy="#{ses.id}" filterBy="#{ses.id}">
+              <h:outputText value="#{ses.id}" />
+            </p:column>
+            
+             <p:column headerText="HTTP Sessions" sortBy="#{ses.httpSessionCount}" filterBy="#{ses.httpSessionCount}">
+              <h:outputText id="httpSession" value="#{ses.httpSessionCount}" />
+              <p:tooltip for="httpSession" rendered="#{!ses.httpSessions.isEmpty()}">
+                <ui:repeat value="#{ses.httpSessions}" var="httpSession">
+                    <h:outputLabel for="creationTime" value="Creation " />
+                    <h:outputText id="creationTime" value="#{httpSession.creationTime}">
+			                <f:convertDateTime type="both" dateStyle="short" timeStyle="short" />
+			              </h:outputText>
+			              /
+			              <h:outputLabel for="lastAccessedTime" value="Last Accessed " />
+			              <h:outputText value="#{httpSession.lastAccessedTime}">
+                      <f:convertDateTime type="both" dateStyle="short" timeStyle="short" />
+                    </h:outputText>
+                    <br />
+                </ui:repeat>
+              </p:tooltip>
+            </p:column>
+            
+            <p:column styleClass="table-btn-1">
+              <p:commandButton id="killSession" title="Kill session" icon="si si-logout-1"
+                actionListener="#{sessionBean.killSession(ses)}" ajax="true" update="@form" disabled="#{!ses.canKill()}" styleClass="ui-button-danger rounded-button" />
+            </p:column>
+          </p:dataTable>
+        </h:form>
+      </div>
+    </ui:define>
+
+    <ui:define name="live-stats">
+      <cc:Sidebar>
+        <cc:LiveStats monitor="#{sessionMonitorBean.sessionsMonitor}" id="sessions" />
+      </cc:Sidebar>
+    </ui:define>
+  </ui:composition>
+</h:body>
+</html>

--- a/engine-cockpit/webContent/view/security-detail.xhtml
+++ b/engine-cockpit/webContent/view/security-detail.xhtml
@@ -19,7 +19,7 @@
       <li><a href="securitysystem.xhtml">Security Systems</a></li>
       <li>/</li>
       <li><a
-          href="#{securityConfigDetailBean.link}">#{securityConfigBean.name}</a>
+          href="#{securityConfigBean.link}">#{securityConfigBean.name}</a>
       </li>
     </ui:define>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7498380/201145078-45846f82-7a98-496f-8aa3-7253fa4f4f58.png)

There is also a tooltip for http sessions where you can see when they have been created and last accessed. I think we will learn from this view in future.

E.g.:
- Whey is the session id not unique over the hole axon ivy engine?
- When killing an ivy session, why don't we destroy all http sessions?
