### PR TITLE
XIVY-13595 Add exception handler to wizard template

### DIFF
--- a/engine-cockpit/webContent/includes/template/wizard.xhtml
+++ b/engine-cockpit/webContent/includes/template/wizard.xhtml
@@ -96,6 +96,7 @@
   </div>
 
   <ui:include src="progress-loader.xhtml" />
+  <ui:include src="exception.xhtml" />
 
   <h:outputStylesheet name="css/layout-ivy-#{ivyFreyaTheme.mode}.css" library="freya-layout" />
   <h:outputStylesheet name="primeflex-2.min.css" library="primeflex" />


### PR DESCRIPTION
Otherwise it ends up in this:
![image](https://github.com/axonivy/engine-cockpit/assets/7498380/b2273fff-158a-421b-992f-7485aeab6dad)
