### PR TITLE
XIVY-13549 fix: do not break layout with html-comment

### DIFF
--- a/engine-cockpit/webContent/resources/composite/Configuration.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Configuration.xhtml
@@ -114,7 +114,7 @@
         <h:outputLabel for="editConfigurationDescription" rendered="#{cc.attrs.bean.activeConfig.hasDescription()}"
           value="Description" />
         <h:outputText id="editConfigurationDescription" value="#{cc.attrs.bean.activeConfig.htmlDescription}" 
-          styleClass="config-edit-description" escape="false" rendered="#{cc.attrs.bean.activeConfig.hasDescription()}" /> <!-- Contains no user input -->
+          styleClass="config-edit-description" escape="false" rendered="#{cc.attrs.bean.activeConfig.hasDescription()}" />
           
         <h:outputLabel for="editConfigurationExamples" rendered="#{!cc.attrs.bean.activeConfig.exampleValues.isEmpty()}"
           value="Examples" />


### PR DESCRIPTION
seems like the comment in xhtml brakes the grid-layout
![grid-layout-broken](https://github.com/axonivy/engine-cockpit/assets/15085693/7c14053e-f672-4771-851d-72996c0a4850)
