### PR TITLE
XIVY-11623 Show multiple lines of the Event bean configuration

### DIFF
--- a/engine-cockpit/webContent/resources/composite/Bean.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Bean.xhtml
@@ -33,7 +33,7 @@
       <p:outputLabel for="serviceState" value="State" />
       <h:outputText id="serviceState" value="#{cc.attrs.event.serviceState}"/>
       <p:outputLabel for="configuration" value="Configuration" />
-      <h:outputText id="configuration" value="#{cc.attrs.event.beanConfiguration}"/>
+      <p:outputPanel id="configuration" styleClass="code">#{cc.attrs.event.beanConfiguration}</p:outputPanel>
 
       <p:outputLabel for="lastStart" value="Last Start" />
       <h:outputText id="lastStart" value="#{cc.attrs.event.lastStartTimestamp}"/>


### PR DESCRIPTION
If the event bean configuration contains multiple lines (e.g. Properties, JSON) show the config with new lines in it.
![image](https://github.com/axonivy/engine-cockpit/assets/5229480/3f71b36f-bfda-4060-a07c-50f33fe53f9b)
