### PR TITLE
Exclude engine-cockpit-monitor-notification-deliveries.png from screenshot comparison

### DIFF
--- a/build/screenshots/Jenkinsfile
+++ b/build/screenshots/Jenkinsfile
@@ -42,5 +42,8 @@ def getScreenshotRefBranch(isReleaseOrMasterBranch) {
 }
 
 def getImageSimilarity(isReleaseOrMasterBranch) {
-  return '90'
+  if (isReleaseOrMasterBranch) {
+    return '97'
+  }
+  return '95'
 }

--- a/image-validation/pom.xml
+++ b/image-validation/pom.xml
@@ -71,6 +71,7 @@
                       <exclude>**/engine-cockpit-monitor-slow-requests.png</exclude>
                       <exclude>**/engine-cockpit-monitor-system-overview.png</exclude>
                       <exclude>**/engine-cockpit-monitor-process-execution.png</exclude>
+                      <exclude>**/engine-cockpit-monitor-notification-deliveries.png</exclude>
                     </excludes>
                   </newImagesFs>
                   <refImages>${project.build.directory}/screenshots</refImages>


### PR DESCRIPTION
I don't see any other quick solution, but I'm open for other thoughts/ideas:

![image](https://github.com/axonivy/engine-cockpit/assets/7498380/b5b1cce3-a354-472b-906b-8d53a59988ac)

