### PR TITLE
updated monaco-yaml generated differnt html

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestConfigFileEditor.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestConfigFileEditor.java
@@ -62,9 +62,9 @@ class WebTestConfigFileEditor {
         .shouldBe(visible);
       idpName.hover();
 
-      $(By.className("hover-contents")).shouldBe(visible)
+      $(By.className("code-hover-contents")).shouldBe(visible)
         .as("config-editor shows key specific help, provided by json-schemas")
-        .shouldHave(Condition.partialText("microsoft-entra-id"));
+        .shouldHave(Condition.partialText("novell-edirectory"));
     }
     finally {
       driver.switchTo().defaultContent();


### PR DESCRIPTION
we upgraded monaco-yaml; and it seems that the hover-help-text is rendered differently.
https://github.com/axonivy/monaco-yaml-ivy/pull/86

**11.3**
![113-help](https://github.com/axonivy/engine-cockpit/assets/15085693/48ad70a1-8358-410a-b8d0-a27d16a2dff9)


**11.4**
![114-help](https://github.com/axonivy/engine-cockpit/assets/15085693/1a620c66-309c-45de-886a-08e00924f454)
