### PR TITLE
XIVY-13085 Use new Event interface and new API methods for it

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
@@ -2,6 +2,7 @@ package ch.ivyteam.enginecockpit.security;
 
 import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.assertCurrentUrlContains;
 import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
+import static com.codeborne.selenide.CollectionCondition.exactTexts;
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.CollectionCondition.sizeLessThan;
@@ -12,19 +13,23 @@ import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.exactValue;
+import static com.codeborne.selenide.Condition.oneOfTexts;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.axonivy.ivy.webtest.primeui.PrimeUi;
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
+
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Tab;
@@ -169,9 +174,9 @@ class WebTestUserDetail {
     var webNewTaskCheckbox = $(By.id("notificationsForm:notificationChannelsTable:0:channels:0:subscriptionCheckbox")).lastChild().lastChild();
 
     table.firstColumnShouldBe(size(1));
-    table.firstColumnShouldBe(CollectionCondition.exactTexts("new-task"));
+    table.tableEntry(1,1).shouldHave(oneOfTexts("Aufgabe", "task"));
     table.headerShouldBe(size(2));
-    table.headerShouldBe(CollectionCondition.exactTexts("Event", "Web"));
+    table.headerShouldBe(exactTexts("Event", "Web"));
 
     shouldHaveSubscribedByDefaultState(webNewTaskIcon, webNewTaskCheckbox);
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotification.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotification.java
@@ -7,19 +7,23 @@ import static com.codeborne.selenide.CollectionCondition.textsInAnyOrder;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.not;
+import static com.codeborne.selenide.Condition.oneOfTexts;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.axonivy.ivy.webtest.primeui.PrimeUi;
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverConditions;
+
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Tab;
@@ -48,7 +52,7 @@ class WebTestNotification {
   void notifications() {
     var notifications = new Table(By.id("tabs:securitySystemTabView:0:form:notificationTable"), true);
     notifications.tableEntry(1, 1).should(matchText(".*-.*-.*"));
-    notifications.tableEntry(1, 3).should(text("new-task"));
+    notifications.tableEntry(1, 3).should(oneOfTexts("task", "Aufgabe"));
     notifications.tableEntry(1, 4).should(text("Everybody"));
     notifications.tableEntry(1, 5).should(text("engine-cockpit-test-data$1"));
     notifications.tableEntry(1, 6).should(text("Default"));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
@@ -2,17 +2,21 @@ package ch.ivyteam.enginecockpit.services;
 
 import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
 import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.oneOfTexts;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.refresh;
+
 import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.axonivy.ivy.webtest.primeui.PrimeUi;
 import com.axonivy.ivy.webtest.primeui.widget.SelectBooleanCheckbox;
-import com.codeborne.selenide.CollectionCondition;
+
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
@@ -132,7 +136,7 @@ public class WebTestNotificationChannelDetail {
   void eventsInTable() {
     Table table = new Table(By.id("form:events"));
     table.firstColumnShouldBe(size(1));
-    table.firstColumnShouldBe(CollectionCondition.exactTexts("new-task"));
+    table.tableEntry(1,1).shouldHave(oneOfTexts("task", "Aufgabe"));
   }
 
   @Test

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDataModel.java
@@ -1,11 +1,12 @@
 package ch.ivyteam.enginecockpit.security.model;
 
-import java.util.ArrayList;
 import java.util.List;
+
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
+
+import ch.ivyteam.ivy.notification.channel.Event;
 import ch.ivyteam.ivy.notification.channel.NotificationSubscription;
-import ch.ivyteam.ivy.notification.event.NotificationEvent;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.security.ISecurityMember;
 
@@ -14,7 +15,7 @@ public class NotificationChannelDataModel {
   private final ISecurityMember subscriber;
   private final ISecurityContext securityContext;
 
-  private List<String> events;
+  private List<NotificationEventDto> events;
   private List<NotificationChannelDto> channels;
 
   private NotificationChannelDataModel(ISecurityMember subscriber, ISecurityContext securityContext) {
@@ -23,8 +24,8 @@ public class NotificationChannelDataModel {
   }
 
   public void onload() {
-    events = new ArrayList<>(NotificationEvent.allAsString());
-    channels = NotificationChannelDto.all(subscriber, securityContext, events);
+    events = NotificationEventDto.all();
+    channels = NotificationChannelDto.all(subscriber, securityContext);
   }
 
   public void reset() {
@@ -59,7 +60,7 @@ public class NotificationChannelDataModel {
     return channels;
   }
 
-  public List<String> getEvents() {
+  public List<NotificationEventDto> getEvents() {
     return events;
   }
 
@@ -69,4 +70,32 @@ public class NotificationChannelDataModel {
     return model;
   }
 
+  public static final class NotificationEventDto {
+
+    private Event event;
+
+    private NotificationEventDto(Event event) {
+      this.event = event;
+    }
+
+    public Event getEvent() {
+      return event;
+    }
+
+    public String getDisplayName() {
+      return event.displayName();
+    }
+
+    public String getDescription() {
+      return event.description();
+    }
+
+    public static List<NotificationEventDto> all() {
+      return Event.all().stream().map(NotificationEventDto::new).toList();
+    }
+
+    public static NotificationEventDto of(Event event) {
+      return new NotificationEventDto(event);
+    }
+  }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDetailBean.java
@@ -79,9 +79,9 @@ public class NotificationChannelDetailBean {
       config.allEventsEnabled(channel.isAllEventsEnabled());
       var events = channel.getEvents().stream()
               .filter(NotificationEventDto::isEnabled)
-              .map(NotificationEventDto::getKind)
+              .map(NotificationEventDto::getEvent)
               .toList();
-      config.events(events);
+      config._events(events);
       Message.info("msgs", "Successfully saved");
     } catch (Exception ex) {
       Message.error("msgs", ex);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDto.java
@@ -12,10 +12,10 @@ import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.io.IOUtils;
 
 import ch.ivyteam.enginecockpit.util.DurationFormat;
+import ch.ivyteam.ivy.notification.channel.Event;
 import ch.ivyteam.ivy.notification.channel.NotificationChannel;
 import ch.ivyteam.ivy.notification.channel.NotificationChannelSystemConfig;
 import ch.ivyteam.ivy.notification.channel.PushNotificationChannel;
-import ch.ivyteam.ivy.notification.event.NotificationEvent;
 import ch.ivyteam.ivy.security.ISecurityContext;
 
 public class NotificationChannelDto {
@@ -136,12 +136,10 @@ public class NotificationChannelDto {
 
   public static NotificationChannelDto instance(ISecurityContext securityContext, NotificationChannel channel) {
     var config = channel.config();
-    var eventKinds = NotificationEvent.all().stream()
-            .map(NotificationEvent::kind)
-            .toList();
-    var presentEventKinds = config.events();
-    var events = eventKinds.stream()
-            .map(eventKind -> new NotificationEventDto(eventKind, presentEventKinds.contains(eventKind)))
+    var allEvents = Event.all();
+    var presentEvents = config._events();
+    var events = allEvents.stream()
+            .map(event -> new NotificationEventDto(event, presentEvents.contains(event)))
             .collect(Collectors.toList());
 
     return new NotificationChannelDto(channel, config,
@@ -150,16 +148,28 @@ public class NotificationChannelDto {
 
   public static class NotificationEventDto {
 
-    private final String kind;
+    private final Event event;
     private boolean enabled;
 
-    public NotificationEventDto(String kind, boolean enabled) {
-      this.kind = kind;
+    public NotificationEventDto(Event event, boolean enabled) {
+      this.event = event;
       this.enabled = enabled;
     }
 
+    public Event getEvent() {
+      return event;
+    }
+
     public String getKind() {
-      return kind;
+      return event.kind();
+    }
+
+    public String getDisplayName() {
+      return event.displayName();
+    }
+
+    public String getDescription() {
+      return event.description();
     }
 
     public boolean isEnabled() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDto.java
@@ -9,6 +9,7 @@ import ch.ivyteam.enginecockpit.application.model.ProcessModelVersion;
 import ch.ivyteam.enginecockpit.security.model.SecurityMember;
 import ch.ivyteam.ivy.application.IProcessModelVersion;
 import ch.ivyteam.ivy.notification.Notification;
+import ch.ivyteam.ivy.notification.channel.Event;
 import ch.ivyteam.ivy.notification.delivery.NotificationDeliveryRepository;
 
 public class NotificationDto {
@@ -29,8 +30,8 @@ public class NotificationDto {
     return createdAt;
   }
 
-  public String getKind() {
-    return notification.kind();
+  public String getEvent() {
+    return Event.ofKind(notification.kind()).displayName();
   }
 
   public String getReceiver() {
@@ -62,7 +63,7 @@ public class NotificationDto {
         .map(ProcessModelVersion::getDetailView)
         .orElse("");
   }
-  
+
   public String getTemplate() {
     return notification.template();
   }
@@ -90,7 +91,7 @@ public class NotificationDto {
   public void retry() {
     notification.retry();
   }
-  
+
   private Optional<ProcessModelVersion> pmv() {
     return notification.pmv()
         .map(ProcessModelVersion::new);

--- a/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
@@ -21,10 +21,14 @@
     
     <p:dataTable paginator="true" rows="10" paginatorPosition="bottom" paginatorAlwaysVisible="false"
       var="event" value="#{userDetailBean.notificationChannels.events}" id="notificationChannelsTable"
-      lazy="false" styleClass="ui-fluid">
+      lazy="false" styleClass="ui-fluid" rowIndexVar="rowIndex">
       
-      <p:column headerText="Event" sortBy="#{event}">
-        <h:outputText value="#{event}" styleClass="event-kind" />
+      <p:column headerText="Event" sortBy="#{event.displayName}">
+        <h:panelGroup id="event">
+          <h:outputText value="#{event.displayName}" styleClass="event-kind" />
+          <i class="si si-question-circle"></i>
+        </h:panelGroup>
+        <p:tooltip for="notificationsForm:notificationChannelsTable:#{rowIndex}:event" value="#{event.description}" position="top" styleClass="pre-tooltip" />
       </p:column>
       
       <p:columns id="channels" var="channel" value="#{userDetailBean.notificationChannels.channels}" style="text-align: center">

--- a/engine-cockpit/webContent/view/notification-channel-detail.xhtml
+++ b/engine-cockpit/webContent/view/notification-channel-detail.xhtml
@@ -79,9 +79,13 @@
             </p:selectBooleanCheckbox>
           </p:panelGrid>
           
-          <p:dataTable id="events" var="event" value="#{notificationChannelDetailBean.channel.events}">
-            <p:column headerText="Event" sortBy="#{event.kind}">
-              <h:outputText value="#{event.kind}" styleClass="event-kind" />
+          <p:dataTable id="events" var="event" value="#{notificationChannelDetailBean.channel.events}" rowIndexVar="rowIndex">
+            <p:column headerText="Event" sortBy="#{event.displayName}">
+              <h:panelGroup id="event">
+                <h:outputText value="#{event.displayName}" styleClass="event-kind" />
+                <i class="si si-question-circle"></i>
+              </h:panelGroup>
+              <p:tooltip for="form:events:#{rowIndex}:event" value="#{event.description}" position="top" styleClass="pre-tooltip" />
             </p:column>
             <p:column>
               <p:selectBooleanCheckbox id="eventEnabled" value="#{event.enabled}"

--- a/engine-cockpit/webContent/view/notifications.xhtml
+++ b/engine-cockpit/webContent/view/notifications.xhtml
@@ -51,8 +51,8 @@
                 </h:outputText>
               </p:column>
  
-              <p:column headerText="Kind" sortBy="#{notification.kind}">
-                <h:outputText value="#{notification.kind}" />
+              <p:column headerText="Event" sortBy="#{notification.event}">
+                <h:outputText value="#{notification.event}" />
               </p:column>
 
               <p:column headerText="Receiver">


### PR DESCRIPTION
Instead of using a String for event use the new Event interface and use the new API method for it instead of the old deprecated ones that provide or consume a String

On the UI use Event.displayName and Event.description instead of the event kind.

![grafik](https://github.com/axonivy/engine-cockpit/assets/5229480/6c90da02-987e-4b6e-8416-0f856f18f0c2)
![grafik](https://github.com/axonivy/engine-cockpit/assets/5229480/4ee978e2-e64b-483a-ad9e-91e93cd0c5d7)
![grafik](https://github.com/axonivy/engine-cockpit/assets/5229480/eaeeadf6-cfa2-4671-b5ad-c9df96159381)
