### PR TITLE
XIVY-12827 Use equals method instead of comparing IDs to search nodes

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/AbstractPermission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/AbstractPermission.java
@@ -2,23 +2,17 @@ package ch.ivyteam.enginecockpit.security.permission;
 
 public abstract class AbstractPermission {
   private String name;
-  private long id;
   private boolean grant;
   private boolean deny;
 
-  protected AbstractPermission(String name, long id, boolean grant, boolean deny) {
+  protected AbstractPermission(String name, boolean grant, boolean deny) {
     this.name = name;
-    this.id = id;
     this.grant = grant;
     this.deny = deny;
   }
 
   public String getName() {
     return name;
-  }
-
-  public long getId() {
-    return id;
   }
 
   public boolean isGrant() {
@@ -58,5 +52,4 @@ public abstract class AbstractPermission {
   public abstract void undeny();
 
   public abstract boolean isGroup();
-
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/Permission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/Permission.java
@@ -8,18 +8,17 @@ import ch.ivyteam.ivy.security.IPermissionAccess;
 public class Permission extends AbstractPermission {
   private boolean explicit;
   private String permissionHolder;
-  private IPermission iPermission;
-  private PermissionBean bean;
+  private final IPermission permission;
+  private final PermissionBean bean;
 
   public Permission(IPermissionAccess access, PermissionBean bean) {
     super(access.getPermission().getName(),
-            access.getPermission().getId(),
             access.isGranted(),
             access.isDenied());
     this.explicit = access.isExplicit();
     this.permissionHolder = Optional.ofNullable(access.getPermissionHolder()).map(r -> r.getName())
             .orElse(null);
-    this.iPermission = access.getPermission();
+    this.permission = access.getPermission();
     this.bean = bean;
   }
 
@@ -76,26 +75,42 @@ public class Permission extends AbstractPermission {
 
   @Override
   public void grant() {
-    bean.grant(iPermission);
+    bean.grant(this);
   }
 
   @Override
   public void ungrant() {
-    bean.ungrant(iPermission);
+    bean.ungrant(this);
   }
 
   @Override
   public void deny() {
-    bean.deny(iPermission);
+    bean.deny(this);
   }
 
   @Override
   public void undeny() {
-    bean.undeny(iPermission);
+    bean.undeny(this);
   }
 
   public IPermission permission() {
-    return iPermission;
+    return permission;
   }
 
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || ! obj.getClass().equals(Permission.class)) {
+      return false;
+    }
+    var other = (Permission)obj;
+    return permission.equals(other.permission);
+  }
+
+  @Override
+  public int hashCode() {
+    return permission.hashCode();
+  }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionBean.java
@@ -14,8 +14,6 @@ import org.primefaces.model.TreeNode;
 import ch.ivyteam.enginecockpit.commons.ResponseHelper;
 import ch.ivyteam.enginecockpit.commons.TreeView;
 import ch.ivyteam.ivy.persistence.db.ISystemDatabasePersistencyService;
-import ch.ivyteam.ivy.security.IPermission;
-import ch.ivyteam.ivy.security.IPermissionGroup;
 import ch.ivyteam.ivy.security.ISecurityContextRepository;
 import ch.ivyteam.ivy.security.ISecurityDescriptor;
 import ch.ivyteam.ivy.security.ISecurityMember;
@@ -128,57 +126,56 @@ public class PermissionBean extends TreeView<AbstractPermission> {
     }
   }
 
-  public void grant(IPermission iPermission) {
-    securityDescriptor.grantPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+  void grant(Permission permission) {
+    securityDescriptor.grantPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void grant(IPermissionGroup iPermissionGroup) {
-    securityDescriptor.grantPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+  void grant(PermissionGroup permissionGroup) {
+    securityDescriptor.grantPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void ungrant(IPermission iPermission) {
-    securityDescriptor.ungrantPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+  void ungrant(Permission permission) {
+    securityDescriptor.ungrantPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void ungrant(IPermissionGroup iPermissionGroup) {
-    securityDescriptor.ungrantPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+  void ungrant(PermissionGroup permissionGroup) {
+    securityDescriptor.ungrantPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void deny(IPermission iPermission) {
-    securityDescriptor.denyPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+  void deny(Permission permission) {
+    securityDescriptor.denyPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void deny(IPermissionGroup iPermissionGroup) {
-    securityDescriptor.denyPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+  void deny(PermissionGroup permissionGroup) {
+    securityDescriptor.denyPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void undeny(IPermission iPermission) {
-    securityDescriptor.undenyPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+  void undeny(Permission permission) {
+    securityDescriptor.undenyPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void undeny(IPermissionGroup iPermissionGroup) {
-    securityDescriptor.undenyPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+  void undeny(PermissionGroup permissionGroup) {
+    securityDescriptor.undenyPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void reloadPermissionTree(IPermission iPermission) {
+  private void reloadPermissionTree(Permission permission) {
     if (StringUtils.isBlank(filter)) {
-      reloadPermissionsUp(searchPermissionNode(rootTreeNode.getChildren(), iPermission.getId()));
+      reloadPermissionsUp(searchPermissionNode(rootTreeNode.getChildren(), permission));
     } else {
-      var permissionNode = searchPermissionNode(filteredTreeNode.getChildren(), iPermission.getId());
-      reSetPermission((Permission) permissionNode.getData());
+      reSetPermission(permission);
     }
   }
 
-  public void reloadPermissionTree(IPermissionGroup iPermissionGroup) {
-    reloadPermissionsUpAndDown(searchPermissionNode(rootTreeNode.getChildren(), iPermissionGroup.getId()));
+  private void reloadPermissionTree(PermissionGroup permissionGroup) {
+    reloadPermissionsUpAndDown(searchPermissionNode(rootTreeNode.getChildren(), permissionGroup));
   }
 
   private void reloadPermissionsUp(TreeNode<AbstractPermission> permissionNode) {
@@ -215,12 +212,12 @@ public class PermissionBean extends TreeView<AbstractPermission> {
     reloadPermissionGroupsUp(permissionGroupNode.getParent());
   }
 
-  public TreeNode<AbstractPermission> searchPermissionNode(List<TreeNode<AbstractPermission>> children, long permissionId) {
+  private TreeNode<AbstractPermission> searchPermissionNode(List<TreeNode<AbstractPermission>> children, AbstractPermission data) {
     for (var child : children) {
-      if (child.getData().getId() == permissionId) {
+      if (data.equals(child.getData())) {
         return child;
       }
-      var search = searchPermissionNode(child.getChildren(), permissionId);
+      var search = searchPermissionNode(child.getChildren(), data);
       if (search != null) {
         return search;
       }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionGroup.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionGroup.java
@@ -6,12 +6,11 @@ import ch.ivyteam.ivy.security.IPermissionGroupAccess;
 public class PermissionGroup extends AbstractPermission {
   private boolean someGrant;
   private boolean someDeny;
-  private PermissionBean bean;
-  private IPermissionGroup permissionGroup;
+  private final PermissionBean bean;
+  private final IPermissionGroup permissionGroup;
 
   public PermissionGroup(IPermissionGroupAccess groupAccess, PermissionBean bean) {
     super(groupAccess.getPermissionGroup().getName(),
-            groupAccess.getPermissionGroup().getId(),
             groupAccess.isGrantedAllPermissions(),
             groupAccess.isDeniedAllPermissions());
     this.someDeny = groupAccess.isDeniedAnyPermission();
@@ -21,7 +20,9 @@ public class PermissionGroup extends AbstractPermission {
   }
 
   public PermissionGroup(String dummy) {
-    super(dummy, -1, false, false);
+    super(dummy, false, false);
+    this.permissionGroup = null;
+    this.bean = null;
   }
 
   @Override
@@ -69,26 +70,44 @@ public class PermissionGroup extends AbstractPermission {
 
   @Override
   public void grant() {
-    bean.grant(permissionGroup);
+    bean.grant(this);
   }
 
   @Override
   public void ungrant() {
-    bean.ungrant(permissionGroup);
+    bean.ungrant(this);
   }
 
   @Override
   public void deny() {
-    bean.deny(permissionGroup);
+    bean.deny(this);
   }
 
   @Override
   public void undeny() {
-    bean.undeny(permissionGroup);
+    bean.undeny(this);
   }
 
   public IPermissionGroup permissionGroup() {
     return permissionGroup;
   }
 
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || ! obj.getClass().equals(PermissionGroup.class)) {
+      return false;
+    }
+    var other = (PermissionGroup)obj;
+    return permissionGroup != null &&
+           other.permissionGroup != null &&
+           permissionGroup.equals(other.permissionGroup);
+  }
+
+  @Override
+  public int hashCode() {
+    return permissionGroup.hashCode();
+  }
 }


### PR DESCRIPTION
In case a PermissionGroup and a Permission has by accident the same ID the method searchPermissionNode might return the wrong node leading to a ClassCastException if a group is returned instead of a permission.

Instead of using the ID use the equals method of Permission and PermissionGroup to search for permission nodes. By doing so a Permission is never equal to a PermissionGroup even if the IDs are the same.