### PR TITLE
Sometimes it tries to use and login a disabled user

### DIFF
--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/Blob.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/Blob.java
@@ -10,7 +10,7 @@ public class Blob {
   public static void create() {
     var ctx = ISecurityContextRepository.instance().getDefault();
     var session = ctx.sessions().create();
-    var user = ctx.users().query().executor().firstResult();
+    var user = ctx.users().query().where().enabled().isTrue().executor().firstResult();
     session.authenticateSessionUser(user, "test");
     new SessionContext(session).runInContext(() -> {
       Sudo.run(() -> Ivy.wfCase().documents().add("louis.txt").write().withContentFrom("louis schreibt man mit s"));


### PR DESCRIPTION
```
Caused by: ch.ivyteam.ivy.scripting.exceptions.invocation.IvyScriptMethodInvocationException: Error calling method create() on an object of class ch.ivyteam.ivy.scripting.language.impl.StaticAccess.
 Error Id: 18BF6EDF9AFB01DA
 Context: request=HTTP GET TestData.p.json/createBlobs.ivp(206.221.0.0), session=30 (anonymous), securityContext=default, task=221, application=test, requestId=5766, executionContext=SYSTEM, pmv=test$engine-cockpit-test-data$1, client=172.25.0.4, processElement=16E88DD61E825E70-f65
	at ch.ivyteam.ivy.scripting.types.classmembers.impl.IvyJavaMethod.invokeImpl(IvyJavaMethod.java:52)
	at ch.ivyteam.ivy.scripting.types.classmembers.impl.IvyMethod.invoke(IvyMethod.java:21)
	at ch.ivyteam.ivy.scripting.language.impl.IvyScriptEnginePerformer.visitControlInstructionInvoke(IvyScriptEnginePerformer.java:493)
	... 171 more
Caused by: ch.ivyteam.ivy.security.AuthenticationException: User is disabled
 Error Id: 18BF6EDF9AFB01DA
```