### PR TITLE
XIVY-11352 Fix resource leak in LogBean >> R10

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SupportBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SupportBean.java
@@ -1,11 +1,8 @@
 package ch.ivyteam.enginecockpit.system;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -16,6 +13,7 @@ import javax.faces.bean.RequestScoped;
 import org.primefaces.model.DefaultStreamedContent;
 import org.primefaces.model.StreamedContent;
 
+import ch.ivyteam.enginecockpit.util.DownloadUtil;
 import ch.ivyteam.enginecockpit.util.UrlUtil;
 import ch.ivyteam.ivy.application.app.IApplicationRepository;
 import ch.ivyteam.ivy.application.restricted.ApplicationConfigurationDumper;
@@ -71,28 +69,10 @@ public class SupportBean {
 
   private StreamedContent createStreamedContent(File zipFile) {
     return DefaultStreamedContent.builder()
-            .stream(() -> getZipFileStream(zipFile))
+            .stream(() -> DownloadUtil.getFileStream(zipFile))
             .contentType("application/zip")
             .name("support-engine-report.zip")
             .build();
-  }
-
-  private InputStream getZipFileStream(File file) {
-    try {
-      return new FileInputStream(file) {
-        @Override
-        public void close() throws IOException {
-          super.close();
-          try {
-            file.delete();
-          } catch (Exception ex) {
-            LOGGER.info("Could not delete temporary support zip file '" + file.getName() + "' : ", ex);
-          }
-        }
-      };
-    } catch (FileNotFoundException ex) {
-      throw new RuntimeException(ex);
-    }
   }
 
   private String createSupportReport() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DownloadUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DownloadUtil.java
@@ -1,13 +1,21 @@
 package ch.ivyteam.enginecockpit.util;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import ch.ivyteam.log.Logger;
+
 public class DownloadUtil {
+
+  private final static Logger LOGGER = Logger.getLogger(DownloadUtil.class);
 
   public static void zipDir(Path source, OutputStream out) throws IOException {
     try (var zs = new ZipOutputStream(out)) {
@@ -19,10 +27,28 @@ public class DownloadUtil {
                   zs.putNextEntry(zipEntry);
                   Files.copy(path, zs);
                   zs.closeEntry();
-                } catch (IOException e) {
-                  System.err.println(e);
+                } catch (IOException ex) {
+                  LOGGER.error(ex);
                 }
               });
+    }
+  }
+
+  public static InputStream getFileStream(File file) {
+    try {
+      return new FileInputStream(file) {
+        @Override
+        public void close() throws IOException {
+          super.close();
+          try {
+            file.delete();
+          } catch (Exception ex) {
+            LOGGER.error("Could not delete file '" + file.getName() + "' after closing stream : ", ex);
+          }
+        }
+      };
+    } catch (FileNotFoundException ex) {
+      throw new RuntimeException(ex);
     }
   }
 


### PR DESCRIPTION
Same as master 
but
uses `DownloadUtil.zipDir()` because `LogFileZipper` doesnt exist 