### PR TITLE
XIVY-13178 show 'examples' when editing configuration

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
@@ -31,6 +32,7 @@ public class ConfigProperty {
   private boolean password;
   private ConfigValueFormat configValueFormat;
   private List<String> enumerationValues;
+  private List<String> exampleValues = List.of();
   private boolean restartRequired;
   private String description;
   private Path file;
@@ -52,6 +54,7 @@ public class ConfigProperty {
     this.password = metaData.isPassword();
     this.configValueFormat = metaData.format();
     this.enumerationValues = metaData.enumerationValues();
+    this.exampleValues = metaData.exampleValues();
     this.restartRequired = metaData.isRestartRequired();
     this.description = metaData.description();
     this.fileExtension = metaData.fileExtension();
@@ -166,6 +169,14 @@ public class ConfigProperty {
 
   public void setEnumerationValues(Supplier<List<String>> enumerationValuesSupplier) {
     this.enumerationValuesSupplier = enumerationValuesSupplier;
+  }
+
+  public List<String> getExampleValues() {
+    return exampleValues;
+  }
+
+  public String getExamples() {
+    return exampleValues.stream().collect(Collectors.joining(", "));
   }
 
   public boolean isRestartRequired() {

--- a/engine-cockpit/webContent/resources/composite/Configuration.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Configuration.xhtml
@@ -115,6 +115,11 @@
           value="Description" />
         <h:outputText id="editConfigurationDescription" value="#{cc.attrs.bean.activeConfig.htmlDescription}" 
           styleClass="config-edit-description" escape="false" rendered="#{cc.attrs.bean.activeConfig.hasDescription()}" /> <!-- Contains no user input -->
+          
+        <h:outputLabel for="editConfigurationExamples" rendered="#{!cc.attrs.bean.activeConfig.exampleValues.isEmpty()}"
+          value="Examples" />
+        <h:outputText id="editConfigurationExamples" value="#{cc.attrs.bean.activeConfig.examples}" 
+          rendered="#{!cc.attrs.bean.activeConfig.exampleValues.isEmpty()}" />
 
         <h:outputLabel for="editConfigurationValue" value="Value" />
         <c:choose>


### PR DESCRIPTION
render examples onto configs, simplifying the selection of valid values.

![exposeExamples_atCockpit](https://github.com/axonivy/engine-cockpit/assets/15085693/8e5ca1dc-24b6-46f3-9349-4c5da5503d11)
