### PR TITLE
XIVY-13463 Improve performance of role detail view of roles with a lot of users by not loading all users in-memory

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDetailBean.java
@@ -278,13 +278,12 @@ public class RoleDetailBean {
     this.roleUser = roleUser;
   }
 
-  public boolean hasRoleAssigned(String userName) {
+  public boolean hasRoleAssigned(User user) {
     var iRole = getIRole();
     if (iRole == null) {
       throw new IllegalStateException("IRole not found: " + roleName);
     }
-    return iRole.users().assignedPaged().stream()
-            .anyMatch(u -> u.getName().equals(userName));
+    return user.getIUser().getRoles().contains(iRole);
   }
 
   public List<User> searchUser(String query) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
@@ -15,6 +15,7 @@ import ch.ivyteam.ivy.security.administrator.Administrator;
 
 public class User implements SecurityMember {
 
+  private IUser iUser;
   private String name;
   private String fullName;
   private String email;
@@ -37,6 +38,7 @@ public class User implements SecurityMember {
   public User() {}
 
   public User(IUser user) {
+    this.iUser = user;
     this.name = user.getName();
     this.fullName = user.getFullName();
     this.email = user.getEMailAddress();
@@ -193,6 +195,10 @@ public class User implements SecurityMember {
             .email(getEmail())
             .password(getRealPassword())
             .toAdministrator();
+  }
+
+  public IUser getIUser() {
+    return iUser;
   }
 
   @Override

--- a/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
@@ -68,7 +68,7 @@
           </a>
         </p:column>
         <p:column styleClass="table-btn-1">
-          <ui:param name="canBeRemoved" value="#{roleDetailBean.hasRoleAssigned(user.name)}" />
+          <ui:param name="canBeRemoved" value="#{roleDetailBean.hasRoleAssigned(user)}" />
           <p:commandButton id="removeUserFromRoleBtn" update="usersOfRoleForm"
             actionListener="#{roleDetailBean.removeUser(user.name)}" icon="si si-subtract" 
             title="#{canBeRemoved ? 'Remove' : 'This user is inherited by a sub role or a role member'}"


### PR DESCRIPTION
Seems to be introduced here:
https://github.com/axonivy/engine-cockpit/commit/7264968eb7c35a7f8fdc183aeac1740c179b09ee
