### PR TITLE
Remove dependency to server.configuration

### DIFF
--- a/engine-cockpit/.classpath
+++ b/engine-cockpit/.classpath
@@ -33,6 +33,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/engine-cockpit/META-INF/MANIFEST.MF
+++ b/engine-cockpit/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Manifest-Version: 1.0
-Bundle-ManifestVersion: 2
-Bundle-Name: engine-cockpit
-Bundle-SymbolicName: engine-cockpit
-Bundle-Version: 8.0.0.qualifier
-Require-Bundle: ch.ivyteam.ivy.server.configuration;bundle-version="8.0.0"
-Automatic-Module-Name: engine-cockpit


### PR DESCRIPTION
server.configuration has been renamed to engine.cli. There is no need anymore for this, so I completeley remove this MANIFEST.MF from engine cockpit.

If you still want to have it, I will re-introduce it but just without dependencies.