### PR TITLE
XIVY-11213 Add a new Flight Recorder View to Engine Cockpit

### DIFF
--- a/engine-cockpit-selenium-test/resources/ivy.jfc
+++ b/engine-cockpit-selenium-test/resources/ivy.jfc
@@ -1,0 +1,1020 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="Axon Ivy" description="Axon Ivy specific JFR configuration file" provider="Axon Ivy">
+
+  <event name="jdk.ThreadAllocationStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ClassLoadingStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ClassLoaderStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.JavaThreadStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.SymbolTableStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.StringTableStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.PlaceholderTableStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.LoaderConstraintsTableStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.ProtectionDomainCacheTableStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.ThreadStart">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ThreadEnd">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ThreadSleep">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadPark">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorEnter">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorWait">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorInflate">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.SyncOnValueBasedClass">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.BiasedLockRevocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.BiasedLockSelfRevocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.BiasedLockClassRevocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ReservedStackActivation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ClassLoad">
+    <setting name="enabled" control="class-loading">false</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ClassDefine">
+    <setting name="enabled" control="class-loading">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.RedefineClasses">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.RetransformClasses">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ClassRedefinition">
+    <setting name="enabled" control="class-loading">false</setting>
+  </event>
+
+  <event name="jdk.ClassUnload">
+    <setting name="enabled" control="class-loading">false</setting>
+  </event>
+
+  <event name="jdk.JVMInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.InitialSystemProperty">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ExecutionSample">
+    <setting name="enabled" control="method-sampling-enabled">true</setting>
+    <setting name="period" control="method-sampling-java-interval">20 ms</setting>
+  </event>
+
+  <event name="jdk.NativeMethodSample">
+    <setting name="enabled" control="method-sampling-enabled">true</setting>
+    <setting name="period" control="method-sampling-native-interval">20 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointBegin">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointStateSynchronization">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointCleanup">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointCleanupTask">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointEnd">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.ExecuteVMOperation">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.Shutdown">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ThreadDump">
+    <setting name="enabled" control="thread-dump-enabled">true</setting>
+    <setting name="period" control="thread-dump">everyChunk</setting>
+  </event>
+
+  <event name="jdk.IntFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.UnsignedIntFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.LongFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.UnsignedLongFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.DoubleFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.BooleanFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.StringFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.IntFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.UnsignedIntFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.LongFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.UnsignedLongFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.DoubleFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.BooleanFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.StringFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ObjectCount">
+    <setting name="enabled" control="gc-enabled-all">false</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCHeapConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.YoungGenerationConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.GCTLABConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.GCSurvivorConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ObjectCountAfterGC">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.GCHeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PSHeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1HeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceGCThreshold">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceAllocationFailure">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceOOM">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceChunkFreeListSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.GarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SystemGC">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ParallelOldGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.YoungGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.OldGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.G1GarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePause">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel1">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel2">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel3">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel4">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhaseConcurrent">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhaseConcurrentLevel1">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCReferenceStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PromotionFailed">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.EvacuationFailed">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.EvacuationInformation">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1MMU">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1EvacuationYoungStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1EvacuationOldStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.GCPhaseParallel">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.G1BasicIHOP">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1AdaptiveIHOP">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PromoteObjectInNewPLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.PromoteObjectOutsidePLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.ConcurrentModeFailure">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.AllocationRequiringGC">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.TenuringDistribution">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1HeapRegionInformation">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.G1HeapRegionTypeChange">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.ShenandoahHeapRegionInformation">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ShenandoahHeapRegionStateChange">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.OldObjectSample">
+    <setting name="enabled" control="old-objects-enabled">true</setting>
+    <setting name="stackTrace" control="old-objects-stack-trace">false</setting>
+    <setting name="cutoff" control="old-objects-cutoff">0 ns</setting>
+  </event>
+
+  <event name="jdk.CompilerConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CompilerStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.Compilation">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-compilation-threshold">1000 ms</setting>
+  </event>
+
+  <event name="jdk.CompilerPhase">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-phase-threshold">60 s</setting>
+  </event>
+
+  <event name="jdk.CompilationFailure">
+    <setting name="enabled" control="compiler-enabled-failure">false</setting>
+  </event>
+
+  <event name="jdk.CompilerInlining">
+    <setting name="enabled" control="compiler-enabled-failure">false</setting>
+  </event>
+
+  <event name="jdk.CodeSweeperConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CodeSweeperStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.SweepCodeCache">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-sweeper-threshold">100 ms</setting>
+  </event>
+
+  <event name="jdk.CodeCacheConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CodeCacheStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.CodeCacheFull">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+  </event>
+
+  <event name="jdk.OSInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.VirtualizationInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ContainerConfiguration">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ContainerCPUUsage">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.ContainerCPUThrottling">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.ContainerMemoryUsage">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.ContainerIOUsage">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.CPUInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ThreadContextSwitchRate">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.CPULoad">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadCPULoad">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.CPUTimeStampCounter">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.SystemProcess">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.ProcessStart">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.NetworkUtilization">
+    <setting name="enabled">true</setting>
+    <setting name="period">5 s</setting>
+  </event>
+
+  <event name="jdk.InitialEnvironmentVariable">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.PhysicalMemory">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationInNewTLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationOutsideTLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationSample">
+    <setting name="enabled" control="object-allocation-enabled">true</setting>
+    <setting name="throttle" control="allocation-profiling">150/s</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.NativeLibrary">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ModuleRequire">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.ModuleExport">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.FileForce">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="file-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.FileRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="file-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.FileWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="file-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.SocketRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="socket-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.SocketWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="socket-threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.Deserialization">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.SecurityPropertyModification">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.TLSHandshake">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.X509Validation">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.X509Certificate">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.JavaExceptionThrow">
+    <setting name="enabled" control="enable-exceptions">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.JavaErrorThrow">
+    <setting name="enabled" control="enable-errors">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ExceptionStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ActiveRecording">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ActiveSetting">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.Flush">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ns</setting>
+  </event>
+
+  <event name="jdk.DataLoss">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.DumpReason">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ZAllocationStall">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZPageAllocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">1 ms</setting>
+  </event>
+
+  <event name="jdk.ZRelocationSet">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZRelocationSetGroup">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZStatisticsCounter">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZStatisticsSampler">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZThreadPhase">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZUncommit">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZUnmap">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.Deoptimization">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">false</setting>
+  </event>
+
+  <event name="jdk.HeapDump">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ns</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.DirectBufferStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">5 s</setting>
+  </event>
+
+  <event name="jdk.GCLocker">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">1 s</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <control>
+
+    <selection name="gc" default="normal" label="Garbage Collector">
+      <option label="Off" name="off">off</option>
+      <option label="Normal" name="normal">normal</option>
+      <option label="Detailed" name="detailed">detailed</option>
+      <option label="High, incl. TLABs/PLABs (may cause many events)" name="high">high</option>
+      <option label="All, incl. Heap Statistics (may cause long GCs)" name="all">all</option>
+    </selection>
+
+    <condition name="gc-enabled-normal" true="true" false="false">
+      <or>
+        <test name="gc" operator="equal" value="normal"/>
+        <test name="gc" operator="equal" value="detailed"/>
+        <test name="gc" operator="equal" value="high"/>
+        <test name="gc" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="gc-enabled-detailed" true="true" false="false">
+      <or>
+        <test name="gc" operator="equal" value="detailed"/>
+        <test name="gc" operator="equal" value="high"/>
+        <test name="gc" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="gc-enabled-high" true="true" false="false">
+      <or>
+        <test name="gc" operator="equal" value="high"/>
+        <test name="gc" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="gc-enabled-all" true="true" false="false">
+      <test name="gc" operator="equal" value="all"/>
+    </condition>
+
+    <selection name="allocation-profiling" default="low" label="Allocation Profiling">
+      <option label="Off" name="off">0/s</option>
+      <option label="Low" name="low">150/s</option>
+      <option label="Medium" name="medium">300/s</option>
+      <option label="High" name="high">1000/s</option>
+      <option label="Maximum" name="maximum">1000000000/s</option>
+    </selection>
+
+    <condition name="object-allocation-enabled" true="true" false="false">
+      <not>
+        <test name="allocation-profiling" operator="equal" value="off"/>
+      </not>
+    </condition>
+
+    <selection name="compiler" default="normal" label="Compiler">
+      <option label="Off" name="off">off</option>
+      <option label="Normal" name="normal">normal</option>
+      <option label="Detailed" name="detailed">detailed</option>
+      <option label="All" name="all">all</option>
+    </selection>
+
+    <condition name="compiler-enabled" true="false" false="true">
+      <test name="compiler" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="compiler-enabled-failure" true="true" false="false">
+      <or>
+        <test name="compiler" operator="equal" value="detailed"/>
+        <test name="compiler" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="compiler-sweeper-threshold" true="0 ms" false="100 ms">
+      <test name="compiler" operator="equal" value="all"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="1000 ms">
+      <test name="compiler" operator="equal" value="normal"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="100 ms">
+      <test name="compiler" operator="equal" value="detailed"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="0 ms">
+      <test name="compiler" operator="equal" value="all"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="60 s">
+      <test name="compiler" operator="equal" value="normal"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="10 s">
+      <test name="compiler" operator="equal" value="detailed"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="0 s">
+      <test name="compiler" operator="equal" value="all"/>
+    </condition>
+
+    <selection name="method-profiling" default="normal" label="Method Profiling">
+      <option label="Off" name="off">off</option>
+      <option label="Normal" name="normal">normal</option>
+      <option label="High" name="high">high</option>
+      <option label="Maximum (High Overhead)" name="max">max</option>
+    </selection>
+
+    <condition name="method-sampling-java-interval" true="999 d">
+      <test name="method-profiling" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="20 ms">
+      <test name="method-profiling" operator="equal" value="normal"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="10 ms">
+      <test name="method-profiling" operator="equal" value="high"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="1 ms">
+      <test name="method-profiling" operator="equal" value="max"/>
+    </condition>
+
+    <condition name="method-sampling-native-interval" true="999 d">
+      <test name="method-profiling" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="method-sampling-native-interval" true="20 ms">
+      <or>
+        <test name="method-profiling" operator="equal" value="normal"/>
+        <test name="method-profiling" operator="equal" value="high"/>
+        <test name="method-profiling" operator="equal" value="max"/>
+      </or>
+    </condition>
+
+    <condition name="method-sampling-enabled" true="false" false="true">
+      <test name="method-profiling" operator="equal" value="off"/>
+    </condition>
+
+    <selection name="thread-dump" default="once" label="Thread Dump">
+      <option label="Off" name="off">999 d</option>
+      <option label="At least Once" name="once">everyChunk</option>
+      <option label="Every 60 s" name="60s">60 s</option>
+      <option label="Every 10 s" name="10s">10 s</option>
+      <option label="Every 1 s" name="1s">1 s</option>
+    </selection>
+
+    <condition name="thread-dump-enabled" true="false" false="true">
+      <test name="thread-dump" operator="equal" value="999 d"/>
+    </condition>
+
+    <selection name="exceptions" default="errors" label="Exceptions">
+      <option label="Off" name="off">off</option>
+      <option label="Errors Only" name="errors">errors</option>
+      <option label="All Exceptions, including Errors" name="all">all</option>
+    </selection>
+
+    <condition name="enable-errors" true="true" false="false">
+      <or>
+        <test name="exceptions" operator="equal" value="errors"/>
+        <test name="exceptions" operator="equal" value="all"/>
+      </or>
+    </condition>
+
+    <condition name="enable-exceptions" true="true" false="false">
+      <test name="exceptions" operator="equal" value="all"/>
+    </condition>
+
+    <selection name="memory-leaks" default="types" label="Memory Leak Detection">
+      <option label="Off" name="off">off</option>
+      <option label="Object Types" name="types">types</option>
+      <option label="Object Types + Allocation Stack Traces" name="stack-traces">stack-traces</option>
+      <option label="Object Types + Allocation Stack Traces + Path to GC Root" name="gc-roots">gc-roots</option>
+    </selection>
+
+    <condition name="old-objects-enabled" true="false" false="true">
+      <test name="memory-leaks" operator="equal" value="off"/>
+    </condition>
+
+    <condition name="old-objects-stack-trace" true="true" false="false">
+      <or>
+        <test name="memory-leaks" operator="equal" value="stack-traces"/>
+        <test name="memory-leaks" operator="equal" value="gc-roots"/>
+      </or>
+    </condition>
+
+    <condition name="old-objects-cutoff" true="1 h" false="0 ns">
+      <test name="memory-leaks" operator="equal" value="gc-roots"/>
+    </condition>
+
+    <text name="locking-threshold" label="Locking Threshold" contentType="timespan" minimum="0 s">20 ms</text>
+
+    <text name="file-threshold" label="File I/O Threshold" contentType="timespan" minimum="0 s">20 ms</text>
+
+    <text name="socket-threshold" label="Socket I/O Threshold" contentType="timespan" minimum="0 s">20 ms</text>
+
+    <flag name="class-loading" label="Class Loading">false</flag>
+
+  </control>
+
+</configuration>

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
@@ -103,6 +103,8 @@ public class WebDocuScreenshot {
     takeScreenshot("monitor-traffic-graph", new Dimension(SCREENSHOT_WIDTH, 800));
     Navigation.toThreads();
     takeScreenshot("monitor-threads", new Dimension(SCREENSHOT_WIDTH, 800));
+    Navigation.toJfr();
+    takeScreenshot("monitor-jfr", new Dimension(SCREENSHOT_WIDTH, 800));
     Navigation.toSessions();
     takeScreenshot("monitor-sessions", new Dimension(SCREENSHOT_WIDTH, 1000));
     Navigation.toJobs();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJfr.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJfr.java
@@ -1,0 +1,143 @@
+package ch.ivyteam.enginecockpit.monitor;
+
+import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
+import static com.codeborne.selenide.CollectionCondition.texts;
+import static com.codeborne.selenide.Condition.enabled;
+import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Condition.not;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static org.openqa.selenium.By.id;
+
+import java.io.File;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import com.axonivy.ivy.webtest.IvyWebTest;
+import com.codeborne.selenide.Condition;
+
+import ch.ivyteam.enginecockpit.util.Navigation;
+import ch.ivyteam.enginecockpit.util.Table;
+
+@IvyWebTest
+public class WebTestJfr {
+
+  private Table recordingsTable;
+
+  @BeforeEach
+  void beforeEach() {
+    login();
+    Navigation.toJfr();
+    recordingsTable = new Table(By.id("form:recordingsTable"));
+  }
+
+  @AfterEach
+  void afterEeach() {
+    var entries = recordingsTable.getFirstColumnEntries();
+    for (var entry : entries) {
+      recordingsTable.clickButtonForEntry(entry, "close");
+    }
+  }
+
+  @Test
+  void start() {
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+
+    $(id("form:start")).shouldBe(visible, enabled).click();
+    $(id("startRecording:start")).shouldBe(visible, enabled).click();
+
+    recordingsTable.rows().shouldBe(texts("Axon Ivy"));
+    var entry = recordingsTable.getFirstColumnEntries().get(0);
+    recordingsTable.tableEntry(entry, 2).shouldBe(Condition.text("Axon Ivy"));
+    recordingsTable.tableEntry(entry, 3).shouldBe(text("RUNNING"));
+    recordingsTable.buttonForEntryShouldBeDisabled(entry, "stop", false);
+    recordingsTable.buttonForEntryShouldBeDisabled(entry, "download", true);
+    recordingsTable.buttonForEntryShouldBeDisabled(entry, "close", false);
+  }
+
+  @Test
+  void stop() {
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+
+    $(id("form:start")).shouldBe(visible, enabled).click();
+    $(id("startRecording:start")).shouldBe(visible, enabled).click();
+
+    recordingsTable.rows().shouldBe(texts("Axon Ivy"));
+    var entry = recordingsTable.getFirstColumnEntries().get(0);
+    recordingsTable.tableEntry(entry, 3).shouldBe(text("RUNNING"));
+    recordingsTable.clickButtonForEntry(entry, "stop");
+    recordingsTable.tableEntry(1, 3).shouldBe(text("STOPPED"));
+    recordingsTable.buttonForEntryShouldBeDisabled(entry, "stop", true);
+    recordingsTable.buttonForEntryShouldBeDisabled(entry, "download", false);
+    recordingsTable.buttonForEntryShouldBeDisabled(entry, "close", false);
+  }
+
+  @Test
+  void close() {
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+
+    $(id("form:start")).shouldBe(visible, enabled).click();
+    $(id("startRecording:start")).shouldBe(visible, enabled).click();
+    recordingsTable.tableEntry(1, 3).shouldBe(text("RUNNING"));
+    var entry = recordingsTable.getFirstColumnEntries().get(0);
+    recordingsTable.clickButtonForEntry(entry, "close");
+
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+  }
+
+  @Test
+  void download() {
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+
+    $(id("form:start")).shouldBe(visible, enabled).click();
+    $(id("startRecording:start")).shouldBe(visible, enabled).click();
+
+    recordingsTable.rows().shouldBe(texts("Axon Ivy"));
+    var entry = recordingsTable.getFirstColumnEntries().get(0);
+    recordingsTable.tableEntry(entry, 3).shouldBe(text("RUNNING"));
+    recordingsTable.clickButtonForEntry(entry, "stop");
+    recordingsTable.clickButtonForEntry(entry, "download");
+  }
+
+  @Test
+  void name() {
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+
+    $(id("form:start")).shouldBe(visible, enabled).click();
+    $(id("startRecording:name")).shouldBe(visible, enabled).sendKeys("My recording");
+    $(id("startRecording:start")).shouldBe(visible, enabled).click();
+
+    recordingsTable.tableEntry(1, 2).shouldBe(text("My recording"));
+    recordingsTable.tableEntry(1, 5).shouldBe(exactText("Unlimited"));
+  }
+
+  @Test
+  void duration() {
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+
+    $(id("form:start")).shouldBe(visible, enabled).click();
+    $(id("startRecording:more_toggler")).shouldBe(visible, enabled).click();
+    $(id("startRecording:duration")).shouldBe(visible, enabled).sendKeys("10 s");
+    $(id("startRecording:start")).shouldBe(visible, enabled).click();
+
+    recordingsTable.tableEntry(1, 5).shouldBe(not(exactText("Unlimited")));
+  }
+
+  @Test
+  void add_upload_configuration() {
+    recordingsTable.rows().shouldBe(texts("No recordings found"));
+
+    $(id("form:start")).shouldBe(visible, enabled).click();
+    var jfcFile = new File(System.getProperty("user.dir") + "/resources/ivy.jfc").toPath();
+    $(id("startRecording:uploadConfig_input")).shouldBe(enabled).sendKeys(jfcFile.toString());
+
+    $(id("startRecording:configuration_label")).shouldBe(visible, enabled, text("Axon Ivy"));
+    $(id("startRecording:start")).shouldBe(visible, enabled).click();
+    recordingsTable.rows().shouldBe(texts("Axon Ivy"));
+  }
+
+}

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
@@ -22,7 +22,7 @@ import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
 
-@IvyWebTest(headless = false)
+@IvyWebTest
 public class WebTestThreads {
 
   private static final Duration TWENTY_SECONDS = Duration.ofSeconds(20);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -57,6 +57,7 @@ public class Navigation {
   private static final String MONITOR_PERFORMANCE_TRACES_MENU = "#menuform\\:sr_monitor_performance_traces";
   private static final String MONITOR_PERFORMANCE_TRAFFIC_GRAPH = "#menuform\\:sr_monitor_performance_traffic_graph";
   private static final String MONITOR_PERFORMANCE_THREADS = "#menuform\\:sr_monitor_performance_threads";
+  private static final String MONITOR_PERFORMANCE_JFR = "#menuform\\:sr_monitor_performance_jfr";
 
   public static void toDashboard() {
     toMenu(DASHBOARD_MENU);
@@ -358,6 +359,10 @@ public class Navigation {
 
   public static void toThreads() {
     toSubSubMenu(MONITOR_MENU, MONITOR_PERFORMANCE_MENU, MONITOR_PERFORMANCE_THREADS);
+  }
+
+  public static void toJfr() {
+    toSubSubMenu(MONITOR_MENU, MONITOR_PERFORMANCE_MENU, MONITOR_PERFORMANCE_JFR);
   }
 
   private static void toMenu(String menuItemPath) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Configuration.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Configuration.java
@@ -1,0 +1,47 @@
+package ch.ivyteam.enginecockpit.monitor.performance.jfr;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.management.openmbean.CompositeData;
+
+import org.apache.commons.io.IOUtils;
+import org.primefaces.model.file.UploadedFile;
+
+import ch.ivyteam.ivy.scripting.objects.Xml;
+
+public record Configuration(String name, String label, String description, String provider, String contents) {
+  
+  static Configuration from(CompositeData data) {
+    return new Configuration(
+        (String)data.get("name"), 
+        (String)data.get("label"), 
+        (String)data.get("description"), 
+        (String)data.get("provider"),
+        null);
+  }
+  
+  static Configuration from(UploadedFile file) throws Exception {
+    try (var is = file.getInputStream()) {
+      var contents = IOUtils.toString(is, StandardCharsets.UTF_8);
+      Xml xml = new Xml(contents);
+      return new Configuration(
+          file.getFileName(),
+          xml.getString("/configuration/@label"),
+          xml.getString("/configuration/@description"),
+          xml.getString("/configuration/@provider"),
+          contents);
+    }
+  }
+  
+  public String getName() {
+    return name();
+  }
+  
+  public String getLabel() {
+    return label();
+  }
+
+  public String getDescription() {
+    return description();
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrBean.java
@@ -1,0 +1,219 @@
+package ch.ivyteam.enginecockpit.monitor.performance.jfr;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import javax.faces.context.FacesContext;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularDataSupport;
+
+import org.primefaces.event.FileUploadEvent;
+import org.primefaces.model.DefaultStreamedContent;
+import org.primefaces.model.StreamedContent;
+
+import ch.ivyteam.ivy.Advisor;
+import ch.ivyteam.log.Logger;
+
+@ManagedBean
+@ViewScoped
+public class JfrBean {
+
+  static final ObjectName FLIGHT_RECORDER = createFlightRecorderName();
+
+  private static final Logger LOGGER = Logger.getPackageLogger(JfrBean.class);
+
+  private List<Recording> recordings;
+  private List<Configuration> configurations;
+
+  private String configuration;
+
+  private String name = Advisor.instance().getApplicationName();
+  private List<Option> options = Option.createAll();
+
+  public JfrBean() {
+    refresh();
+    configurations = queryConfigurations();
+    if (!configurations.isEmpty()) {
+      configuration = configurations.get(0).name();
+    }
+  }
+
+  public List<Configuration> getConfigurations() {
+    return configurations;
+  }
+
+  public String getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(String configuration) {
+    this.configuration = configuration;
+  }
+
+  private Configuration configuration() {
+    return configurations
+        .stream()
+        .filter(config -> Objects.equals(config.name(), configuration))
+        .findAny()
+        .orElseThrow();
+  }
+
+  public void addConfiguration(FileUploadEvent event) {
+    try {
+      var uploadedConfiguration = Configuration.from(event.getFile());
+      if (uploadedConfiguration != null) {
+        configurations.add(uploadedConfiguration);
+        setConfiguration(uploadedConfiguration.getName());
+      }
+    } catch (Exception ex) {
+      showError("Cannot upload configuration file", ex);
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<Recording> getRecordings() {
+    return recordings;
+  }
+
+  public boolean isHasRunningRecordings() {
+    return recordings.stream().anyMatch(Recording::isRunning);
+  }
+
+  public boolean isHasNotRunningRecordings() {
+    return recordings.stream().anyMatch(Recording::isNotRunning);
+  }
+
+  public void refresh() {
+    recordings = queryRecordings();
+  }
+
+  public void startRecording() {
+    try {
+      var id = ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "newRecording", null, null);
+      configureRecording(id);
+      configureOptions(id);
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "startRecording", new Object[]{id}, new String[]{long.class.getName()});
+      refresh();
+    } catch (InstanceNotFoundException | ReflectionException | MBeanException | OpenDataException ex) {
+      showError("Cannot start recording '" + name + "'", ex);
+    }
+  }
+
+  private void configureRecording(Object id)
+          throws ReflectionException, MBeanException, InstanceNotFoundException
+  {
+    var config = configuration();
+    if (config.contents() != null) {
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "setConfiguration", new Object[] {id, config.contents()}, new String[] {long.class.getName(), String.class.getName()});
+    } else {
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "setPredefinedConfiguration", new Object[] {id, config.name()}, new String[] {long.class.getName(), String.class.getName()});
+    }
+  }
+
+  private void configureOptions(Object id)
+          throws ReflectionException, MBeanException, InstanceNotFoundException, OpenDataException {
+    var originalOptions = (TabularData)ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "getRecordingOptions", new Object[] {id}, new String[] {long.class.getName()});
+    var opts = new TabularDataSupport(originalOptions.getTabularType());
+    var originalNameOption = originalOptions.get(new Object[] {"name"});
+    var nameOption = new CompositeDataSupport(originalNameOption.getCompositeType(), Map.of("key", "name", "value", name));
+    opts.put(nameOption);
+    for (var opt : options) {
+      if (!opt.isDefaultValue()) {
+        var o = new CompositeDataSupport(originalNameOption.getCompositeType(), Map.of("key", opt.getName(), "value", opt.getValue()));
+        opts.put(o);
+      }
+    }
+    ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "setRecordingOptions", new Object[] {id, opts}, new String[] {long.class.getName(), TabularData.class.getName()});
+  }
+
+  public List<Option> getOptions() {
+    return options;
+  }
+
+  public void stopRecording(Recording recording) {
+    try {
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "stopRecording", new Object[]{recording.id()}, new String[]{long.class.getName()});
+      refresh();
+    } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
+      showError("Cannot stop recording '"+recording.name()+"'", ex);
+    }
+  }
+
+  public void closeRecording(Recording recording) {
+    try {
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "closeRecording", new Object[]{recording.id()}, new String[]{long.class.getName()});
+      refresh();
+    } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
+      showError("Cannot close recording '"+recording.name()+"'", ex);
+    }
+  }
+
+  public StreamedContent downloadRecording(Recording recording) {
+    return DefaultStreamedContent.builder()
+        .name(recording.name()+".jfr")
+        .stream(() -> new JfrStream(recording))
+        .build();
+  }
+
+  public static List<Recording> queryRecordings() {
+    try {
+      var recordings = (CompositeData[])ManagementFactory.getPlatformMBeanServer().getAttribute(FLIGHT_RECORDER, "Recordings");
+      return Stream.of(recordings)
+          .map(Recording::from)
+          .toList();
+    } catch (InstanceNotFoundException | AttributeNotFoundException | ReflectionException | MBeanException ex) {
+      showError("Cannot read attribute 'Recordings' from flight recorder", ex);
+      return List.of();
+    }
+  }
+
+  private static List<Configuration> queryConfigurations() {
+    try {
+      var configurations = (CompositeData[])ManagementFactory.getPlatformMBeanServer().getAttribute(FLIGHT_RECORDER, "Configurations");
+      return new ArrayList<>(Stream.of(configurations)
+          .map(Configuration::from)
+          .toList());
+    } catch (InstanceNotFoundException | AttributeNotFoundException | ReflectionException | MBeanException ex) {
+      showError("Cannot read attribute 'Configurations' from flight recorder", ex);
+      return List.of();
+    }
+  }
+
+  private static ObjectName createFlightRecorderName() {
+    try {
+      return new ObjectName("jdk.management.jfr", "type", "FlightRecorder");
+    } catch (MalformedObjectNameException ex) {
+      showError("Cannot create FlightRecorder name", ex);
+      return null;
+    }
+  }
+
+  private static void showError(String msg, Exception ex) {
+    var message = new FacesMessage(FacesMessage.SEVERITY_ERROR, msg, ex.getMessage());
+    FacesContext.getCurrentInstance().addMessage("msgs", message);
+    LOGGER.error(msg, ex);
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrStream.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrStream.java
@@ -1,0 +1,65 @@
+package ch.ivyteam.enginecockpit.monitor.performance.jfr;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.ReflectionException;
+import javax.management.openmbean.TabularData;
+
+class JfrStream extends InputStream {
+  private final long streamId;
+  private byte[] buffer;
+  private int nextIndexToRead = 0;
+  private IOException error;
+
+  JfrStream(Recording recording) {
+    this.streamId = open(recording);
+  }
+
+  private long open(Recording recording) {
+    try {
+      return (long)ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "openStream", new Object[]{recording.id(), null}, new String[]{long.class.getName(), TabularData.class.getName()});
+    } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
+      this.error = new IOException("Cannot open JFR stream for recording '" + recording.id() + "'", ex);
+      return -1;
+    }
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (error != null) {
+      throw error;
+    }
+    if (nextIndexToRead == -1) {
+      return nextIndexToRead;
+    }
+    if (buffer == null || nextIndexToRead >= buffer.length) {
+      try {
+        buffer = (byte[])ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "readStream", new Object[]{streamId}, new String[]{long.class.getName()});
+      } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
+        throw new IOException("Cannot read JFR stream", ex);
+      }
+      if (buffer == null) {
+        nextIndexToRead = -1;
+        return nextIndexToRead;
+      }
+      nextIndexToRead = 0;
+    }
+    return Byte.toUnsignedInt(buffer[nextIndexToRead++]);
+  }
+  
+  @Override
+  public void close() throws IOException {
+    if (error != null) {
+      throw error;
+    }
+    try {
+      ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "closeStream", new Object[]{streamId}, new String[]{long.class.getName()});
+    } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
+      throw new IOException("Cannot close JFR stream", ex); 
+    }
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Option.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Option.java
@@ -1,0 +1,116 @@
+package ch.ivyteam.enginecockpit.monitor.performance.jfr;
+
+import java.util.List;
+
+public final class Option {
+  private final String name;
+  private final String label;
+  private final String description;
+  private final String defaultValue;
+  private String value;
+
+  public Option(String name, String label, String description, String value) {
+    this.name = name;
+    this.label = label;
+    this.description = description;
+    this.value = value;
+    this.defaultValue = value;
+  }
+  public String getName() {
+    return name;
+  }
+  
+  public String getLabel() {
+    return label;
+  }
+  
+  public String getDescription() {
+    return description;
+  }
+
+  public String getValue() {
+    return value;
+  }
+  
+  public void setValue(String value) {
+    this.value = value;
+  }    
+  
+  public boolean isDefaultValue() {
+    return defaultValue.equals(value);
+  }
+  
+  public static List<Option> createAll()
+  {
+    return List.of(
+            new Option("duration", "Duration", """
+              Sets how long the recording should be running.
+              
+              "0" if no limit should be imposed, otherwise a string representation of a positive Long 
+              followed by an empty space and one of the following units:
+
+              "ns" (nanoseconds)
+              "us" (microseconds)
+              "ms" (milliseconds)
+              "s" (seconds)
+              "m" (minutes)
+              "h" (hours)
+              "d" (days)
+              
+              Examples:
+              "60 s",
+              "10 m",
+              "4 h",
+              "0"
+              """, "0"),
+            new Option("maxAge", "Max age", """
+              Specify the length of time that the data is kept in the disk repository until the oldest
+              data may be deleted. Only works if disk=true, otherwise this parameter is ignored.
+              
+              "0" if no limit is imposed, otherwise a string representation of a positive Long value 
+              followed by an empty space and one of the following units,
+
+              "ns" (nanoseconds)
+              "us" (microseconds)
+              "ms" (milliseconds)
+              "s" (seconds)
+              "m" (minutes)
+              "h" (hours)
+              "d" (days)
+              
+              Examples:
+              "2 h"
+              "24 h"
+              "2 d"
+              "0"                                                                           
+              """, "0"), 
+            new Option("maxSize", "Max size", """
+              Specifies the size, measured in bytes, at which data is kept in disk repository. 
+              Only works if disk=true, otherwise this parameter is ignored.
+              
+              String representation of a Long value, must be positive
+              
+              Examples:
+              "0"
+              "100000000"                              
+              """, "0"),
+            new Option("disk", "Disk", """
+              Stores recorded data as it is recorded.
+              
+              String representation of a Boolean value, "true" or "false"
+              
+              Examples:
+              "true"
+              "false"                              
+              """, "false"),
+            new Option("dumpOnExit", "Dump on exit", """
+              Dumps recording data to disk on Java Virtual Machine (JVM) exit.
+              
+              String representation of a Boolean value, "true" or "false"
+              
+              Examples:
+              "true"
+              "false"                              
+              """, "false")); 
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Recording.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Recording.java
@@ -1,0 +1,118 @@
+package ch.ivyteam.enginecockpit.monitor.performance.jfr;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+
+import javax.management.openmbean.CompositeData;
+
+import ch.ivyteam.enginecockpit.monitor.unit.Unit;
+
+public record Recording(long id, String name, String state, LocalDateTime startTime, LocalDateTime stopTime, long size, long duration) {
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault());
+
+  static Recording from(CompositeData data) {
+    return new Recording(
+        (Long)data.get("id"),
+        (String)data.get("name"),
+        (String)data.get("state"),
+        toLocalDateTime(data.get("startTime")),
+        toLocalDateTime(data.get("stopTime")),
+        (Long)data.get("size"),
+        (Long)data.get("duration"));
+  }
+
+  private static LocalDateTime toLocalDateTime(Object msSinceEpoch) {
+    long ms = (Long)msSinceEpoch;
+    if (ms == 0L) {
+      return null;
+    }
+    return LocalDateTime.ofInstant(Instant.ofEpochMilli((Long)msSinceEpoch), ZoneId.systemDefault());
+  }
+  
+  public long getId() {
+    return id();
+  }
+  
+  public String getName() {
+    return name();
+  }
+  
+  public String getState() {
+    return state();
+  }
+  
+  public String getSize() {
+    var unit = Unit.BYTES;
+    var value = size();
+    var scaledValue = Unit.BYTES.convertTo(value, unit);
+    while (scaledValue > 10000) {
+      unit= unit.scaleUp();
+      scaledValue = Unit.BYTES.convertTo(value, unit);
+    }
+    return scaledValue+" "+ unit.symbol();
+  }
+  
+  public String getStartTime() {
+    return format(startTime());
+  }
+
+  public String getStopTime() {
+    return format(stopTime());
+  }
+  
+  public String getDuration() {
+    var unit = Unit.SECONDS;
+    var value = duration();
+    if (value == 0) {
+      return "Unlimited";
+    }
+    if (isRunning()) { 
+      value = Duration.between(LocalDateTime.now(), startTime().plus(Duration.ofSeconds(value))).getSeconds();
+      if (value <= 0) {
+        return "Now";
+      }
+    }
+    var scaledValue = Unit.SECONDS.convertTo(value, unit);
+    while (scaledValue > 100) {
+      unit= unit.scaleUp();
+      scaledValue = Unit.SECONDS.convertTo(value, unit);
+    }
+    return scaledValue+" "+ unit.symbol();
+    
+  }
+  
+  public boolean isCanStop() {
+    return isRunning();
+  }
+  
+  public boolean isCanClose() {
+    return true;
+  }
+
+  public boolean isCanDownload() {
+    return switch(state()) {
+      case "STOPPED" -> true;
+      default -> false;
+    };
+  }
+  
+  public boolean isRunning() {
+    return "RUNNING".equals(state);
+  }
+  
+  public boolean isNotRunning() {
+    return !isRunning();
+  }
+
+  private String format(LocalDateTime time) {
+    if (time == null) {
+      return "";
+    }
+    return time.format(DATE_TIME_FORMATTER);
+  }
+}
+

--- a/engine-cockpit/webContent/includes/template/sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/sidebar.xhtml
@@ -80,7 +80,8 @@
                 url="monitorTraces.xhtml" />
               <p:menuitem id="sr_monitor_performance_traffic_graph" value="Traffic Graph" icon="si si-view-1"
                 url="monitorTrafficGraph.xhtml" />
-              <p:menuitem id="sr_monitor_performance_threads" value="Threads" icon="si si si-synchronize-arrow-clock" url="monitorThreads.xhtml" />
+              <p:menuitem id="sr_monitor_performance_threads" value="Threads" icon="si si-synchronize-arrow-clock" url="monitorThreads.xhtml" />
+              <p:menuitem id="sr_monitor_performance_jfr" value="Flight Recorder" icon="si si-plane-take-off" url="monitorJfr.xhtml" />
             </p:submenu>
             <p:menuitem id="sr_logs" value="Logs" icon="si si-common-file-text" url="logs.xhtml" />
           </p:submenu>

--- a/engine-cockpit/webContent/resources/css/engine-cockpit.css
+++ b/engine-cockpit/webContent/resources/css/engine-cockpit.css
@@ -225,6 +225,10 @@ body .ui-datatable .ui-datatable-header {
   text-align: right; 
   width: 75px;
 }
+.table-btn-3 {
+  text-align: right; 
+  width: 115px;
+}
 .table-btn-4 {
   text-align: right; 
   width: 150px;

--- a/engine-cockpit/webContent/view/monitorJfr.xhtml
+++ b/engine-cockpit/webContent/view/monitorJfr.xhtml
@@ -1,0 +1,112 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+  xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
+  xmlns:pe="http://primefaces.org/ui/extensions" xmlns:cc="http://java.sun.com/jsf/composite/composite"
+  xmlns:c="http://java.sun.com/jsp/jstl/core">
+  <h:body>
+    <ui:composition template="../includes/template/template.xhtml">
+      <ui:define name="breadcrumb">
+        <li><span>Monitor</span></li>
+        <li>/</li>
+        <li><span>Engine</span></li>
+        <li>/</li>
+        <li><span>Performance</span></li>
+        <li>/</li>
+        <li><a href="monitorJfr.xhtml">Flight Recorder</a></li>
+      </ui:define>
+  
+      <ui:define name="topbar-items">
+        <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}monitor.html#flightrecorder" />
+      </ui:define>
+  
+      <ui:define name="content">
+        <p:growl id="msgs" showDetail="true">
+         <p:autoUpdate />
+       </p:growl>
+        <h:form id="form">
+          <div class="layout-dashboard">
+            <div class="card">
+              <div class="card-header p-flex-wrap">
+                <div class="card-title p-d-flex p-ai-center">
+                  <i class="p-pr-3 si si-plane-take-off"></i>
+                  <h2 class="p-m-0">Flight Recorder</h2>
+                  <p:commandButton id="start" title="Start recording" onclick="PF('startRecordingDialog').show();" icon="si si-controls-play" styleClass="p-col-fixed p-ml-auto ui-button-success rounded-button"/>
+                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{jfrBean.refresh()}" update="@form startRecordingDialog" title="Refresh" styleClass="p-col-fixed p-ml-1 rounded-button"/>
+                </div>
+              </div>
+              <p:dataTable var="recording" value="#{jfrBean.recordings}"
+                widgetVar="recordingsTable" styleClass="ui-fluid"
+                id="recordingsTable" style="min-width: 950px;" emptyMessage="No recordings found">
+                <p:column headerText="Id" sortBy="#{recording.id}" width="5%">
+                  <span><h:outputText value="#{recording.id}"/></span>
+                </p:column>
+                <p:column headerText="Name" sortBy="#{recording.name}" width="20%">
+                  <h:outputText value="#{recording.name}"/>
+                </p:column>
+                <p:column headerText="State" sortBy="#{recording.state}" width="10%">
+                  <h:outputText value="#{recording.state}"/>
+                </p:column>
+                <p:column headerText="Size" sortBy="#{recording.size}" width="10%">
+                  <h:outputText value="#{recording.size}"/>
+                </p:column>
+                <p:column headerText="Duration" sortBy="#{recording.duration}" width="10%">
+                  <h:outputText value="#{recording.duration}"/>
+                </p:column>
+                <p:column headerText="Start Time" sortBy="#{recording.startTime}" width="15%">
+                  <h:outputText value="#{recording.startTime}"/>
+                </p:column>
+                <p:column headerText="Stop Time" sortBy="#{recording.stopTime}" width="15%">
+                  <h:outputText value="#{recording.stopTime}"/>
+                </p:column>
+                <p:column styleClass="table-btn-3">
+                  <p:commandButton id="stop" action="#{jfrBean.stopRecording(recording)}" update="@form startRecordingDialog" title="Stop recording"
+                    icon="si si-controls-stop" styleClass="p-col-fixed p-ml-1 ui-button-danger rounded-button" disabled="#{not recording.canStop}"/>
+                  <p:commandButton id="download" icon="pi pi-arrow-down" ajax="false" title="Download recording" styleClass="p-col-fixed p-ml-1 ui-button-success rounded-button" disabled="#{not recording.canDownload}">
+                    <p:fileDownload value="#{jfrBean.downloadRecording(recording)}"/>
+                  </p:commandButton>
+                  <p:commandButton id="close" action="#{jfrBean.closeRecording(recording)}" update="@form startRecordingDialog" title="Delete recording" disabled="#{not recording.canClose}"
+                    icon="si si-bin-1" styleClass="p-col-fixed p-ml-1 ui-button-danger rounded-button"/>
+                </p:column>
+              </p:dataTable>
+            </div>
+          </div>
+        </h:form>
+        
+        <p:dialog style="min-width: 600px;" header="Start Recording" id="startRecordingDialog"
+            widgetVar="startRecordingDialog" responsive="true" closeOnEscape="true">
+          <h:form id="startRecording" styleClass="custom-dialog-form">
+            <p:staticMessage severity="warn" detail="Start of a Fligh recording can have a negative impact on the performance of the engine."/>
+            <p:staticMessage severity="warn" rendered="#{jfrBean.hasRunningRecordings}" detail="There is already at least one recording running. Sure you want to start another one?"/>
+            <p:staticMessage severity="warn" rendered="#{jfrBean.hasNotRunningRecordings}" detail="There is already at least one recording available. Consider deleting it before starting another one."/>
+            <p:panelGrid columns="3" layout="flex" columnClasses="p-col-12 p-md-4 p-lg-2, p-col-12 p-md-5 p-lg-9, p-col-12 p-md-1 p-lg-1" styleClass="grey-label-panel ui-fluid">
+              <p:outputLabel for="configuration" value="Configuration"/>
+              <p:selectOneMenu id="configuration" value="#{jfrBean.configuration}">
+                <f:selectItems value="#{jfrBean.configurations}" var="config" itemLabel="#{config.label}" itemValue="#{config.name}" itemDescription="#{config.description}"/>
+              </p:selectOneMenu>
+              <p:commandButton id="add" title="Add configuration" onclick="PF('uploadConfig').show();return false;" icon="si si-add" styleClass="p-ml-1 rounded-button"/>
+              <p:outputLabel for="name" value="Name"/>
+              <p:inputText id="name" value="#{jfrBean.name}"/>
+            </p:panelGrid>
+            <p:fileUpload id="uploadConfig" widgetVar="uploadConfig" listener="#{jfrBean.addConfiguration}" style="display: none;" update="startRecording" auto="true"/>
+            <p:panel id="more" toggleable="true" collapsed="true" header="More Options ..." toggleTitle="More Options" style="width: 600px;">
+              <p:panelGrid columns="2" layout="flex" columnClasses="p-col-12 p-md-4 p-lg-2, p-col-12 p-md-6 p-lg-10" styleClass="grey-label-panel ui-fluid">
+                <c:forEach items="#{jfrBean.options}" var="option">
+                  <p:outputPanel>
+                    <p:outputLabel id="#{option.name}Label" for="#{option.name}" value="#{option.label}"/>
+                    <p:tooltip for="#{option.name}Label"><pre>#{option.description}</pre></p:tooltip>
+                  </p:outputPanel>
+                  <p:inputText id="#{option.name}" value="#{option.value}"/>
+                </c:forEach>
+              </p:panelGrid>
+            </p:panel>            
+            <div class="custom-dialog-footer">
+              <p:commandButton id="cancel" type="button" onclick="PF('startRecordingDialog').hide();" value="Cancel" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
+              <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="Start" icon="si si-controls-play"
+                styleClass="modal-input-button" actionListener="#{jfrBean.startRecording}" update="form"/>
+            </div>
+          </h:form>
+        </p:dialog>
+      </ui:define>
+    </ui:composition>
+  </h:body>
+</html>


### PR DESCRIPTION
Add a new Flight Recorder view to the Engine Cockpit that allows to start, stop, download, and delete Flight recordings.

The flight recording can be configure with predefined configurations and user defined configurations that can be uploaded as *.jfc files.

Added WebTest for the new view.
Add a screenshot for the new view.

![image](https://github.com/axonivy/engine-cockpit/assets/5229480/0ee8b293-a2be-415f-bf76-bb85a6de2f88)
