### PR TITLE
Feature/XIVY-4071 Add new Jobs view

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
@@ -105,6 +105,8 @@ public class WebDocuScreenshot {
     takeScreenshot("monitor-threads", new Dimension(SCREENSHOT_WIDTH, 800));
     Navigation.toSessions();
     takeScreenshot("monitor-sessions", new Dimension(SCREENSHOT_WIDTH, 1000));
+    Navigation.toJobs();
+    takeScreenshot("monitor-jobs", new Dimension(SCREENSHOT_WIDTH, 800));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJobs.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJobs.java
@@ -1,0 +1,90 @@
+package ch.ivyteam.enginecockpit.monitor;
+
+import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
+import static com.codeborne.selenide.Condition.empty;
+import static com.codeborne.selenide.Condition.not;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import com.axonivy.ivy.webtest.IvyWebTest;
+import com.codeborne.selenide.CollectionCondition;
+
+import ch.ivyteam.enginecockpit.util.Navigation;
+import ch.ivyteam.enginecockpit.util.Table;
+
+@IvyWebTest
+class WebTestJobs {
+
+  private static final String DURATION_STR = "[0-9][0-9]? (s|m|h|d)";
+  private static final Pattern DATE_TIME = Pattern.compile("[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}");
+  private static final Pattern DURATION = Pattern.compile(DURATION_STR);
+  private static final String CRON = "(([0-9][0-9]?|\\*|\\?)\\s){6}";
+  private static final Pattern CONFIGURATION = Pattern.compile("("+DURATION+"\\s|"+CRON+")\\(.*\\)");
+
+  private static final By TABLE_ID = By.id("form:jobTable");
+  private Table table;
+
+  @BeforeAll
+  static void beforeAll() {
+    login();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    Navigation.toJobs();
+    table = new Table(TABLE_ID, true);
+  }
+
+  @Test
+  void view() {
+    $("h2").shouldHave(text("Jobs"));
+    table.rows().shouldHave(CollectionCondition.sizeGreaterThan(20));
+    for (int row = 1; row < table.rows().size(); row++) {
+      table.tableEntry(row, 1).shouldBe(not(empty));
+      var config = table.tableEntry(row, 3).text();
+      assertThat(config).isNotBlank().matches(CONFIGURATION);
+      var time = table.tableEntry(row, 4).text();
+      assertThat(time).isNotBlank().matches(DATE_TIME);
+      var timeTo = table.tableEntry(row, 5).text();
+      assertThat(timeTo).isNotBlank().matches(DURATION);
+      var executions = table.tableEntry(row, 6).text();
+      assertThat(executions).isNotBlank().satisfies(exec -> Long.parseLong(exec));
+      var errors = table.tableEntry(row, 7).text();
+      assertThat(errors).isNotBlank().satisfies(err -> Long.parseLong(err));
+    }
+  }
+
+  @Test
+  void filter() {
+    table.rows().shouldHave(CollectionCondition.sizeGreaterThan(20));
+    $(By.id("form:jobTable:globalFilter")).sendKeys("Search system task");
+    table.rows().shouldHave(CollectionCondition.size(1));
+    
+    $(By.id("form:jobTable:globalFilter")).clear();
+    $(By.id("form:jobTable:globalFilter")).sendKeys("\n");
+    table.rows().shouldHave(CollectionCondition.sizeGreaterThan(20));
+    $(By.id("form:jobTable:globalFilter")).sendKeys("Searches for system tasks");
+    table.rows().shouldHave(CollectionCondition.size(1));
+  }
+
+  @Test
+  void schedule() {
+    $(By.id("form:jobTable:0:schedule")).click();
+  }
+
+  @Test
+  void liveStats() {
+    $(By.id("layout-config-button")).click();
+    $$("h4").get(0).shouldBe(text("Jobs Executed"));
+    $$("h4").get(1).shouldHave(text("Job Execution Time"));
+  }
+}

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -8,6 +8,10 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
+import static org.openqa.selenium.By.className;
+
+import java.util.ArrayList;
+import java.util.Collections;
 
 import com.codeborne.selenide.Selenide;
 
@@ -47,6 +51,7 @@ public class Navigation {
   private static final String MONITOR_ENGINE_MBEANS_MENU = "#menuform\\:sr_monitor_engine_mbeans";
   private static final String MONITOR_ENGINE_CACHE_MENU = "#menuform\\:sr_monitor_engine_cache";
   private static final String MONITOR_ENGINE_SESSION_MENU = "#menuform\\:sr_monitor_engine_sessions";
+  private static final String MONITOR_ENGINE_JOBS_MENU = "#menuform\\:sr_monitor_engine_jobs";
   private static final String MONITOR_PERFORMANCE_MENU = "#menuform\\:sr_monitor_performance";
   private static final String MONITOR_PERFORMANCE_PROCESS_EXECUTION_MENU = "#menuform\\:sr_monitor_performance_process_execution";
   private static final String MONITOR_PERFORMANCE_TRACES_MENU = "#menuform\\:sr_monitor_performance_traces";
@@ -315,6 +320,12 @@ public class Navigation {
     menuShouldBeActive(MONITOR_ENGINE_SESSION_MENU);
   }
 
+  public static void toJobs() {
+    toSubSubMenu(MONITOR_MENU, MONITOR_ENGINE_MENU, MONITOR_ENGINE_JOBS_MENU);
+    assertCurrentUrlContains("monitorJobs.xhtml");
+    menuShouldBeActive(MONITOR_ENGINE_JOBS_MENU);
+  }
+
   public static void toMBeans() {
     toSubSubMenu(MONITOR_MENU, MONITOR_ENGINE_MENU, MONITOR_ENGINE_MBEANS_MENU);
     assertCurrentUrlContains("mbeans.xhtml");
@@ -349,35 +360,45 @@ public class Navigation {
     toSubSubMenu(MONITOR_MENU, MONITOR_PERFORMANCE_MENU, MONITOR_PERFORMANCE_THREADS);
   }
 
-
   private static void toMenu(String menuItemPath) {
+    closeAllMenus();
     $(menuItemPath).find("a").scrollIntoView(false).click();
     menuShouldBeActive(menuItemPath);
   }
 
   private static void toSubMenu(String menuItemPath, String subMenuItemPath) {
+    closeAllMenus();
     $(menuItemPath).shouldBe(visible);
-    if (!$(subMenuItemPath).isDisplayed()) {
-      $(menuItemPath).find("a").scrollIntoView(false).click();
-    }
+    $(menuItemPath).find("a").scrollIntoView(false).click();
     $(subMenuItemPath).find("a").shouldBe(visible).scrollIntoView(false).click();
     menuShouldBeActive(subMenuItemPath);
   }
 
   private static void toSubSubMenu(String menuItemPath, String subMenuItemPath, String subSubMenuItemPath) {
+    closeAllMenus();
     $(menuItemPath).shouldBe(visible);
-    if (!$(subMenuItemPath).isDisplayed()) {
-      $(menuItemPath).find("a").scrollIntoView(false).click();
-    }
+    $(menuItemPath).find("a").scrollIntoView(false).click();
     $(subMenuItemPath).find("a").shouldBe(visible);
-    if (!$(subSubMenuItemPath).isDisplayed()) {
-      $(subMenuItemPath).find("a").scrollIntoView(false).click();
-    }
+    $(subMenuItemPath).find("a").scrollIntoView(false).click();
     $(subSubMenuItemPath).scrollIntoView(false).click();
     menuShouldBeActive(subSubMenuItemPath);
   }
 
   private static void menuShouldBeActive(String menu) {
     $(menu).shouldHave(cssClass("active-menuitem"));
+  }
+
+  private static void closeAllMenus() {
+    var activeMenues = new ArrayList<>($$(className("active-menuitem")));
+    Collections.reverse(activeMenues);
+    for (var activeMenu : activeMenues) {
+      if (activeMenu.exists()) {
+        if (activeMenu.$("ul").exists())
+        {
+          activeMenu.find("a").shouldBe(visible).click();
+          activeMenu.$("ul").shouldNotBe(visible);
+        }
+      }
+    }
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/JobBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/JobBean.java
@@ -1,0 +1,151 @@
+package ch.ivyteam.enginecockpit.monitor;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import com.google.common.collect.Streams;
+
+import ch.ivyteam.enginecockpit.monitor.unit.Unit;
+import ch.ivyteam.enginecockpit.util.DateUtil;
+
+@ManagedBean
+@ViewScoped
+public class JobBean {
+
+  private List<Job> jobs;
+  private List<Job> filteredJobs;
+  private String filter;
+
+  public JobBean() {
+    try {
+      var cronJobs = ManagementFactory.getPlatformMBeanServer()
+              .queryNames(new ObjectName("ivy Engine:type=Cron Job,name=*"), null)
+              .stream()
+              .map(Job::new);
+      var periodicalJobs = ManagementFactory.getPlatformMBeanServer()
+              .queryNames(new ObjectName("ivy Engine:type=Periodical Job,name=*"), null)
+              .stream()
+              .map(Job::new);
+
+      var allJobs = Streams
+          .concat(cronJobs, periodicalJobs)
+          .toList();
+      jobs = new ArrayList<>(allJobs);
+    } catch (MalformedObjectNameException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  public List<Job> getJobs() {
+    return jobs;
+  }
+
+  public List<Job> getFilteredJobs() {
+    return filteredJobs;
+  }
+
+  public void setFilteredJobs(List<Job> filteredJobs) {
+    this.filteredJobs = filteredJobs;
+  }
+
+  public String getFilter() {
+    return filter;
+  }
+
+  public void setFilter(String filter) {
+    this.filter = filter;
+  }
+
+  public static final class Job {
+
+    private static final Object[] EMPTY_PARAMS = new Object[0];
+    private static final String[] EMPTY_TYPES = new String[0];
+    private ObjectName name;
+
+    private Job(ObjectName name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return readStringAttribute("name");
+    }
+
+    public String getDescription() {
+      return readStringAttribute("description");
+    }
+
+    public String getNextExecutionTime() {
+      return DateUtil.formatDate((Date)readAttribute("nextExecutionTime"));
+    }
+
+    public long getTimeUntilNextExecution() {
+      return readLongAttribute("timeUntilNextExecution");
+    }
+
+    public String getTimeUntilNextExecutionFormated() {
+      return format(readLongAttribute("timeUntilNextExecution"));
+    }
+
+    public String getConfiguration() {
+      if ("Cron Job".equals(name.getKeyProperty("type"))) {
+        return readStringAttribute("expression") + " (" + readStringAttribute("humanReadableExpression")+")";
+      }
+      var atFixRate = (boolean)readAttribute("atFixedRate");
+      var desc = atFixRate ? " (each)" : " (between)";
+      return format(readLongAttribute("period")) + desc;
+    }
+
+    public long getExecutions() {
+      return readLongAttribute("executions");
+    }
+
+    public long getErrors() {
+      return readLongAttribute("errors");
+    }
+
+    public void schedule() {
+      try {
+        ManagementFactory.getPlatformMBeanServer().invoke(name, "schedule", EMPTY_PARAMS, EMPTY_TYPES);
+      } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+
+    private String format(long value) {
+      var unit = Unit.MILLI_SECONDS;
+      var scaledValue = Unit.MILLI_SECONDS.convertTo(value, unit);
+      while (scaledValue > 100) {
+        unit= unit.scaleUp();
+        scaledValue = Unit.MILLI_SECONDS.convertTo(value, unit);
+      }
+      return scaledValue+" "+ unit.symbol();
+    }
+
+    private long readLongAttribute(String attribute) {
+      return (long)readAttribute(attribute);
+    }
+
+    private String readStringAttribute(String attribute) {
+      return (String)readAttribute(attribute);
+    }
+
+    Object readAttribute(String attribute) {
+      try {
+        return ManagementFactory.getPlatformMBeanServer().getAttribute(name, attribute);
+      } catch (InstanceNotFoundException | AttributeNotFoundException | ReflectionException | MBeanException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/JobMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/JobMonitorBean.java
@@ -1,0 +1,60 @@
+package ch.ivyteam.enginecockpit.monitor.mbeans.ivy;
+
+import static ch.ivyteam.enginecockpit.monitor.value.ValueProvider.format;
+
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
+import ch.ivyteam.enginecockpit.monitor.monitor.Series;
+
+@ManagedBean
+@ViewScoped
+public class JobMonitorBean {
+  private static final ObjectName JOB_MANAGER;
+
+  static {
+    try {
+      JOB_MANAGER = new ObjectName("ivy Engine:type=Job Manager");
+    } catch (MalformedObjectNameException ex) {
+      throw new IllegalArgumentException("Wrong object name", ex);
+    }
+  }
+
+  private final Monitor executionsMonitor;
+  private final Monitor executionTimeMonitor;
+
+  public JobMonitorBean() {
+    executionsMonitor = Monitor.build().name("Jobs Executed").icon("dns").toMonitor();
+    executionTimeMonitor = Monitor.build().name("Job Execution Time").icon("timer").yAxisLabel("Time").toMonitor();
+
+    var jobExecutions = new ExecutionCounter(JOB_MANAGER.getCanonicalName(), "jobExecutions", "errors");
+
+    executionsMonitor.addInfoValue(format("%5d", jobExecutions.deltaExecutions()));
+    executionsMonitor.addInfoValue(format("Total %5d", jobExecutions.executions()));
+    executionsMonitor.addInfoValue(format("Errors %5d", jobExecutions.deltaErrors()));
+    executionsMonitor.addInfoValue(format("Errors Total %5d", jobExecutions.errors()));
+
+    executionsMonitor.addSeries(Series.build(jobExecutions.deltaExecutions(), "Executed").toSeries());
+    executionsMonitor.addSeries(Series.build(jobExecutions.deltaErrors(), "Errors").toSeries());
+
+    executionTimeMonitor.addInfoValue(format("Min %t", jobExecutions.deltaMinExecutionTime()));
+    executionTimeMonitor.addInfoValue(format("Avg %t", jobExecutions.deltaAvgExecutionTime()));
+    executionTimeMonitor.addInfoValue(format("Max %t", jobExecutions.deltaMaxExecutionTime()));
+    executionTimeMonitor.addInfoValue(format("Total %t", jobExecutions.executionTime()));
+
+    executionTimeMonitor.addSeries(Series.build(jobExecutions.deltaMinExecutionTime(), "Min").toSeries());
+    executionTimeMonitor.addSeries(Series.build(jobExecutions.deltaAvgExecutionTime(), "Avg").toSeries());
+    executionTimeMonitor.addSeries(Series.build(jobExecutions.deltaMaxExecutionTime(), "Max").toSeries());
+  }
+
+  public Monitor getExecutionsMonitor() {
+    return executionsMonitor;
+  }
+
+  public Monitor getExecutionTimeMonitor() {
+    return executionTimeMonitor;
+  }
+}

--- a/engine-cockpit/webContent/includes/template/sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/sidebar.xhtml
@@ -68,6 +68,8 @@
                 url="monitor-sessions.xhtml" />
               <p:menuitem id="sr_monitor_engine_cache" value="Cache" icon="si si-monitor-heart-beat-search"
                 url="monitorCache.xhtml" />
+              <p:menuitem id="sr_monitor_engine_jobs" value="Jobs" icon="si si-task-list-approve"
+                url="monitorJobs.xhtml" />
               <p:menuitem id="sr_monitor_engine_mbeans" value="MBeans" icon="si si-graph-statistics-coffee"
                 url="mbeans.xhtml" />
             </p:submenu>

--- a/engine-cockpit/webContent/view/monitorJobs.xhtml
+++ b/engine-cockpit/webContent/view/monitorJobs.xhtml
@@ -1,0 +1,87 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:f="http://xmlns.jcp.org/jsf/core"
+  xmlns:h="http://xmlns.jcp.org/jsf/html"
+  xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+  xmlns:ic="http://ivyteam.ch/jsf/component"
+  xmlns:p="http://primefaces.org/ui"
+  xmlns:pe="http://primefaces.org/ui/extensions"
+  xmlns:cc="http://java.sun.com/jsf/composite/composite">
+<h:body>
+  <ui:composition template="../includes/template/charts-template.xhtml">
+
+    <ui:define name="breadcrumb">
+      <li><span>Monitor</span></li>
+      <li>/</li>
+      <li><span>Engine</span></li>
+      <li>/</li>
+      <li><a href="monitorJobs.xhtml">Jobs</a></li>
+    </ui:define>
+
+    <ui:define name="topbar-items">
+      <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}monitor.html#jobs"/>
+    </ui:define>
+
+    <ui:define name="content">
+      <div class="card">
+        <div class="p-d-flex p-ai-center p-mb-3">
+          <i class="p-pr-3 si si si-task-list-approve card-title-icon"></i>
+          <h2 class="p-m-0">Jobs</h2>
+        </div>
+        <h:form id="form" style="overflow: auto;">
+          <p:dataTable var="job" value="#{jobBean.jobs}" filteredValue="#{jobBean.filteredJobs}"
+            widgetVar="jobTable" styleClass="ui-fluid"
+            paginator="true" rows="100" paginatorPosition="bottom" paginatorAlwaysVisible="false"
+            id="jobTable" style="min-width: 950px;">
+            <f:facet name="header">
+              <div class="ui-input-icon-left filter-container">
+                <i class="pi pi-search"/>
+                <p:inputText id="globalFilter" onkeyup="PF('jobTable').filter()" placeholder="Search" value="#{jobBean.filter}" />
+              </div>
+            </f:facet>
+            
+            <p:column headerText="Name" sortBy="#{job.name}" filterBy="#{job.name}">
+              <h:outputText value="#{job.name}"/>
+            </p:column>
+
+            <p:column headerText="Description" sortBy="#{job.description}" filterBy="#{job.description}">
+              <h:outputText value="#{job.description}"/>
+            </p:column>
+
+            <p:column headerText="Configuration" sortBy="#{job.configuration}" filterBy="#{job.configuration}" style="width: 130px;">
+              <h:outputText value="#{job.configuration}"/>
+            </p:column>
+            
+            <p:column headerText="Next execution" sortBy="#{job.nextExecutionTime}" style="width: 130px;">
+              <h:outputText value="#{job.nextExecutionTime}"/>
+            </p:column>
+
+            <p:column headerText="Time until next execution" sortBy="#{job.timeUntilNextExecution}" style="width: 190px;">
+              <h:outputText value="#{job.timeUntilNextExecutionFormated}"/>
+            </p:column>
+            
+            <p:column headerText="Executions" sortBy="#{job.executions}" style="width: 100px;">
+              <h:outputText value="#{job.executions}"/>
+            </p:column>
+            
+            <p:column headerText="Errors" sortBy="#{job.errors}" style="width: 100px;">
+              <h:outputText value="#{job.errors}"/>
+            </p:column>
+            
+             <p:column styleClass="table-btn-1">
+              <p:commandButton id="schedule" title="Schedule to execute the job now" icon="si si-controls-play"
+                actionListener="#{job.schedule()}" ajax="true" update="@form" styleClass="ui-button-danger rounded-button" />
+            </p:column>
+          </p:dataTable>
+        </h:form>
+      </div>
+    </ui:define>
+
+    <ui:define name="live-stats">
+      <cc:Sidebar>
+        <cc:LiveStats monitor="#{jobMonitorBean.executionsMonitor}" id="executions" />
+        <cc:LiveStats monitor="#{jobMonitorBean.executionTimeMonitor}" id="executionTime" />
+      </cc:Sidebar>
+    </ui:define>
+  </ui:composition>
+</h:body>
+</html>


### PR DESCRIPTION
Add new jobs view to the Monitor/Engine menu that displays all relevant information about periodical jobs. Also add a button to execute jobs immediately.

Before navigating to a menu close all open menus