### PR TITLE
XIVY-14130 Filter the correct bean to work on for poll and start/stop

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestClassHistogram.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestClassHistogram.java
@@ -13,15 +13,18 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.junit5.ScreenShooterExtension;
 
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
+@ExtendWith(ScreenShooterExtension.class)
 public class WebTestClassHistogram {
 
   private static final Duration TWENTY_SECONDS = Duration.ofSeconds(20);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestIntermediateEvents.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestIntermediateEvents.java
@@ -18,17 +18,20 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.junit5.ScreenShooterExtension;
 
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
+@ExtendWith(ScreenShooterExtension.class)
 class WebTestIntermediateEvents {
 
   private static final String INTERMEDIATE_EVENT_PATH = "/engine-cockpit-test-data$1/188B95440FE25CA6-f19";

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJobs.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJobs.java
@@ -19,16 +19,19 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.junit5.ScreenShooterExtension;
 
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
+@ExtendWith(ScreenShooterExtension.class)
 class WebTestJobs {
 
   private static final String DURATION_STR = "[0-9][0-9]* (ms|s|m|h|d)";

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestStartEvents.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestStartEvents.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
@@ -30,6 +31,7 @@ import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverConditions;
 import com.codeborne.selenide.WebElementCondition;
+import com.codeborne.selenide.junit5.ScreenShooterExtension;
 
 import ch.ivyteam.enginecockpit.util.Conditions;
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
@@ -37,6 +39,7 @@ import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
+@ExtendWith(ScreenShooterExtension.class)
 class WebTestStartEvents {
 
   private static final String DURATION_STR = "[0-9][0-9]?[0-9]? (us|ms|s|m|h|d)";
@@ -112,13 +115,13 @@ class WebTestStartEvents {
   @Test
   void filter() {
     table.rows().shouldHave(CollectionCondition.sizeGreaterThan(1));
-    $(By.id("form:beanTable:globalFilter")).sendKeys(EngineCockpitUtil.getAppName()+"/engine-cockpit-test-data$1/188AE871FC5C4A58/eventLink.ivp");
+    filter("188AE871FC5C4A58/eventLink.ivp");
     table.rows().shouldHave(CollectionCondition.size(1));
 
     $(By.id("form:beanTable:globalFilter")).clear();
     $(By.id("form:beanTable:globalFilter")).sendKeys("\n");
     table.rows().shouldHave(CollectionCondition.sizeGreaterThan(1));
-    $(By.id("form:beanTable:globalFilter")).sendKeys(EngineCockpitUtil.getAppName()+"/engine-cockpit-test-data$1/188AE871FC5C4A58/eventLink.ivp");
+    filter("188AE871FC5C4A58/eventLink.ivp");
     table.rows().shouldHave(CollectionCondition.size(1));
   }
   
@@ -143,25 +146,27 @@ class WebTestStartEvents {
       });
   }
 
-  // @Test
-  // void poll() {
-  //   var initialExecutions = Long.parseLong(table.tableEntry(1, 5).text());
-  //   $(By.id("form:beanTable:0:poll")).click();
-  //   $(By.id("pollBean:poll")).click();
+  @Test
+  void poll() {
+    filterAndAssertOne("188AE871FC5C4A58/eventLink.ivp");  
+    var initialExecutions = Long.parseLong(table.tableEntry(1, 5).text());
+    $(By.id("form:beanTable:0:poll")).click();
+    $(By.id("pollBean:poll")).click();
 
-  //   Wait()
-  //       .withTimeout(Duration.ofSeconds(10))
-  //       .ignoring(AssertionError.class)
-  //       .until(webDriver -> {
-  //         $(By.id("refresh")).click();
-  //         var executions = Long.parseLong(table.tableEntry(1, 5).text());
-  //         assertThat(executions).isGreaterThan(initialExecutions);
-  //         return true;
-  //       });
-  // }
+    Wait()
+        .withTimeout(Duration.ofSeconds(10))
+        .ignoring(AssertionError.class)
+        .until(webDriver -> {
+          $(By.id("refresh")).click();
+          var executions = Long.parseLong(table.tableEntry(1, 5).text());
+          assertThat(executions).isGreaterThan(initialExecutions);
+          return true;
+        });
+  }
 
   @Test
   void stop_start() {
+    filterAndAssertOne("188AE871FC5C4A58/eventLink.ivp");
     $(By.id("form:beanTable:0:start")).shouldBe(disabled);
     $(By.id("form:beanTable:0:stop")).shouldBe(enabled);
 
@@ -369,5 +374,14 @@ class WebTestStartEvents {
           assertThat(polls).isGreaterThan(initialPolls);
           return true;
         });
+  }
+  
+  private void filter(String filter) {
+    $(By.id("form:beanTable:globalFilter")).sendKeys(EngineCockpitUtil.getAppName()+"/engine-cockpit-test-data$1/" + filter);
+  }
+  
+  private void filterAndAssertOne(String filter) {
+    filter(filter);
+    table.rows().shouldHave(CollectionCondition.size(1));
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
@@ -16,16 +16,19 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.By;
 
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.junit5.ScreenShooterExtension;
 
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
 
 @IvyWebTest
+@ExtendWith(ScreenShooterExtension.class)
 public class WebTestThreads {
 
   private static final Duration TWENTY_SECONDS = Duration.ofSeconds(20);


### PR DESCRIPTION
Using the first bean in the list is not reliable as on some systems the order is different an the first bean may not work correctly in case of poll and start/stop.
Therefore, I now filter the correct bean to work on for testing poll and start/stop.

Wait() throws a TimeoutException and not a UIAssertionException. Therefore no screenshot is taken by default.
Adding the ScreenShooterExtension to tests were Wait() is used so that a screenshot is taken if the test fails.