### PR TITLE
Disable polling of Start and Intermediate Beans after it fails once

### DIFF
--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollError.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollError.java
@@ -17,6 +17,7 @@ public class PollError extends AbstractProcessStartEventBean {
    */
   @Override
   public void poll() {
+    getEventBeanRuntime().poll().disable();
     throw new RuntimeException("Exception in Poll Method");
   }
 }

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollErrorIntermediateClass.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollErrorIntermediateClass.java
@@ -13,10 +13,11 @@ public class PollErrorIntermediateClass extends AbstractProcessIntermediateEvent
   public void initialize(IProcessIntermediateEventBeanRuntime eventRuntime, String configuration) {
     super.initialize(eventRuntime, configuration);
     eventRuntime.threads().boundToEventLifecycle(() -> {});
-    
+
   }
   @Override
   public void poll() {
+    getEventBeanRuntime().poll().disable();
     throw new RuntimeException("Exception in Poll Method");
   }
 }


### PR DESCRIPTION
Produce a lot less error logs because of failing poll methods of Start and Intermediate Beans. The poll method will fail once and after that polling is disabled.