### PR TITLE
XIVY-12904 fix null pointer

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDeliveryDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDeliveryDto.java
@@ -14,6 +14,7 @@ import ch.ivyteam.enginecockpit.security.model.SecurityMember;
 import ch.ivyteam.enginecockpit.util.DurationFormat;
 import ch.ivyteam.ivy.notification.channel.NotificationChannel;
 import ch.ivyteam.ivy.notification.delivery.NotificationDelivery;
+import ch.ivyteam.ivy.security.ISecurityMember;
 
 public class NotificationDeliveryDto {
 
@@ -59,8 +60,12 @@ public class NotificationDeliveryDto {
   }
 
   public String getChannelUri() {
+    ISecurityMember receiver = delivery.receiver();
+    if (receiver == null) {
+      return null;
+    }
     return UriBuilder.fromPath("notification-channel-detail.xhtml")
-        .queryParam("system", delivery.receiver().getSecurityContext().getName())
+        .queryParam("system", receiver.getSecurityContext().getName())
         .queryParam("channel", delivery.channel())
         .build()
         .toString();
@@ -75,7 +80,11 @@ public class NotificationDeliveryDto {
   }
 
   public String getReceiverUri() {
-    return SecurityMember.createFor(delivery.receiver()).getViewUrl();
+    ISecurityMember receiver = delivery.receiver();
+    if (receiver == null) {
+      return null;
+    }
+    return SecurityMember.createFor(receiver).getViewUrl();
   }
 
   public Date getDeliveredAt() {

--- a/engine-cockpit/webContent/view/notificationDeliveries.xhtml
+++ b/engine-cockpit/webContent/view/notificationDeliveries.xhtml
@@ -51,17 +51,18 @@
             </p:column>
             
             <p:column headerText="Channel" sortBy="#{delivery.channel}">
-              <p:link href="#{delivery.channelUri}">
+              <p:link href="#{delivery.channelUri}" rendered="#{delivery.channelUri != null}">
                 <h:outputText value="${delivery.channelIcon}" class="notification-channel-table-icon" escape="false" />
                 <h:outputText value="#{delivery.channel}" />
               </p:link>
             </p:column>
 
             <p:column headerText="Receiver">
-              <p:link href="#{delivery.receiverUri}">
+              <p:link href="#{delivery.receiverUri}" rendered="#{delivery.receiverUri != null}">
                 <i class="#{delivery.receiverIcon} table-icon"/>
                 <h:outputText value="#{delivery.receiver}" />
               </p:link>
+              <h:outputText value="DELETED" rendered="#{delivery.receiverUri == null}"/>
             </p:column>
 
             <p:column headerText="State">


### PR DESCRIPTION
If the user has been deleted after the notification has been created, `delivery.receiver()` will be `null`. In case of a deleted user, `notificationDeliveries.xhtml` now looks like this:

![image](https://github.com/axonivy/engine-cockpit/assets/141232142/58821515-2d52-44b1-ac39-596f773c2f1c)

Once we have access to the securityContext directly through the deliveryContext, we can show the correct channel again.