### PR TITLE
XIVY-13085 Notification can have multiple receivers

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDto.java
@@ -1,6 +1,8 @@
 package ch.ivyteam.enginecockpit.services.notification;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import javax.ws.rs.core.UriBuilder;
@@ -31,19 +33,20 @@ public class NotificationDto {
   }
 
   public String getEvent() {
-    return Event.ofKind(notification.kind()).displayName();
+    return Event.ofKind(notification.kind()).displayName(Locale.ENGLISH);
   }
 
-  public String getReceiver() {
-    return notification.receiver().getName();
+  public List<SecurityMember> getReceivers() {
+    return notification
+        .receivers()
+        .stream()
+        .map(SecurityMember::createFor)
+        .limit(20)
+        .toList();
   }
 
-  public String getReceiverIcon() {
-    return SecurityMember.createFor(notification.receiver()).getCssIconClass();
-  }
-
-  public String getReceiverUri() {
-    return SecurityMember.createFor(notification.receiver()).getViewUrl();
+  public boolean isReceiversConcat() {
+    return notification.receivers().size() > 20;
   }
 
   public String getPmv() {

--- a/engine-cockpit/webContent/view/notifications.xhtml
+++ b/engine-cockpit/webContent/view/notifications.xhtml
@@ -56,10 +56,13 @@
               </p:column>
 
               <p:column headerText="Receiver">
-                <p:link href="#{notification.receiverUri}">
-                  <i class="#{notification.receiverIcon} table-icon"/>
-                  <h:outputText value="#{notification.receiver}" />
-                </p:link>
+                <ui:repeat value="#{notification.receivers}" var="receiver">
+                  <p:link href="#{receiver.viewUrl}">
+                    <i class="#{receiver.cssIconClass} table-icon"/>
+                    <h:outputText value="#{receiver.name}" />
+                  </p:link>
+                </ui:repeat>
+                <h:outputText value="..." rendered="#{notification.receiversConcat}"/>
               </p:column>
 
               <p:column headerText="PMV">


### PR DESCRIPTION
Show up to 20 receivers of a notification in the
Monitor/Engine/Notifications view

Extend search so that also searching notification receivers and template is possible. Receivers must match exactly.