### PR TITLE
XIVY-10710 Always craft urls via managed objects

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdvisorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdvisorBean.java
@@ -8,11 +8,10 @@ import javax.faces.bean.SessionScoped;
 
 import ch.ivyteam.enginecockpit.util.UrlUtil;
 import ch.ivyteam.ivy.Advisor;
-import ch.ivyteam.ivy.server.restricted.EngineMode;
+import ch.ivyteam.ivy.security.ISecurityContextRepository;
 
 @ManagedBean
 @SessionScoped
-@SuppressWarnings("restriction")
 public class AdvisorBean {
 
   public String getApplicationName() {
@@ -32,16 +31,19 @@ public class AdvisorBean {
     return "&copy; 2001 - " + Calendar.getInstance().get(Calendar.YEAR);
   }
 
-  private String getApp() {
-    return EngineMode.isEmbeddedInDesigner() ? "designer" : "system";
-  }
-  
-  public String getAppBaseUrl() {
-    return UrlUtil.getAppBaseUrl(getApp());
+  public String getApiBrowserUrl() {
+    return systemPath() + "/api-browser";
   }
 
+  /**
+   * only used for deployment rest endpoint
+   */
   public String getApiBaseUrl() {
-    return UrlUtil.getApiBaseUrl(getApp());
+    return systemPath() + "/api";
+  }
+
+  private String systemPath() {
+    return ISecurityContextRepository.instance().getSystem().contextPath();
   }
 
   public String getEngineGuideBaseUrl() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/UrlUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/UrlUtil.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.StringUtils;
 import ch.ivyteam.io.FileUtil;
 import ch.ivyteam.ivy.Advisor;
 import ch.ivyteam.ivy.config.IFileAccess;
-import ch.ivyteam.ivy.security.ISecurityConstants;
 
 @SuppressWarnings("restriction")
 public class UrlUtil {
@@ -31,14 +30,6 @@ public class UrlUtil {
 
   public static String getCockpitEngineGuideUrl() {
     return getEngineGuideBaseUrl() + "/reference/engine-cockpit/";
-  }
-
-  public static String getAppBaseUrl(String appName) {
-    return ISecurityConstants.baseContextPath("/" + appName);
-  }
-
-  public static String getApiBaseUrl(String appName) {
-    return ISecurityConstants.baseContextPath("/" +  appName + "/api");
   }
 
   public static String replaceLinks(String text) {

--- a/engine-cockpit/webContent/includes/components/services/backend-rest.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/backend-rest.xhtml
@@ -9,14 +9,14 @@
       <i class="p-pr-3 si si-network-share"></i>
       <h6 class="p-m-0">Rest Services</h6>
       <p:linkButton id="browseRestAPI" title="Browse available REST Backend Services" icon="si si-network-browser" type="button"
-        href="#{advisorBean.appBaseUrl}/api-browser/index.html?urls.primaryName=#{managerBean.selectedApplicationName}"
+        href="#{advisorBean.apiBrowserUrl}/index.html?urls.primaryName=#{managerBean.selectedApplicationName}"
         target="_blank" rel="noopener noreferrer" styleClass="p-col-fixed p-ml-auto rounded-button" />
       <p:linkButton id="configRestBackend" title="Configure Rest Backend" icon="si si-cog" type="button"
         styleClass="p-col-fixed p-ml-1 ui-button-secondary rounded-button" href="systemconfig.xhtml?filter=REST.Servlet" />
     </div>
   </div>
   <iframe id="apiBrowser"
-    src="#{advisorBean.appBaseUrl}/api-browser/index.html?urls.primaryName=#{managerBean.selectedApplicationName}"
+    src="#{advisorBean.apiBrowserUrl}/index.html?urls.primaryName=#{managerBean.selectedApplicationName}"
     style="border: none; width: 100%; height: calc(100vh - 500px); min-height: 400px; margin-top: 10px;"></iframe>
 </div>
 


### PR DESCRIPTION
- Use securityContext#contextPath to get the path
- API Browser is on every system at the same place /system/api-browser
- API url is now just used for deployment endpoint, which is always just in /system available