### PR TITLE
XIVY-14370 Display bean and process element name and description

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestStartEvents.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestStartEvents.java
@@ -124,7 +124,7 @@ class WebTestStartEvents {
     filter("188AE871FC5C4A58/eventLink.ivp");
     table.rows().shouldHave(CollectionCondition.size(1));
   }
-  
+
   @Test
   void sort() {
     table.sortByColumn("Name");
@@ -148,7 +148,7 @@ class WebTestStartEvents {
 
   @Test
   void poll() {
-    filterAndAssertOne("188AE871FC5C4A58/eventLink.ivp");  
+    filterAndAssertOne("188AE871FC5C4A58/eventLink.ivp");
     var initialExecutions = Long.parseLong(table.tableEntry(1, 5).text());
     $(By.id("form:beanTable:0:poll")).click();
     $(By.id("pollBean:poll")).click();
@@ -277,6 +277,9 @@ class WebTestStartEvents {
 
     detailsPoll();
 
+    $(By.id("bean:eventBean:name")).shouldHave(text("poll error (PollError)"));
+    $(By.id("bean:eventBean:description")).shouldHave(text("Throws an error in the poll method (Description of PollError)"));
+
     $(By.id("polls:eventPoll:lastPollError:message")).shouldHave(text("Exception in poll method"));
     $(By.id("polls:eventPoll:lastPollError:showDetails")).click();
     assertErrorDialog("Exception in poll method");
@@ -375,11 +378,11 @@ class WebTestStartEvents {
           return true;
         });
   }
-  
+
   private void filter(String filter) {
     $(By.id("form:beanTable:globalFilter")).sendKeys(EngineCockpitUtil.getAppName()+"/engine-cockpit-test-data$1/" + filter);
   }
-  
+
   private void filterAndAssertOne(String filter) {
     filter(filter);
     table.rows().shouldHave(CollectionCondition.size(1));

--- a/engine-cockpit-test-data/processes/IntermediateEvent.p.json
+++ b/engine-cockpit-test-data/processes/IntermediateEvent.p.json
@@ -38,15 +38,13 @@
     }, {
       "id" : "f1",
       "type" : "WaitEvent",
-      "name" : "TestIntermediateEvent",
       "config" : {
         "javaClass" : "ch.ivyteam.enginecockpit.monitor.TestIntermediateClass",
         "eventId" : "in.eventID.toString()"
       },
       "visual" : {
         "at" : { "x" : 224, "y" : 144 },
-        "labelOffset" : { "x" : 72, "y" : 36 },
-        "description" : "intermediate event description"
+        "labelOffset" : { "x" : 72, "y" : 36 }
       },
       "connect" : [
         { "id" : "f3", "to" : "f2" }
@@ -88,7 +86,7 @@
     }, {
       "id" : "f6",
       "type" : "WaitEvent",
-      "name" : "PollErrorIntermediateEvent",
+      "name" : "Poll error",
       "config" : {
         "javaClass" : "ch.ivyteam.enginecockpit.monitor.PollErrorIntermediateClass",
         "eventId" : "in.eventID.toString()"
@@ -96,7 +94,7 @@
       "visual" : {
         "at" : { "x" : 224, "y" : 244 },
         "labelOffset" : { "x" : 72, "y" : 36 },
-        "description" : "another intermediate event description"
+        "description" : "Throws an error in the poll method"
       },
       "connect" : [
         { "id" : "f9", "to" : "f7" }

--- a/engine-cockpit-test-data/processes/StartEvent.p.json
+++ b/engine-cockpit-test-data/processes/StartEvent.p.json
@@ -13,7 +13,6 @@
     }, {
       "id" : "f0",
       "type" : "ProgramStart",
-      "name" : "nominal",
       "config" : {
         "javaClass" : "ch.ivyteam.ivy.process.eventstart.beans.TimerBean",
         "userConfig" : {
@@ -71,7 +70,8 @@
       },
       "visual" : {
         "at" : { "x" : 96, "y" : 232 },
-        "labelOffset" : { "x" : 13, "y" : 33 }
+        "labelOffset" : { "x" : 13, "y" : 33 },
+        "description" : "Throws an error in the poll method"
       },
       "connect" : [
         { "id" : "f8", "to" : "f1", "via" : [ { "x" : 352, "y" : 232 } ] }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/Event.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/Event.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 
 import javax.management.ObjectName;
 
+import org.apache.commons.lang3.StringUtils;
+
 import ch.ivyteam.enginecockpit.monitor.mbeans.MBean;
 import ch.ivyteam.enginecockpit.util.ErrorHandler;
 import ch.ivyteam.enginecockpit.util.ErrorValue;
@@ -35,11 +37,21 @@ public abstract class Event {
   }
 
   public String getBeanName() {
-    return bean.readAttribute("name").asString();
+    var elementName = bean.readAttribute("processElementName").asString();
+    var beanName = bean.readAttribute("name").asString();
+    if (StringUtils.isEmpty(elementName)) {
+      return beanName;
+    }
+    return elementName +" (" + beanName + ")";
   }
 
   public String getBeanDescription() {
-    return bean.readAttribute("description").asString();
+    var elementDescr = bean.readAttribute("processElementDescription").asString();
+    var beanDescr = bean.readAttribute("description").asString();
+    if (StringUtils.isEmpty(elementDescr)) {
+      return beanDescr;
+    }
+    return elementDescr +" (" + beanDescr + ")";
   }
 
   public String getApplication() {
@@ -153,7 +165,7 @@ public abstract class Event {
   public List<Firing> getFirings() {
     return firings;
   }
-  
+
   public List<EventBeanThread> getThreads() {
     return threads;
   }


### PR DESCRIPTION
The start and intermediate event views shows now the name and description of the bean and also of the process element. If no name is configured on the process element only the name of the bean is displayed.
If the name is configured on the process element then the name of the process element with the name of the bean in brackets as postfix is displayed in the name column.
Same for the description column.