### PR TITLE
XIVY-13583 Escape single quotes for migration differ

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Question.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Question.java
@@ -19,7 +19,8 @@ public class Question {
     title = quest.title;
     more = quest.more;
     options = quest.options;
-    this.diff = RegExUtils.replaceAll(diff, "(\\r|\\n|\\r\\n)", "\\\\n");
+    diff = RegExUtils.replaceAll(diff, "(\\r|\\n|\\r\\n)", "\\\\n");
+    this.diff = diff.replace("'", "\\'"); // for javascript
   }
 
   public String getTitle() {


### PR DESCRIPTION
If a file contains a single quote ', then the differ can not be loaded.
I think this should solve the issue.

Maybe there would be a JSF Component to call a javascript method, but I'm not aware of it.

```
<script>
   showDiff('form:tasks:#{tasksRepeat.index}:questions:#{questionsRepeat.index}:diff', '#{question.diff}');
</script>
```