### PR TITLE
XIVY-12773 Fix NPE when using custom auth feature for web service clients or rest clients

### DIFF
--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/services/model/TestRestClientAuthTypeCalculator.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/services/model/TestRestClientAuthTypeCalculator.java
@@ -1,0 +1,24 @@
+package ch.ivyteam.enginecockpit.services.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class TestRestClientAuthTypeCalculator {
+
+  @Test
+  void get() {
+    var features = List.of("ch.ivyteam.ivy.rest.client.authentication.NtlmAuthenticationFeature");
+    var authType = new RestClientAuthTypeCalculator(features).get();
+    assertThat(authType).isEqualTo("Ntlm");
+  }
+
+  @Test
+  void get_custom() {
+    var features = List.of("com.axonivy.authentication.NewNTLMFeature");
+    var authType = new RestClientAuthTypeCalculator(features).get();
+    assertThat(authType).isEmpty();
+  }
+}

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/services/model/TestWebServiceClientAuthTypeCalcuator.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/services/model/TestWebServiceClientAuthTypeCalcuator.java
@@ -1,0 +1,24 @@
+package ch.ivyteam.enginecockpit.services.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class TestWebServiceClientAuthTypeCalcuator {
+
+  @Test
+  void get() {
+    var features = List.of("ch.ivyteam.ivy.webservice.exec.cxf.feature.NTLMAuthenticationFeature");
+    var authType = new WebServiceClientAuthTypeCalcuator(features).get();
+    assertThat(authType).isEqualTo("NTLM");
+  }
+
+  @Test
+  void get_custom() {
+    var features = List.of("com.axonivy.webservice.NewNTLMAuthenticationFeature");
+    var authType = new WebServiceClientAuthTypeCalcuator(features).get();
+    assertThat(authType).isEmpty();
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientAuthTypeCalculator.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientAuthTypeCalculator.java
@@ -1,0 +1,23 @@
+package ch.ivyteam.enginecockpit.services.model;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class RestClientAuthTypeCalculator {
+
+  private final List<String> features;
+
+  public RestClientAuthTypeCalculator(List<String> features) {
+    this.features = features;
+  }
+
+  public String get() {
+    return features.stream().filter(f -> StringUtils.contains(f, "authentication"))
+            .map(f -> StringUtils.substringBetween(f, "authentication.", "AuthenticationFeature"))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse("");
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientDto.java
@@ -71,11 +71,7 @@ public class RestClientDto implements IService {
   }
 
   public String getAuthType() {
-    return features.stream()
-            .filter(f -> StringUtils.contains(f, "authentication"))
-            .map(f -> StringUtils.substringBetween(f, "authentication.", "AuthenticationFeature"))
-            .findFirst()
-            .orElse("");
+    return new RestClientAuthTypeCalculator(features).get();
   }
 
   public String getUsername() {
@@ -114,5 +110,4 @@ public class RestClientDto implements IService {
   public void setUsername(String username) {
     this.username = username;
   }
-
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/WebServiceClientAuthTypeCalcuator.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/WebServiceClientAuthTypeCalcuator.java
@@ -1,0 +1,23 @@
+package ch.ivyteam.enginecockpit.services.model;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class WebServiceClientAuthTypeCalcuator {
+
+  private final List<String> features;
+
+  public WebServiceClientAuthTypeCalcuator(List<String> features) {
+    this.features = features;
+  }
+
+  public String get() {
+    return features.stream().filter(f -> StringUtils.contains(f, "AuthenticationFeature"))
+            .map(f -> StringUtils.substringBetween(f, "cxf.feature.", "AuthenticationFeature"))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse("");
+  }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/Webservice.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/Webservice.java
@@ -74,11 +74,7 @@ public class Webservice implements IService {
   }
 
   public String getAuthType() {
-    return features.stream().filter(f -> StringUtils.contains(f, "AuthenticationFeature"))
-            .map(f -> StringUtils.substringBetween(f, "cxf.feature.", "AuthenticationFeature"))
-            .findFirst().orElseGet(() -> properties.stream()
-                    .filter(p -> StringUtils.equals(p.getName(), "authType"))
-                    .map(Property::getValue).findFirst().orElse(""));
+    return new WebServiceClientAuthTypeCalcuator(features).get();
   }
 
   public String getUsername() {


### PR DESCRIPTION
I would have this implemented different instead of guessing. With this approach, you can not use username or password input fields with a custom (not following the naming convention) auth feature.