### PR TITLE
Fix broken DeadLinks test

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/HttpAsserter.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/HttpAsserter.java
@@ -46,7 +46,7 @@ public class HttpAsserter {
 
       currentDepth += 1;
       for (var link : linksFound) {
-        if (link.contains("faces/view/engine-cockpit")) {
+        if (link.contains("/faces/") && link.contains("/engine-cockpit/")) {
           assertThat(link).hasNoDeadLinks(maxDepth, currentDepth, crawled, checked, sessionId);
         }
       }


### PR DESCRIPTION
The test is broken since the Engine Cockpit is deployed as jar and not as iar.