### PR TITLE
XIVY-11183 Add new Threads view to the Performance menu

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestDownload.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestDownload.java
@@ -1,13 +1,17 @@
 package ch.ivyteam.enginecockpit;
 
+import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openqa.selenium.By.id;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -87,5 +91,15 @@ public class WebTestDownload {
     $(By.id("downloadDialog:downloadForm:downloadBtn")).shouldBe(visible).download();
     $(By.id("msgs_container")).shouldHave(text("No branding resources found for app 'test-ad'"));
   }
+  
+  @Test
+  void dumpButton() throws IOException {
+    Navigation.toThreads();
+    var dump = $(id("form:dump"))
+        .shouldBe(visible, enabled)
+        .download();
 
+    String content = Files.readString(dump.toPath());
+    assertThat(content).contains("Full thread dump OpenJDK 64-Bit Server VM");
+  }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
@@ -101,6 +101,8 @@ public class WebDocuScreenshot {
     takeScreenshot("monitor-slow-requests", new Dimension(SCREENSHOT_WIDTH, 800));
     WebTestTrafficGraph.prepareScreenshot();
     takeScreenshot("monitor-traffic-graph", new Dimension(SCREENSHOT_WIDTH, 800));
+    Navigation.toThreads();
+    takeScreenshot("monitor-threads", new Dimension(SCREENSHOT_WIDTH, 800));
     Navigation.toSessions();
     takeScreenshot("monitor-sessions", new Dimension(SCREENSHOT_WIDTH, 1000));
   }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
