### PR TITLE
XIVY-12503 Do not create database property on browser refresh (F5)

### DIFF
--- a/engine-cockpit/webContent/includes/components/services/database-properties.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-properties.xhtml
@@ -58,7 +58,7 @@
       </h:panelGroup>
     </p:panelGrid>
     <div class="custom-dialog-footer">
-      <p:commandButton id="saveProperty" validateClient="true" ajax="false" update="databasePropertiesForm"
+      <p:commandButton id="saveProperty" validateClient="true" onsuccess="PF('propertyModal').hide()" update="databasePropertiesForm"
         actionListener="#{databaseDetailBean.saveProperty}" value="Save" icon="si si-floppy-disk"
         styleClass="modal-input-button" />
       <p:commandButton id="cancelProperty" onclick="PF('propertyModal').hide();" value="Cancel" type="button"


### PR DESCRIPTION
Bug:

- Go to engine cockpit
- Database
- Database Detail View
- Add a new property
- Delete the property
- Make a browser refresh F5
the property is here again…