### PR TITLE
XIVY-12827 Use equals method instead of comparing IDs to search nodes

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/model/AbstractPermission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/model/AbstractPermission.java
@@ -3,14 +3,12 @@ package ch.ivyteam.enginecockpit.model;
 public abstract class AbstractPermission
 {
   private String name;
-  private long id;
   private boolean grant;
   private boolean deny;
 
-  protected AbstractPermission(String name, long id, boolean grant, boolean deny)
+  protected AbstractPermission(String name, boolean grant, boolean deny)
   {
     this.name = name;
-    this.id = id;
     this.grant = grant;
     this.deny = deny;
   }
@@ -20,11 +18,6 @@ public abstract class AbstractPermission
     return name;
   }
   
-  public long getId()
-  {
-    return id;
-  }
-
   public boolean isGrant()
   {
     return grant;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/model/Permission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/model/Permission.java
@@ -10,18 +10,17 @@ public class Permission extends AbstractPermission
 {
   private boolean explicit;
   private String permissionHolder;
-  private IPermission iPermission;
+  private IPermission permission;
   private PermissionBean bean;
 
   public Permission(IPermissionAccess access, PermissionBean bean)
   {
     super(access.getPermission().getName(),
-            access.getPermission().getId(),
             access.isGranted(),
             access.isDenied());
     this.explicit = access.isExplicit();
     this.permissionHolder = Optional.ofNullable(access.getPermissionHolder()).map(r -> r.getName()).orElse(null);
-    this.iPermission = access.getPermission();
+    this.permission = access.getPermission();
     this.bean = bean;
   }
 
@@ -90,30 +89,46 @@ public class Permission extends AbstractPermission
   @Override
   public void grant()
   {
-    bean.grant(iPermission);
+    bean.grant(this);
   }
 
   @Override
   public void ungrant()
   {
-    bean.ungrant(iPermission);
+    bean.ungrant(this);
   }
 
   @Override
   public void deny()
   {
-    bean.deny(iPermission);
+    bean.deny(this);
   }
 
   @Override
   public void undeny()
   {
-    bean.undeny(iPermission);
+    bean.undeny(this);
   }
   
   public IPermission permission() 
   {
-    return iPermission;
+    return permission;
+  }
+  
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || ! obj.getClass().equals(Permission.class)) {
+      return false;
+    }
+    var other = (Permission)obj;
+    return permission.equals(other.permission);
   }
 
+  @Override
+  public int hashCode() {
+    return permission.hashCode();
+  }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/model/PermissionGroup.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/model/PermissionGroup.java
@@ -8,13 +8,12 @@ public class PermissionGroup extends AbstractPermission
 {
   private boolean someGrant;
   private boolean someDeny;
-  private PermissionBean bean;
-  private IPermissionGroup permissionGroup;
+  private final PermissionBean bean;
+  private final IPermissionGroup permissionGroup;
 
   public PermissionGroup(IPermissionGroupAccess groupAccess, PermissionBean bean)
   {
     super(groupAccess.getPermissionGroup().getName(),
-            groupAccess.getPermissionGroup().getId(),
             groupAccess.isGrantedAllPermissions(),
             groupAccess.isDeniedAllPermissions());
     this.someDeny = groupAccess.isDeniedAnyPermission();
@@ -24,7 +23,9 @@ public class PermissionGroup extends AbstractPermission
   }
   
   public PermissionGroup(String dummy) {
-    super(dummy, -1, false, false);
+    super(dummy, false, false);
+    this.bean = null;
+    this.permissionGroup = null;
   }
 
   @Override
@@ -82,25 +83,25 @@ public class PermissionGroup extends AbstractPermission
   @Override
   public void grant()
   {
-    bean.grant(permissionGroup);
+    bean.grant(this);
   }
 
   @Override
   public void ungrant()
   {
-    bean.ungrant(permissionGroup);
+    bean.ungrant(this);
   }
 
   @Override
   public void deny()
   {
-    bean.deny(permissionGroup);
+    bean.deny(this);
   }
 
   @Override
   public void undeny()
   {
-    bean.undeny(permissionGroup);
+    bean.undeny(this);
   }
   
   public IPermissionGroup permissionGroup() 
@@ -108,4 +109,22 @@ public class PermissionGroup extends AbstractPermission
     return permissionGroup;
   }
   
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || ! obj.getClass().equals(PermissionGroup.class)) {
+      return false;
+    }
+    var other = (PermissionGroup)obj;
+    return permissionGroup != null &&
+           other.permissionGroup != null &&
+           permissionGroup.equals(other.permissionGroup);
+  }
+
+  @Override
+  public int hashCode() {
+    return permissionGroup.hashCode();
+  }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/PermissionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/PermissionBean.java
@@ -18,8 +18,6 @@ import ch.ivyteam.enginecockpit.ManagerBean;
 import ch.ivyteam.enginecockpit.model.AbstractPermission;
 import ch.ivyteam.enginecockpit.model.Permission;
 import ch.ivyteam.enginecockpit.model.PermissionGroup;
