### PR TITLE
XIVY-10524 Fix ES document dialog not scaling properly if data is long

### DIFF
--- a/engine-cockpit/webContent/view/searchindex.xhtml
+++ b/engine-cockpit/webContent/view/searchindex.xhtml
@@ -58,8 +58,8 @@
         </h:form>
       </div>
 
-      <p:dialog style="max-width:600px;" header="Document: #{searchDocBean.doc.id}" id="searchDocModal"
-        onShow="hljs.highlightBlock(document.querySelector('pre code.json'))" widgetVar="searchDocModal" modal="true"
+      <p:dialog header="Document: #{searchDocBean.doc.id}" id="searchDocModal" width="50%" modal="true"
+        onShow="hljs.highlightBlock(document.querySelector('pre code.json'))" widgetVar="searchDocModal"
         responsive="true" closeOnEscape="true">
         <pre>
           <code style="overflow: auto; max-height: 500px;" class="json">


### PR DESCRIPTION
Small fix of a weird behavior 
Before: (scrollbar gets bigger but window doesnt)
![Peek 2023-04-04 16-16](https://user-images.githubusercontent.com/45038833/229822107-776231a2-6ebd-45fe-9a20-2c738c04f19c.gif)

After: (might look weird becuase not recording the whole screen)
![Peek 2023-04-04 16-17](https://user-images.githubusercontent.com/45038833/229822130-32371cfd-8484-43c6-a21c-f15dc0052d1b.gif)

FYI @alexsuter 