@@ -1,0 +1,98 @@
+package ch.ivyteam.enginecockpit.monitor;
+
+import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
+import static com.codeborne.selenide.Condition.enabled;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.Wait;
+import static org.openqa.selenium.By.id;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import com.axonivy.ivy.webtest.IvyWebTest;
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.Selenide;
+
+import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
+import ch.ivyteam.enginecockpit.util.Navigation;
+import ch.ivyteam.enginecockpit.util.Table;
+
+@IvyWebTest(headless = false)
+public class WebTestThreads {
+
+  private static final Duration TWENTY_SECONDS = Duration.ofSeconds(20);
+  
+  private Table threadsTable;
+
+  @BeforeEach
+  void beforeEach() {
+    login();
+    Navigation.toThreads();
+    threadsTable = new Table(By.id("form:threadTable"));
+  }
+
+  @Test
+  void refreshButton() {
+    String oldTableContent = threadsTable.body().text();
+    
+    Wait()
+        .withTimeout(TWENTY_SECONDS)
+        .ignoring(AssertionError.class)
+        .until(webDriver -> {
+          $(id("form:refresh"))
+              .shouldBe(visible, enabled)
+              .click();
+          threadsTable.body().shouldNotBe(text(oldTableContent));
+          return true;
+        });
+  }
+
+  @Test
+  void filter() {
+    int all = threadsTable.rows().size();
+    threadsTable.searchFilterShould(visible, enabled);
+    threadsTable.search("http");
+    threadsTable.rows().shouldBe(CollectionCondition.sizeLessThan(all));
+  }
+  
+  @Test
+  void deadlock() {
+    threadsTable.body().$$(By.className("deadlocked")).shouldBe(CollectionCondition.size(0));
+    
+    EngineCockpitUtil.deadlock();
+    EngineCockpitUtil.openDashboard();
+    Navigation.toThreads();
+    
+    Wait().withTimeout(TWENTY_SECONDS)
+        .ignoring(AssertionError.class)
+        .until(webDriver -> { 
+          $(id("form:refresh"))
+              .shouldBe(visible, enabled)
+              .click();
+          threadsTable.body().$$(By.className("deadlocked")).shouldBe(CollectionCondition.size(4));
+          return true;
+        });
+  }
+
+  @Test
+  void openDetails() {
+    threadsTable.tableEntry(1, 1).shouldBe(visible, enabled).click();
+    $("#threadDialog").shouldBe(visible);
+    $("#thread\\:close").shouldBe(visible, enabled).click();
+    $("#threadDialog").shouldNotBe(visible);
+  }
+
+  @Test
+  void copyStacktrace() {
+    threadsTable.tableEntry(1, 1).shouldBe(visible, enabled).click();
+    $("#threadDialog").shouldBe(visible);
+    var stackTrace = $("#thread\\:stackTrace").text();
+    $("#thread\\:copyStack").shouldBe(visible, enabled).click();
+    Selenide.confirm(stackTrace);
+  }
+}

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/EngineCockpitUtil.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/EngineCockpitUtil.java
@@ -156,6 +156,10 @@ public class EngineCockpitUtil {
   public static void destroyRunningCase() {
     runTestProcess("17D57ADFD804B24E/destroyRunningCase.ivp");
   }
+  
+  public static void deadlock() {
+    runTestProcess("1871451A54CFD978/deadlock.ivp");
+  }
 
   private static void runTestProcess(String processLink) {
     open(create().app(getAppName()).servlet(SERVLET.PROCESS).path("engine-cockpit-test-data/" + processLink)

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -51,6 +51,7 @@ public class Navigation {
   private static final String MONITOR_PERFORMANCE_PROCESS_EXECUTION_MENU = "#menuform\\:sr_monitor_performance_process_execution";
   private static final String MONITOR_PERFORMANCE_TRACES_MENU = "#menuform\\:sr_monitor_performance_traces";
   private static final String MONITOR_PERFORMANCE_TRAFFIC_GRAPH = "#menuform\\:sr_monitor_performance_traffic_graph";
+  private static final String MONITOR_PERFORMANCE_THREADS = "#menuform\\:sr_monitor_performance_threads";
 
   public static void toDashboard() {
     toMenu(DASHBOARD_MENU);
@@ -336,6 +337,11 @@ public class Navigation {
   public static void toTrafficGraph() {
     toSubSubMenu(MONITOR_MENU, MONITOR_PERFORMANCE_MENU, MONITOR_PERFORMANCE_TRAFFIC_GRAPH);
   }
+
+  public static void toThreads() {
+    toSubSubMenu(MONITOR_MENU, MONITOR_PERFORMANCE_MENU, MONITOR_PERFORMANCE_THREADS);
+  }
+
 
   private static void toMenu(String menuItemPath) {
     $(menuItemPath).find("a").scrollIntoView(false).click();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Table.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Table.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.By;
 
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 
 public class Table {
@@ -67,9 +68,20 @@ public class Table {
   public SelenideElement tableEntry(String entry, int column) {
     return $x(findColumnOverEntry(entry) + "/td[" + column + "]");
   }
+  
+  public SelenideElement tableEntry(int row, int column)
+  {
+    return $x(getBody() + "/tr[" + row + "]/td[" + column + "]");
+  }
+
 
   public SelenideElement row(String entry) {
     return $x(findColumnOverEntry(entry));
+  }
+  
+  public ElementsCollection rows()
+  {
+    return $$x(getBody()+"/tr");
   }
 
   public SelenideElement body() {
@@ -140,8 +152,8 @@ public class Table {
     $(By.id(globalFilter)).sendKeys(search);
   }
 
-  public void searchFilterShould(Condition condition) {
-    $(By.id(globalFilter)).should(condition);
+  public void searchFilterShould(Condition... conditions) {
+    $(By.id(globalFilter)).should(conditions);
   }
 
   public String getSearchFilter() {

--- a/engine-cockpit-test-data/processes/Monitor.p.json
+++ b/engine-cockpit-test-data/processes/Monitor.p.json
@@ -1,0 +1,46 @@
+{
+  "format" : "11.1.14",
+  "id" : "1871451A54CFD978",
+  "config" : {
+    "data" : "engine.cockpit.test.data.Data"
+  },
+  "elements" : [ {
+      "id" : "f0",
+      "type" : "RequestStart",
+      "name" : "deadlock.ivp",
+      "config" : {
+        "callSignature" : "deadlock",
+        "outLink" : "deadlock.ivp",
+        "startName" : "Start deadlock threads"
+      },
+      "visual" : {
+        "at" : { "x" : 96, "y" : 64 }
+      },
+      "connect" : [
+        { "id" : "f4", "to" : "f3" }
+      ]
+    }, {
+      "id" : "f1",
+      "type" : "TaskEnd",
+      "visual" : {
+        "at" : { "x" : 360, "y" : 64 }
+      }
+    }, {
+      "id" : "f3",
+      "type" : "Script",
+      "config" : {
+        "output" : {
+          "code" : [
+            "import ch.ivyteam.enginecockpit.monitor.Deadlock;",
+            "Deadlock.start();"
+          ]
+        }
+      },
+      "visual" : {
+        "at" : { "x" : 232, "y" : 64 }
+      },
+      "connect" : [
+        { "id" : "f2", "to" : "f1" }
+      ]
+    } ]
+}

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/Deadlock.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/Deadlock.java
@@ -1,0 +1,43 @@
+package ch.ivyteam.enginecockpit.monitor;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+public class Deadlock {
+
+  private ReentrantLock lock = new ReentrantLock();
+  private Deadlock other;
+
+  public static void start() {
+    var deadlock1 = new Deadlock();
+    var deadlock2 = new Deadlock();
+    deadlock1.other = deadlock2;
+    deadlock2.other = deadlock1;
+    new Thread(() -> deadlock1.monitor(0), "Deadlock-Monitor-1").start();
+    new Thread(() -> deadlock2.monitor(0), "Deadlock-Monitor-2").start();
+    new Thread(() -> deadlock1.reentrantLock(0), "Deadlock-ReentrantLock-1").start();
+    new Thread(() -> deadlock2.reentrantLock(0), "Deadlock-ReentrantLock-2").start();
+  }
+
+  private synchronized void monitor(int count) {
+    try {
+      if (count == 0) {
+        Thread.sleep(5000);
+        other.monitor(++count);
+      }
+    } catch (InterruptedException e) {
+    }
+  }
+
+  private void reentrantLock(int count) {
+    lock.lock();
+    try {
+      if (count == 0) {
+        Thread.sleep(5000);
+        other.reentrantLock(++count);
+      }
+    } catch (InterruptedException ex) {
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ThreadBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ThreadBean.java
@@ -1,0 +1,256 @@
+package ch.ivyteam.enginecockpit.monitor.performance;
+
+import java.io.ByteArrayInputStream;
+import java.lang.Thread.State;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import javax.faces.context.FacesContext;
+import javax.management.ObjectName;
+
+import org.apache.commons.lang3.StringUtils;
+import org.primefaces.model.DefaultStreamedContent;
+import org.primefaces.model.StreamedContent;
+
+import ch.ivyteam.enginecockpit.monitor.trace.BackgroundMeterUtil;
+
+@ManagedBean
+@SessionScoped
+public class ThreadBean {
+
+  private List<Info> threads;
+  private List<Info> filteredThreads;
+  private long[] deadLocked;
+  private boolean isCpuEnabled;
+  private long maxCpuTime;
+  private long maxUserTime;
+  private Info selected;
+
+  public ThreadBean() {
+    refresh();
+  }
+
+  public void refresh() {
+    isCpuEnabled = threadMxBean().isThreadCpuTimeSupported() && threadMxBean().isThreadCpuTimeEnabled();
+    deadLocked = threadMxBean().findDeadlockedThreads();
+    ThreadInfo[] infos = threadMxBean().dumpAllThreads(true, true);
+    maxCpuTime = Stream.of(infos).map(this::toCpuTime).max(Long::compareTo).orElse(-1L);
+    maxUserTime = Stream.of(infos).map(this::toUserTime).max(Long::compareTo).orElse(-1L);
+    threads = Stream.of(infos).map(info -> infoFor(info)).collect(Collectors.toList());
+    filteredThreads = threads;
+  }
+
+  public StreamedContent dump() {
+    String dump = dumpToString();
+    if (dump == null) {
+      return null;
+    }
+    return DefaultStreamedContent.builder().name("ThreadDump.txt").contentType("text/text")
+            .stream(() -> new ByteArrayInputStream(dump.getBytes(StandardCharsets.UTF_8))).build();
+  }
+
+  private String dumpToString() {
+    try {
+      return (String) ManagementFactory.getPlatformMBeanServer().invoke(
+              new ObjectName("com.sun.management", "type", "DiagnosticCommand"), "threadPrint",
+              new Object[] {new String[0]}, new String[] {String[].class.getName()});
+    } catch (Exception ex) {
+      var message = new FacesMessage(FacesMessage.SEVERITY_ERROR, ex.getClass().getSimpleName(), ex.getMessage());
+      FacesContext.getCurrentInstance().addMessage("msgs", message);
+      return null;
+    }
+  }
+
+  public List<Info> getThreads() {
+    return threads;
+  }
+
+  public List<Info> getFilteredThreads() {
+    return filteredThreads;
+  }
+
+  public void setFilteredThreads(List<Info> filteredThreads) {
+    this.filteredThreads = filteredThreads;
+  }
+
+  public boolean filter(Object value, Object filter, @SuppressWarnings("unused") Locale locale) {
+    if (value instanceof Info info) {
+      String name = info.getName();
+      return name != null && StringUtils.containsIgnoreCase(name, filter.toString());
+    }
+    return false;
+  }
+
+  public Info getSelected() {
+    return this.selected;
+  }
+
+  public void setSelected(Info thread) {
+    this.selected = thread;
+  }
+
+  private static ThreadMXBean threadMxBean() {
+    return ManagementFactory.getThreadMXBean();
+  }
+
+  private long toCpuTime(ThreadInfo info) {
+    return isCpuEnabled ? threadMxBean().getThreadCpuTime(info.getThreadId()) : -1;
+  }
+
+  private long toUserTime(ThreadInfo info) {
+    return isCpuEnabled ? threadMxBean().getThreadUserTime(info.getThreadId()) : -1;
+  }
+
+  private Info infoFor(ThreadInfo info) {
+    var cpuTime = toCpuTime(info);
+    var userTime = toUserTime(info);
+    return new Info(info, cpuTime, userTime);
+  }
+
+  public final class Info {
+
+    private final long id;
+    private final String name;
+    private final State state;
+    private final int priority;
+    private final long cpuTime;
+    private final long userTime;
+    private final ThreadInfo info;
+
+    private Info(ThreadInfo info, long cpuTime, long userTime) {
+      super();
+      this.id = info.getThreadId();
+      this.name = info.getThreadName();
+      this.state = info.getThreadState();
+      this.priority = info.getPriority();
+      this.cpuTime = cpuTime;
+      this.userTime = userTime;
+      this.info = info;
+    }
+
+    public long getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public State getState() {
+      return state;
+    }
+
+    public String getStateColorClass() {
+      return switch (state) {
+        case RUNNABLE -> "thread-runnable";
+        case BLOCKED -> isDeadLocked() ? "thread-deadlocked" : "thread-waiting";
+        case WAITING -> isDeadLocked() ? "thread-deadlocked" : "thread-waiting";
+        case TIMED_WAITING -> "thread-waiting";
+        case NEW -> "";
+        case TERMINATED -> "";
+      };
+    }
+
+    public String getStateTitle() {
+      if (isDeadLocked()) {
+        return "This thread is deadlocked! It is waiting to lock " + getLockName()
+                + " which is owned by thread " + getLockOwner() + ".";
+      }
+      return switch (state) {
+        case RUNNABLE -> "Thread is runnable.";
+        case BLOCKED -> "Thread is blocked. It waits to lock " + getLockName() + " which is owned by thread "
+                + getLockOwner() + ".";
+        case WAITING -> "Thread is waiting on lock " + getLockName() + ".";
+        case TIMED_WAITING -> "Thread is waiting with a timeout on lock " + getLockName() + ".";
+        case NEW -> "Thread is new and not yet started";
+        case TERMINATED -> "Thread has terminated";
+      };
+    }
+
+    public int getPriority() {
+      return priority;
+    }
+
+    public long getCpuTime() {
+      return cpuTime;
+    }
+
+    public String getCpuTimeBackground() {
+      return BackgroundMeterUtil.background(cpuTime, maxCpuTime);
+    }
+
+    public long getUserTime() {
+      return userTime;
+    }
+
+    public String getUserTimeBackground() {
+      return BackgroundMeterUtil.background(userTime, maxUserTime);
+    }
+
+    public boolean isDeadLocked() {
+      return deadLocked != null && Arrays.stream(deadLocked).anyMatch(threadId -> threadId == id);
+    }
+
+    public ThreadInfo getInfo() {
+      return info;
+    }
+
+    public String getLockedSynchronizers() {
+      var lockedSynchronizers = info.getLockedSynchronizers();
+      if (lockedSynchronizers == null || lockedSynchronizers.length == 0) {
+        return "None";
+      }
+      return Stream.of(lockedSynchronizers).map(LockInfo::toString).collect(Collectors.joining(",\n"));
+    }
+
+    public String getLockedMonitors() {
+      var lockedMonitors = info.getLockedMonitors();
+      if (lockedMonitors == null || lockedMonitors.length == 0) {
+        return "None";
+      }
+      return Stream.of(lockedMonitors).map(this::toMonitorString).collect(Collectors.joining(",\n"));
+    }
+
+    private String toMonitorString(MonitorInfo monitor) {
+      var frame = monitor.getLockedStackFrame();
+      return monitor.toString() + " - " + frame.getClassName() + "." + frame.getMethodName() + "("
+              + frame.getFileName() + ":" + frame.getLineNumber() + ")";
+    }
+
+    public String getLockName() {
+      var lockName = info.getLockName();
+      if (StringUtils.isBlank(lockName)) {
+        return "None";
+      }
+      return lockName;
+    }
+
+    public String getLockOwner() {
+      var lockOwnerName = info.getLockOwnerName();
+      if (StringUtils.isBlank(lockOwnerName)) {
+        return "None";
+      }
+      return info.getLockOwnerId() + " - " + lockOwnerName;
+    }
+
+    public String getStackTrace() {
+      var lockedMonitors = info.getStackTrace();
+      if (lockedMonitors == null || lockedMonitors.length == 0) {
+        return "None";
+      }
+      return Stream.of(lockedMonitors).map(StackTraceElement::toString).collect(Collectors.joining("\n"));
+    }
+  }
+}

--- a/engine-cockpit/webContent/includes/template/sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/sidebar.xhtml
@@ -78,6 +78,7 @@
                 url="monitorTraces.xhtml" />
               <p:menuitem id="sr_monitor_performance_traffic_graph" value="Traffic Graph" icon="si si-view-1"
                 url="monitorTrafficGraph.xhtml" />
+              <p:menuitem id="sr_monitor_performance_threads" value="Threads" icon="si si si-synchronize-arrow-clock" url="monitorThreads.xhtml" />
             </p:submenu>
             <p:menuitem id="sr_logs" value="Logs" icon="si si-common-file-text" url="logs.xhtml?log=console.log" />
           </p:submenu>

--- a/engine-cockpit/webContent/resources/css/engine-cockpit.css
+++ b/engine-cockpit/webContent/resources/css/engine-cockpit.css
@@ -120,6 +120,12 @@ body .user-avatar > img {
   overflow: auto;
   max-height: 500px;
 }
+.code {
+  font-family: monospace !important;
+  white-space: pre;
+  overflow: auto;
+  max-height: 200px;
+}
 .ui-dialog .ui-dialog-content .custom-dialog-form {
   height: 100%;
   display: flex;
@@ -268,8 +274,12 @@ body .ui-datatable .ui-datatable-header {
 .state-active,
 .activity-state-active,
 .search-machine-state-true,
-.search-machine-health-green {
+.search-machine-health-green,
+.thread-runnable {
   color: var(--success-color, #2aa483);
+}
+.thread-waiting {
+  color: var(--primary-color);
 }
 .state-unknown,
 .activity-state-locked,
@@ -281,7 +291,8 @@ body .ui-datatable .ui-datatable-header {
 .activity-state-error,
 .search-machine-state-false,
 .search-machine-health-red,
-.licence-messages i.error {
+.licence-messages i.error, 
+.thread-deadlocked {
   color: var(--error-color, #d23636);
 }
 .table-icon.search-machine-health-unknown,
@@ -476,7 +487,6 @@ body .ui-datatable .ui-datatable-header {
   color: var(--ivy-primary-text-color);
   border-radius: 2px;
 }
-
 .migration-question-select-button {
   display: flex;
 }

--- a/engine-cockpit/webContent/view/monitorThreads.xhtml
+++ b/engine-cockpit/webContent/view/monitorThreads.xhtml
@@ -1,0 +1,131 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+  xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
+  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:cc="http://java.sun.com/jsf/composite/composite">
+  <h:body>
+    <ui:composition template="../includes/template/template.xhtml">
+      <ui:define name="breadcrumb">
+        <li><span>Monitor</span></li>
+        <li>/</li>
+        <li><span>Engine</span></li>
+        <li>/</li>
+        <li><span>Performance</span></li>
+        <li>/</li>
+        <li><a href="monitorThread.xhtml">Threads</a></li>
+      </ui:define>
+  
+      <ui:define name="topbar-items">
+        <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}monitor.html#threads" />
+      </ui:define>
+  
+      <ui:define name="content">
+        <p:growl id="msgs" showDetail="true">
+          <p:autoUpdate />
+        </p:growl>
+      
+        <h:form id="form">
+          <div class="layout-dashboard">
+            <div class="card">
+              <div class="card-header p-flex-wrap">
+                <div class="card-title p-d-flex p-ai-center">
+                  <i class="p-pr-3 si si-synchronize-arrow-clock"></i>
+                  <h2 class="p-m-0">Threads</h2>
+                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{threadBean.refresh()}" title="Refresh" styleClass="p-col-fixed p-ml-auto rounded-button" update="threadTable"/>
+                  <p:commandButton id="dump" icon="pi pi-arrow-down" ajax="false" title="Save Thread Dump" styleClass="p-col-fixed p-ml-1 ui-button-success rounded-button">
+                    <p:fileDownload value="#{threadBean.dump()}"/>
+                  </p:commandButton>
+                </div>
+              </div>
+              <p:dataTable var="thread" value="#{threadBean.threads}"
+                widgetVar="threadTable" styleClass="ui-fluid"
+                filteredValue="#{threadBean.filteredThreads}" globalFilterFunction="#{threadBean.filter}"
+                id="threadTable" style="min-width: 950px;">
+                <f:facet name="header">
+                  <div class="ui-input-icon-left filter-container">
+                    <i class="pi pi-search"/>
+                    <p:inputText id="globalFilter" onkeyup="PF('threadTable').filter()" placeholder="Search"/>
+                  </div>
+                </f:facet>
+                <p:column headerText="Id" sortBy="#{thread.id}" width="5%">              
+                  <p:commandLink oncomplete="PF('threadDialog').show();" title="Thread Detail" action="#{threadBean.setSelected(thread)}" update="threadDialog">
+                    <i class="p-pr-3 si si-synchronize-arrow-clock"></i>
+                  <h:outputText value="#{thread.id}"/>
+                </p:commandLink>
+                </p:column>
+                <p:column headerText="Name" sortBy="#{thread.name}" width="40%">
+                  <h:outputText value="#{thread.name}"/>
+                </p:column>
+                <p:column headerText="State" sortBy="#{thread.state}" width="10%">
+                  <h:panelGroup id="state">
+                    <h:outputText value="#{thread.state}" class="#{thread.stateColorClass}"/>
+                    <p:tooltip for="state" value="#{thread.stateTitle}" position="right"/>
+                    <h:panelGroup rendered="#{thread.deadLocked}">
+                      <i h:rendered="#{thread.deadLocked}" class="p-pr-3 si si-road-sign-warning deadlocked ${thread.stateColorClass}"></i>
+                    </h:panelGroup>
+                  </h:panelGroup>
+                </p:column>
+                <p:column headerText="Priority" sortBy="#{thread.priority}" width="5%">
+                  <h:outputText value="#{thread.priority}"/>
+                </p:column>
+                <p:column headerText="CPU Time" sortBy="#{thread.cpuTime}" width="20%">
+                  <div style="background: #{thread.cpuTimeBackground};">
+                    <h:outputText styleClass="gradient-text" value="#{thread.cpuTime}"/>
+                  </div>
+                </p:column>
+                <p:column headerText="User Time" sortBy="#{thread.userTime}" width="20%">
+                  <div style="background: #{thread.userTimeBackground};">
+                    <h:outputText styleClass="gradient-text" value="#{thread.userTime}"/>
+                  </div>
+                </p:column>
+              </p:dataTable>
+            </div>
+          </div>
+        </h:form>
+        <p:dialog style="min-width: 300px; max-width: 80%;" header="Thread #{threadBean.selected.id} - #{threadBean.selected.name}" id="threadDialog"
+            widgetVar="threadDialog" responsive="true" closeOnEscape="true">
+          <h:form id="thread" styleClass="custom-dialog-form">
+            <p:panelGrid columns="2" layout="flex" columnClasses="p-col-2, p-col-10" styleClass="grey-label-panel ui-fluid">
+              <p:outputLabel for="daemon" value="Daemon" />
+              <h:outputText id="daemon" value="#{threadBean.selected.info.daemon}"/>
+              <p:outputLabel for="native" value="In Native Code" />
+              <h:outputText id="native" value="#{threadBean.selected.info.inNative}"/>
+              <p:outputLabel for="deadlocked" value="Deadlocked" />
+              <h:outputText id="deadlocked" value="#{threadBean.selected.deadLocked}"/>          
+              <p:outputLabel for="blocked" value="Blocked" />
+              <h:outputText id="blocked" value="#{threadBean.selected.info.blockedCount} (#{threadBean.selected.info.blockedTime} ns)"/>
+              <p:outputLabel for="waited" value="Waited" />
+              <h:outputText id="waited" value="#{threadBean.selected.info.waitedCount} (#{threadBean.selected.info.waitedTime} ns)"/>
+              <p:outputLabel for="lock" value="Waiting on or for Lock"/>
+              <p:outputPanel id="lock" styleClass="code">#{threadBean.selected.lockName}</p:outputPanel>
+              <p:outputLabel for="lockOwner" value="Lock Owner"/>
+              <p:outputPanel id="lockOwner" styleClass="code">#{threadBean.selected.lockOwner}</p:outputPanel>
+              <p:outputLabel for="lockedSynchronizers" value="Locked Synchronizers"/>
+              <p:outputPanel id="lockedSynchronizers" styleClass="code">#{threadBean.selected.lockedSynchronizers}</p:outputPanel>
+              <p:outputLabel for="lockedMonitors" value="Locked Monitors"/>
+              <p:outputPanel id="lockedMonitors" styleClass="code">#{threadBean.selected.lockedMonitors}</p:outputPanel>
+              <h:panelGroup>
+                <p:outputLabel for="stackTrace" value="Stack Trace"/>
+                <p:commandButton id="copyStack" icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="copyToClipboard(this)"
+                    styleClass="ui-button-flat rounded-button"/>
+              </h:panelGroup>
+              <p:outputPanel id="stackTrace" styleClass="code">#{threadBean.selected.stackTrace}</p:outputPanel>  
+            </p:panelGrid>
+            <div class="custom-dialog-footer">
+              <p:commandButton id="close" type="button" onclick="PF('threadDialog').hide();" value="Close" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
+            </div>
+          </h:form>
+        </p:dialog>
+        <script>
+  function copyToClipboard(btn) {
+    var stackTrace = $("#thread\\:stackTrace").text();
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(stackTrace);
+    } else {
+      alert(stackTrace);
+    }
+  }
+        </script>
+      </ui:define>
+    </ui:composition>
+  </h:body>
+</html>


### PR DESCRIPTION
Add Threads view that allows you to store a thread dump

It shows all threads in a filterable table with columns id, name, state, priority, cpu time, user time.

State column is read if the thread is deadlocked. A warning icon is also shown nearby. Tooltip provides information about the deadlock

Detail thread dialog shows more threads info including the current stack

Add web test for threads view
Add a screenshot for the threads view

Cherry-Pick 8c033733810af843f1928973704ea08ed5e6ea29 from master