### PR TITLE
XIVY-11120 Fix IndexOutOfBoundException if no custom security system is defined

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityBean.java
@@ -45,10 +45,11 @@ public class SecurityBean {
   }
 
   public static List<SecuritySystem> readSecuritySystems() {
-    return readAllSecurityContexts()
-            .map(s -> new SecuritySystem(s))
-            .filter(s -> !isDefaultWithNoApps(s))
-            .collect(Collectors.toList());
+    var securitySystems = readAllSecurityContexts().map(SecuritySystem::new).toList();
+    if (securitySystems.size() > 1) {
+      return securitySystems.stream().filter(s -> !isDefaultWithNoApps(s)).toList();
+    }
+    return securitySystems;
   }
 
   private static Stream<ISecurityContext> readAllSecurityContexts() {


### PR DESCRIPTION
Maybe missleading, but the "default" security system is not visible because there is no application. So as soon as there is one also the "default" security system will show up.
And if the message is "You don't have any security system configured." with a link to the security system we may lead the people to define an additional security system.

The other possible solution would be to display the default security system even if it has not app (if not apps in general exist)