-import ch.ivyteam.ivy.security.IPermission;
-import ch.ivyteam.ivy.security.IPermissionGroup;
 import ch.ivyteam.ivy.security.ISecurityDescriptor;
 import ch.ivyteam.ivy.security.ISecurityMember;
 
@@ -142,70 +140,69 @@ public class PermissionBean
     }
   }
  
-  public void grant(IPermission iPermission) 
+  public void grant(Permission permission) 
   {
-    securityDescriptor.grantPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+    securityDescriptor.grantPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void grant(IPermissionGroup iPermissionGroup) 
+  public void grant(PermissionGroup permissionGroup) 
   {
-    securityDescriptor.grantPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+    securityDescriptor.grantPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void ungrant(IPermission iPermission) 
+  public void ungrant(Permission permission) 
   {
-    securityDescriptor.ungrantPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+    securityDescriptor.ungrantPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void ungrant(IPermissionGroup iPermissionGroup) 
+  public void ungrant(PermissionGroup permissionGroup) 
   {
-    securityDescriptor.ungrantPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+    securityDescriptor.ungrantPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void deny(IPermission iPermission) 
+  public void deny(Permission permission) 
   {
-    securityDescriptor.denyPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+    securityDescriptor.denyPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void deny(IPermissionGroup iPermissionGroup) 
+  public void deny(PermissionGroup permissionGroup) 
   {
-    securityDescriptor.denyPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+    securityDescriptor.denyPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void undeny(IPermission iPermission) 
+  public void undeny(Permission permission) 
   {
-    securityDescriptor.undenyPermission(iPermission, securityMember);
-    reloadPermissionTree(iPermission);
+    securityDescriptor.undenyPermission(permission.permission(), securityMember);
+    reloadPermissionTree(permission);
   }
 
-  public void undeny(IPermissionGroup iPermissionGroup) 
+  public void undeny(PermissionGroup permissionGroup) 
   {
-    securityDescriptor.undenyPermissions(iPermissionGroup, securityMember);
-    reloadPermissionTree(iPermissionGroup);
+    securityDescriptor.undenyPermissions(permissionGroup.permissionGroup(), securityMember);
+    reloadPermissionTree(permissionGroup);
   }
 
-  public void reloadPermissionTree(IPermission iPermission) 
+  public void reloadPermissionTree(Permission permission) 
   {
     if (StringUtils.isBlank(filter)) 
     {
-      reloadPermissionsUp(searchPermissionNode(rootTreeNode.getChildren(), iPermission.getId()));
+      reloadPermissionsUp(searchPermissionNode(rootTreeNode.getChildren(), permission));
     } 
     else 
     {
-      var permissionNode = searchPermissionNode(filteredRootTreeNode.getChildren(), iPermission.getId());
-      reSetPermission((Permission) permissionNode.getData());
+      reSetPermission(permission);
     }
   }
 
-  public void reloadPermissionTree(IPermissionGroup iPermissionGroup) 
+  public void reloadPermissionTree(PermissionGroup permissionGroup) 
   {
-    reloadPermissionsUpAndDown(searchPermissionNode(rootTreeNode.getChildren(), iPermissionGroup.getId()));
+    reloadPermissionsUpAndDown(searchPermissionNode(rootTreeNode.getChildren(), permissionGroup));
   }
 
   private void reloadPermissionsUp(TreeNode permissionNode) 
@@ -251,15 +248,15 @@ public class PermissionBean
     reloadPermissionGroupsUp(permissionGroupNode.getParent());
   }
 
-  public TreeNode searchPermissionNode(List<TreeNode> children, long permissionId) 
+  public TreeNode searchPermissionNode(List<TreeNode> children, AbstractPermission data) 
   {
     for (var child : children) 
     {
-      if (((AbstractPermission) child.getData()).getId() == permissionId) 
+      if (data.equals(child.getData())) 
       {
         return child;
       }
-      var search = searchPermissionNode(child.getChildren(), permissionId);
+      var search = searchPermissionNode(child.getChildren(), data);
       if (search != null) 
       {
         return search;


### PR DESCRIPTION
In case a PermissionGroup and a Permission has by accident the same ID the method searchPermissionNode might return the wrong node leading to a ClassCastException if a group is returned instead of a permission.

Instead of using the ID use the equals method of Permission and PermissionGroup to search for permission nodes. By doing so a Permission is never equal to a PermissionGroup even if the IDs are the same.

Cherry-Pick 1ef7aba3dfa8537774a948dbeb4018f9f52c3ddb from master