### PR TITLE
XIVY-13513 Fix useSSL in ldap browser

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityLdapBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityLdapBean.java
@@ -1,9 +1,9 @@
 package ch.ivyteam.enginecockpit.security.system;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
@@ -319,9 +319,13 @@ public class SecurityLdapBean {
   }
 
   public Map<String, String> getEnvironmentProperties() {
-    return IConfiguration.instance().getMap(SecuritySystemConfig.SECURITY_SYSTEMS + "." + name + "." + "Connection.Environment")
-            .keySet().stream()
-            .collect(Collectors.toMap(key -> StringUtils.removeStart(key, "Connection.Environment."),
-                    key -> IConfiguration.instance().get("SecuritySystems." + name + "." + key).orElse("")));
+    var properties = IConfiguration.instance().getMap(SecuritySystemConfig.SECURITY_SYSTEMS + "." + name + "." + "Connection.Environment");
+    var newProperties = new HashMap<String, String>();
+    for (var entry : properties.entrySet()) {
+      var key = StringUtils.removeStartIgnoreCase(entry.getKey(), "Connection.Environment.");
+      var value = entry.getValue();
+      newProperties.put(key, value);
+    }
+    return newProperties;
   }
 }


### PR DESCRIPTION
If you configure the following in the Engine Cockpit for Microsoft Active Directory:
- URL: ldaps://test-ad.ivyteam.io:637
- User: admin@zugtstdomain.wan
- Password: ***
- DefaultContext: OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan
- EnableInsecureSSL: true

The Browser does not work. In Axon Ivy 10 you still need to set useSSL=true.
If you set new useSSL=true, it does still not work.

This is because the Engine Cockpit does not read this property correctly.
If this property isset, the IvySslSocketFactory comes into charge which is capable
to handle enableInsecure and is working with our own trust- and keystore.
