### PR TITLE
XIVY-12240 fix: follow sym-links to comply with Debian > R10

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/LogBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/LogBean.java
@@ -3,6 +3,7 @@ package ch.ivyteam.enginecockpit.monitor;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.util.Calendar;
 import java.util.Date;
@@ -44,12 +45,12 @@ public class LogBean implements AllResourcesDownload {
 
   private void initLogFiles() {
     try {
-      logs = Files.walk(UrlUtil.getLogDir().toRealPath())
-              .filter(Files::isRegularFile)
-              .filter(log -> log.toString().endsWith(".log"))
-              .map(log -> new LogView(log.getFileName().toString(), date))
-              .sorted()
-              .collect(Collectors.toList());
+      logs = Files.walk(UrlUtil.getLogDir().toRealPath() , FileVisitOption.FOLLOW_LINKS)
+        .filter(Files::isRegularFile)
+        .filter(log -> log.toString().endsWith(".log"))
+        .map(log -> new LogView(log.getFileName().toString(), date))
+        .sorted()
+        .collect(Collectors.toList());
     } catch (IOException ex) {
       FacesContext.getCurrentInstance().addMessage("msgs",
               new FacesMessage(FacesMessage.SEVERITY_ERROR, "Could not load logs", ex.getMessage()));

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SupportBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SupportBean.java
@@ -3,6 +3,7 @@ package ch.ivyteam.enginecockpit.system;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -42,7 +43,7 @@ public class SupportBean {
     try (var fos = new FileOutputStream(zipFile);
             var zos = new ZipOutputStream(fos)) {
       addEntryToZip(zos, "report.txt", errorReport.getBytes());
-      try (var walker = Files.walk(UrlUtil.getLogDir().toRealPath())) {
+      try (var walker = Files.walk(UrlUtil.getLogDir().toRealPath(), FileVisitOption.FOLLOW_LINKS)) {
         walker.filter(Files::isRegularFile)
           .filter(log -> log.toString().endsWith(".log"))
           .forEach(log -> addLogToZip(zos, log.toFile()));

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DownloadUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DownloadUtil.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
@@ -19,7 +20,7 @@ public class DownloadUtil {
 
   public static void zipDir(Path source, OutputStream out) throws IOException {
     try (var zs = new ZipOutputStream(out)) {
-      Files.walk(source)
+      Files.walk(source, FileVisitOption.FOLLOW_LINKS)
               .filter(path -> !Files.isDirectory(path))
               .forEach(path -> {
                 var zipEntry = new ZipEntry(source.relativize(path).toString());


### PR DESCRIPTION
- on deb based engines, we have /var/logs/axonivy-engine8/ as log out-dir ... which is symlinked into the original product install dir.