### PR TITLE
XIVY-12441 fix: show in-memory migrated content of yaml files.

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorFile.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorFile.java
@@ -2,9 +2,12 @@ package ch.ivyteam.enginecockpit.system.editor;
 
 import java.nio.file.Path;
 import java.util.List;
+
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
+
 import org.primefaces.extensions.event.CompleteEvent;
+
 import ch.ivyteam.ivy.configuration.file.provider.ConfigFile;
 
 public class EditorFile {
@@ -35,7 +38,16 @@ public class EditorFile {
   }
 
   public String getContent() {
+    if (getFileName().endsWith(".yaml")) {
+      return readMigratedYaml();
+    }
     return config.read();
+  }
+
+  @SuppressWarnings("restriction")
+  private String readMigratedYaml() {
+    var yaml = new ch.ivyteam.ivy.configuration.yaml.YamlConfigFile(getPath());
+    return yaml.readLatest();
   }
 
   public void save() {


### PR DESCRIPTION
- do not let the user create invalid configs by copying new yaml structures into 'old' schemas and vice versa
![reveal-ivy-yaml-state](https://github.com/axonivy/engine-cockpit/assets/15085693/bebf213b-26fd-4fb7-a055-29b6f83842ae)
