### PR TITLE
XIVY-12244 Allow to edit managed roles of unmanaged users

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
@@ -154,14 +154,6 @@ public class UserDetailBean {
     return roleDataModel;
   }
 
-  public boolean isUserMemberOfAllRole(String roleName) {
-    return getIUser().getAllRoles().stream().anyMatch(r -> r.getName().equals(roleName));
-  }
-
-  public boolean isUserMemberOfRole(String roleName) {
-    return getIUser().getRoles().stream().anyMatch(r -> r.getName().equals(roleName));
-  }
-
   public void removeRole(String roleName) {
     getIUser().removeRole(securityContext.roles().find(roleName));
   }
@@ -227,5 +219,40 @@ public class UserDetailBean {
 
   public boolean isIvySecuritySystem() {
     return SecuritySystem.isIvySecuritySystem(securityContext);
+  }
+
+  public boolean isManaged() {
+    return getIUser().isExternal();
+  }
+
+  public boolean isUserMemberOfButNotDirect(Role role) {
+    var hasRole = getIUser().getAllRoles().stream().anyMatch(r -> r.getName().equals(role.getName()));
+    return hasRole && !hasUserRoleDirect(role);
+  }
+
+  public boolean isUserDirectMemberOf(Role role) {
+    return hasUserRoleDirect(role);
+  }
+
+  public boolean isAddRoleButtonDisabled(Role role) {
+    if (role.isTopLevel()) {
+      return true;
+    }
+    return hasUserRoleDirect(role);
+  }
+
+  public boolean isRemoveRoleButtonDisabled(Role role) {
+    if (role.isTopLevel()) {
+      return true;
+    }
+    return !hasUserRoleDirect(role);
+  }
+
+  private boolean hasUserRoleDirect(Role role) {
+    return getIUser().getRoles().stream().anyMatch(r -> r.getName().equals(role.getName()));
+  }
+
+  public boolean isRoleManaged(Role role) {
+    return role.isManaged() && isIvySecuritySystem();
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/Role.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/Role.java
@@ -3,6 +3,7 @@ package ch.ivyteam.enginecockpit.security.model;
 import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.lang3.StringUtils;
 import ch.ivyteam.ivy.security.IRole;
+import ch.ivyteam.ivy.security.ISecurityConstants;
 
 public class Role implements SecurityMember{
 
@@ -114,5 +115,9 @@ public class Role implements SecurityMember{
   @Override
   public String toString() {
     return name;
+  }
+
+  public boolean isTopLevel() {
+    return ISecurityConstants.TOP_LEVEL_ROLE_NAME.equals(name);
   }
 }

--- a/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
@@ -18,8 +18,6 @@
     <p:treeTable id="rolesTree" value="#{userDetailBean.roles.tree}" var="role" nodeVar="node">
       <p:ajax event="expand" listener="#{userDetailBean.roles.nodeExpand}" />
       <p:ajax event="collapse" listener="#{userDetailBean.roles.nodeCollapse}" />
-      <ui:param name="isUserDirectMember" value="#{userDetailBean.isUserMemberOfRole(role.name)}" />
-      <ui:param name="isUserMember" value="#{userDetailBean.isUserMemberOfAllRole(role.name)}" />
       <f:facet name="header">
         <div class="p-d-flex ui-fluid">
           <span class="ui-input-icon-left filter-container" style="width: 100%;">
@@ -44,7 +42,7 @@
               <i class="#{role.cssIconClass} table-icon"></i>
             </h:outputText>
             <h:outputText value=" (#{role.displayName})" styleClass="addition-row-info" />
-            <h:panelGroup rendered="#{role.managed and !userDetailBean.ivySecuritySystem}">
+            <h:panelGroup rendered="#{userDetailBean.isRoleManaged(role)}">
               <i class="si si-button-refresh-arrows table-icon" title="Role is managed by the external security system"></i>
             </h:panelGroup>
           </a>
@@ -59,12 +57,10 @@
       
       <p:column styleClass="table-btn-1">
         <h:panelGroup rendered="#{node.type == 'role'}">
-          <h:outputText
-            rendered="#{isUserMember and !isUserDirectMember}">
+          <h:outputText rendered="#{userDetailBean.isUserMemberOfButNotDirect(role)}">
             <i class="si si-check-circle table-icon light" title="Inherited" />
           </h:outputText>
-          <h:outputText
-            rendered="#{isUserMember and isUserDirectMember}">
+          <h:outputText rendered="#{userDetailBean.isUserDirectMemberOf(role)}">
             <i class="si si-check-circle table-icon" />
           </h:outputText>
         </h:panelGroup>
@@ -74,11 +70,11 @@
         <h:panelGroup rendered="#{node.type == 'role'}">
           <p:commandButton id="addRoleToUserBtn" update="@form" actionListener="#{userDetailBean.addRole(role.name)}"
             icon="si si-add" title="Add" styleClass="rounded-button"
-            disabled="#{role.name == 'Everybody' or isUserDirectMember or role.managed and !userDetailBean.ivySecuritySystem}" />
+            disabled="#{userDetailBean.isAddRoleButtonDisabled(role)}" />
           <p:commandButton id="removeRoleFromUserBtn" update="@form"
             actionListener="#{userDetailBean.removeRole(role.name)}" icon="si si-subtract" title="Remove"
             styleClass="p-ml-1 ui-button-secondary rounded-button"
-            disabled="#{role.name == 'Everybody' or !isUserDirectMember or role.managed and !userDetailBean.ivySecuritySystem}" />
+            disabled="#{userDetailBean.isRemoveRoleButtonDisabled(role)}" />
         </h:panelGroup>
       </p:column>
     </p:treeTable>


### PR DESCRIPTION
The core allows to edit the 'managed' roles of 'unmanaged' users. The cockpit does not allow that.
https://github.com/axonivy/core/pull/3601

I would recommend to simplify the code, that you always can remove and add roles even if the user itself is managed. If the user is managed, then the role will be added/removed the next time it will be synchronized.

If you don't like that, I will try to implement only the requested feature from Frox.

TODO:
- Maybe I should fix a performance issue so that we don't query the role stuff mulitple times for the same user
- I should also support this on roledetails page, so that we can add/remove the users.


I want to merge the changes to 10.0