### PR TITLE
XIVY-13760 Remove system database conversion button

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
@@ -98,12 +98,6 @@ public class WebTestSystemDb {
   }
 
   @Test
-  void testConvertOldDb() {
-    assertSystemDbConversionDialog();
-    assertSystemDbConversion();
-  }
-
-  @Test
   void testDefaultPortSwitch() {
     assertDefaultPortSwitch();
   }
@@ -155,9 +149,9 @@ public class WebTestSystemDb {
   }
 
   public static void assertSystemDbCreation() {
-    $("#systemDb\\:createDatabaseForm\\:confirmConvertButton").click();
-    $("#systemDb\\:createDatabaseForm\\:confirmConvertButton").shouldNotBe(enabled);
-    $("#systemDb\\:createDatabaseForm\\:confirmConvertButton > .ui-icon")
+    $(By.id("systemDb:createDatabaseForm:confirmCreateButton")).click();
+    $(By.id("systemDb:createDatabaseForm:confirmCreateButton")).shouldNotBe(enabled);
+    $("#systemDb\\:createDatabaseForm\\:confirmCreateButton > .ui-icon")
             .shouldHave(cssClass("si-is-spinning"));
     $("#systemDb\\:createDatabaseForm\\:closeCreationButton")
             .shouldBe(and("wait until db created", appear, enabled), Duration.ofSeconds(20));
@@ -171,29 +165,7 @@ public class WebTestSystemDb {
   public static void assertSystemDbConversionDialog() {
     insertDbConnection("MySQL", "mySQL", SYS_DB, OLD_DB_NAME, SYS_DB_USER, SYS_DB_PW);
     $(CONNECTION_BUTTON).click();
-    $(CONNECTION_PANEL).shouldBe(
-            text("Database too old"), text("Convert system database."));
-    $("#systemDb\\:systemDbForm\\:migrateDatabaseButton").shouldBe(enabled).click();
-    $("#systemDb\\:convertDatabaseDialog").shouldBe(visible);
-  }
-
-  private static void assertSystemDbConversion() {
-    $("#systemDb\\:convertDatabaseForm\\:confirmConvertButton").click();
-    $("#systemDb\\:convertDatabaseForm\\:confirmConvertButton").shouldNotBe(enabled);
-    $("#systemDb\\:convertDatabaseForm\\:confirmConvertButton > .ui-icon")
-            .shouldHave(cssClass("si-is-spinning"));
-    $("#systemDb\\:convertDatabaseForm\\:convertionWarning").shouldBe(visible);
-    $("#systemDb\\:convertDatabaseForm\\:closeConversionButton")
-            .shouldBe(and("wait until db converted", appear, enabled), Duration.ofSeconds(20));
-    $("#systemDb\\:convertDatabaseForm\\:convertionError").shouldNot(exist);
-    $("#systemDb\\:convertDatabaseForm\\:convertionWarning").shouldNot(exist);
-    $("#systemDb\\:convertDatabaseForm\\:convertionInfo").shouldBe(text("The database was migrated successfully"));
-    $("#systemDb\\:convertDatabaseForm\\:closeConversionButton").click();
-    $("#systemDb\\:convertDatabaseDialog").shouldNotBe(visible);
-    $(CONNECTION_PANEL).shouldBe(text("Connected"));
-
-    Selenide.refresh();
-    $(CONNECTION_PANEL).shouldBe(text("Connected"));
+    $(CONNECTION_PANEL).shouldBe(text("Database too old"), text("Convert system database."));
   }
 
   public static void assertConnectionResults() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SystemDatabaseBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SystemDatabaseBean.java
@@ -26,7 +26,6 @@ import ch.ivyteam.enginecockpit.system.model.SystemDbConnectionProperty;
 import ch.ivyteam.enginecockpit.system.model.SystemDbCreationParameter;
 import ch.ivyteam.ivy.configuration.restricted.IConfiguration;
 import ch.ivyteam.ivy.persistence.db.connection.ConnectionTester;
-import ch.ivyteam.ivy.persistence.db.init.SystemDatabaseConverter;
 import ch.ivyteam.ivy.persistence.db.init.SystemDatabaseCreator;
 import ch.ivyteam.ivy.persistence.db.init.SystemDatabaseSetup;
 import ch.ivyteam.ivy.server.restricted.EngineMode;
@@ -46,7 +45,6 @@ public class SystemDatabaseBean extends StepStatus {
   private Properties additionalProps;
   private String propKey;
   private String propValue;
-  private SystemDatabaseConverter converter;
   private SystemDatabaseCreator creator;
 
   private final ConnectionTestWrapper connectionTest;
@@ -224,34 +222,6 @@ public class SystemDatabaseBean extends StepStatus {
   public String getDbCreatorError() {
     if (creator != null && creator.getError() != null) {
       return creator.getError().getMessage();
-    }
-    return "";
-  }
-
-  public void createConverter() {
-    converter = new SystemDatabaseSetup(createConfiguration())
-            .createConverter();
-  }
-
-  public void convertDatabase() {
-    saveConfiguration();
-    converter.executeAsync();
-  }
-
-  public boolean isDbConversionRunning() {
-    return converter != null && converter.isRunning();
-  }
-
-  public boolean isDbConversionFinished() {
-    return converter != null &&
-            !converter.isRunning() &&
-            StringUtils.equals(converter.getProgressText(), "Finished") &&
-            StringUtils.isBlank(getDbConversionError());
-  }
-
-  public String getDbConversionError() {
-    if (converter != null && converter.getError() != null) {
-      return converter.getError().getMessage();
     }
     return "";
   }

--- a/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
@@ -37,10 +37,6 @@
               styleClass="mr-1 wizard-top-button ui-button-secondary" actionListener="#{systemDatabaseBean.initCreator()}"
               update="systemDb:createDatabaseDialog" oncomplete="PF('createDatabaseDialog').show();"
               disabled="#{!systemDatabaseBean.connectionInfo.mustCreate}" />
-            <p:commandButton value="Migrate Database" id="migrateDatabaseButton" icon="si si-synchronize-arrows"
-              styleClass="wizard-top-button ui-button-secondary" actionListener="#{systemDatabaseBean.createConverter()}"
-              update="systemDb:convertDatabaseDialog" onsuccess="PF('convertDatabaseDialog').show();"
-              disabled="#{!systemDatabaseBean.connectionInfo.mustConvert}" />
           </div>
         </p:outputPanel>
       </div>
@@ -180,7 +176,7 @@
         <h:panelGroup rendered="#{!systemDatabaseBean.dbCreatorFinished}">
           <p:commandButton value="Cancel" rendered="#{!systemDatabaseBean.dbCreatorRunning}" styleClass="ui-button-secondary ui-button-flat modal-input-button"
             oncomplete="PF('createDatabaseDialog').hide();" />
-          <p:commandButton id="confirmConvertButton" value="Save and create"
+          <p:commandButton id="confirmCreateButton" value="Save and create"
             disabled="#{systemDatabaseBean.dbCreatorRunning}"
             icon="si si-#{systemDatabaseBean.dbCreatorRunning ? 'button-refresh-arrows si-is-spinning' : 'database-settings'}"
             actionListener="#{systemDatabaseBean.createDatabase}" style="width: 170px;" update="@form"
@@ -189,48 +185,6 @@
         <h:panelGroup rendered="#{systemDatabaseBean.dbCreatorFinished}">
           <p:commandButton id="closeCreationButton" value="Connect" icon="si si-check-1"
             actionListener="#{systemDatabaseBean.testConnection}" onclick="PF('createDatabaseDialog').hide();"
-            update="#{cc.attrs.updateFields}" styleClass="modal-input-button" />
-        </h:panelGroup>
-      </div>
-    </h:form>
-  </p:dialog>
-
-  <p:dialog id="convertDatabaseDialog" widgetVar="convertDatabaseDialog" header="Do you really want to convert?"
-    dynamic="true" modal="true" closable="false">
-    <h:form id="convertDatabaseForm" styleClass="custom-dialog-form">
-      <div>
-        <p:poll autoStart="#{systemDatabaseBean.dbConversionRunning}" id="convertingOutputPoll"
-          widgetVar="convertingOutputPoll" update="@form" interval="2" />
-        <div id="migrationWarnMessage" class="ui-message ui-staticmessage ui-message-warn ui-widget ui-corner-all">
-          <span class="ui-message-warn-icon"></span>
-          <span class="ui-message-warn-summary">Warning</span>
-          <span class="ui-message-warn-detail">Database Migration may result in inconsistent Engine state. Use the
-            <p:link href="migrate.xhtml" rel="noopener noreferrer" value="Migration Wizard" /> instead for proper migration.
-          </span>
-        </div>
-        <p:staticMessage id="convertionError" severity="error" summary="Error" detail="#{systemDatabaseBean.dbConversionError}" 
-          rendered="#{not empty systemDatabaseBean.dbConversionError}" />
-        <p:staticMessage id="convertionWarning" severity="warn" summary="Warning" detail="Do not leave this page, while the migration is running!" 
-          rendered="#{systemDatabaseBean.dbConversionRunning}" />
-        <p:staticMessage id="convertionInfo" severity="info" summary="Success" detail="The database was migrated successfully. Please check the connection!" 
-          rendered="#{systemDatabaseBean.dbConversionFinished}" />
-      </div>
-
-      <div class="custom-dialog-footer">
-        <h:panelGroup rendered="#{!systemDatabaseBean.dbConversionFinished}">
-          <p:commandButton value="Cancel" rendered="#{!systemDatabaseBean.dbConversionRunning}"
-            styleClass="ui-button-secondary ui-button-flat modal-input-button" oncomplete="PF('convertDatabaseDialog').hide();" />
-          <p:commandButton id="confirmConvertButton" value="Save and convert"
-            disabled="#{systemDatabaseBean.dbConversionRunning}"
-            icon="si si-#{systemDatabaseBean.dbConversionRunning ? 'button-refresh-arrows si-is-spinning' : 'synchronize-arrows'}"
-            actionListener="#{systemDatabaseBean.convertDatabase}" style="width: 170px;" update="@form"
-            styleClass="modal-input-button"
-            onclick="window.onbeforeunload = function () {return 'A database conversion is running!';}" />
-        </h:panelGroup>
-        <h:panelGroup rendered="#{systemDatabaseBean.dbConversionFinished}">
-          <p:commandButton id="closeConversionButton" value="Connect" icon="si si-check-1"
-            actionListener="#{systemDatabaseBean.testConnection}"
-            onclick="PF('convertDatabaseDialog').hide(); window.onbeforeunload = undefined;"
             update="#{cc.attrs.updateFields}" styleClass="modal-input-button" />
         </h:panelGroup>
       </div>


### PR DESCRIPTION
I think we should already remove this button. It's well-known that running only the system database conversion is only doing half of the job.

This will give more pressure on the backlog to priorize the Migration Wizard.