### PR TITLE
XIVY-14130 Fix flaky WebTestJfr.duration

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJfr.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJfr.java
@@ -122,8 +122,8 @@ public class WebTestJfr {
     $(id("form:start")).shouldBe(visible, enabled).click();
     $(id("startRecording:more_toggler")).shouldBe(visible, enabled).click();
     $(id("startRecording:duration")).shouldBe(visible, enabled).sendKeys("10 s");
+    $(id("startRecording:more_toggler")).shouldBe(visible, enabled).click();
     $(id("startRecording:start")).shouldBe(visible, enabled).click();
-
     recordingsTable.tableEntry(1, 5).shouldBe(not(exactText("Unlimited")));
   }
 


### PR DESCRIPTION
Depending on timing and animation the Start button is no longer visible after inserting the duration. Closing the toggable panel after inserting the duration makes it visible again.

I will merge to 11.3 and 10 too.