### PR TITLE
XIVY-11636 EMail schema now also outlines oauth propery defaults

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestConfiguration.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestConfiguration.java
@@ -55,6 +55,13 @@ class WebTestConfiguration {
     assertUrlFiltering(filter);
   }
 
+  private void assertUrlFiltering(String filter) {
+    assertCurrentUrlContains("systemconfig.xhtml?filter=" + filter);
+    table = new Table(TABLE_ID, "span");
+    table.searchFilterShould(exactValue(filter));
+    table.firstColumnShouldBe(size(9));
+  }
+
   @Test
   void systemDbConfigUrl() {
     $("#configureSystemDbBtn").shouldBe(visible).click();
@@ -268,13 +275,6 @@ class WebTestConfiguration {
       assertThatConfigEditModalIsVisible(config, "com.axonivy.portal:portal", "default-pages", "auto");
       $(By.id("config:editConfigurationForm:editConfigurationValue")).shouldHave(cssClass("ui-selectonemenu"));
     }
-  }
-
-  private void assertUrlFiltering(String filter) {
-    assertCurrentUrlContains("systemconfig.xhtml?filter=" + filter);
-    table = new Table(TABLE_ID, "span");
-    table.searchFilterShould(exactValue(filter));
-    table.firstColumnShouldBe(size(8));
   }
 
   private void assertSearchConfigEntry() {


### PR DESCRIPTION
test results changed, due to the new "properties" regarding oauth:
![mailSessionProps](https://github.com/axonivy/engine-cockpit/assets/15085693/a2a2034d-75e9-4a5b-8a8a-e9f7aa475497)
