### PR TITLE
XIVY-14293 Show health messages in top menu

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestHealthWarning.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestHealthWarning.java
@@ -1,0 +1,69 @@
+package ch.ivyteam.enginecockpit;
+
+import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.assertCurrentUrlContains;
+import static ch.ivyteam.enginecockpit.util.EngineCockpitUtil.login;
+import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import com.axonivy.ivy.webtest.IvyWebTest;
+
+@IvyWebTest
+public class WebTestHealthWarning {
+
+  @BeforeEach
+  void beforeEach() {
+    login();
+  }
+
+  @Test
+  void badge() {
+    $(By.id("health-check-badge")).shouldHave(text("2"));  
+  }
+  
+  @Test
+  void messages() {
+    var health = $(".health-messages");
+    health.shouldBe(visible).click();
+    var messages= health.$$("li");
+    messages.shouldHave(size(3));
+    
+    var first = messages.get(0);
+    first.$("i").shouldHave(cssClass("health-high"));
+    first.$("span").shouldHave(text("Release Candidate"));
+
+    var second = messages.get(1);
+    second.$("i").shouldHave(cssClass("health-low"));
+    second.$("span").shouldHave(text("Demo Mode"));
+
+    var third = messages.get(2);
+    third.shouldHave(text("Show health details ..."));
+  }
+
+  @Test
+  void messageLink() {
+    var health = $(".health-messages");
+    health.shouldBe(visible).click();
+    var messages= health.$$("li");
+    var demoMode = messages.get(1);
+    demoMode.click();
+    assertCurrentUrlContains("setup-intro.xhtml");
+  }
+
+  @Test
+  void showDetails() {
+    var health = $(".health-messages");
+    health.shouldBe(visible).click();
+    var messages= health.$$("li");
+    var showDetails = messages.get(2);
+    showDetails.click();
+    assertCurrentUrlContains("monitor-health.xhtml");
+  }
+
+}

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestConfiguration.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestConfiguration.java
@@ -9,6 +9,7 @@ import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
 import static com.codeborne.selenide.Condition.attribute;
+import static com.codeborne.selenide.Condition.clickable;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.exactValue;
@@ -30,6 +31,7 @@ import org.openqa.selenium.By;
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.axonivy.ivy.webtest.primeui.PrimeUi;
 import com.axonivy.ivy.webtest.primeui.widget.SelectOneMenu;
+import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Configuration;
 
 import ch.ivyteam.enginecockpit.util.Navigation;
@@ -163,13 +165,17 @@ class WebTestConfiguration {
       var config = "Connector.HTTP.Address";
       assertEditConfig(config, "", "hi", "For servers with more than one IP address");
       refresh();
-      $(".restart-notification").should(exist);
+      var messages = $(".health-messages");
+      messages.shouldHave(text("3"));
+      messages.shouldBe(visible).shouldBe(clickable).click();      
+      messages.shouldHave(Condition.partialText("Restart is required"));
       table.valueForEntryShould(config, 2, exactText("hi"));
       assertResetConfig(config);
       refresh();
-      $(".restart-notification").shouldNot(exist);
+      messages.shouldHave(text("2"));
+      messages.shouldBe(visible).shouldBe(clickable).click();
+      messages.shouldNotHave(text("Restart is required"));
     }
-
   }
 
   @Nested
@@ -324,6 +330,7 @@ class WebTestConfiguration {
     $("#config\\:editConfigurationForm\\:saveEditConfiguration").click();
     $("#config\\:form\\:msgs_container").shouldHave(text(key), text("saved"));
     table.valueForEntryShould(key, 2, exactText(newValue));
+    $("#config\\:form\\:msgs_container").shouldNotBe(visible);
   }
 
   private void assertThatConfigEditModalIsVisible(String key, String value, String desc) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
@@ -80,6 +80,13 @@ public class HealthBean {
     return messages;
   }
 
+  public List<Message> getTopMessages() {
+    if (messages.size() <= 4) {
+      return messages;
+    }
+    return messages.subList(0, 4);
+  }
+
   public int getMessageCount() {
     return messages.size();
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/EngineModeBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/EngineModeBean.java
@@ -3,14 +3,10 @@ package ch.ivyteam.enginecockpit.system;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
 
-import org.apache.commons.lang3.StringUtils;
-
 import ch.ivyteam.ivy.server.restricted.EngineMode;
-import ch.ivyteam.ivy.server.restricted.MaintenanceReason;
 
 @ManagedBean
 @SessionScoped
-@SuppressWarnings("restriction")
 public class EngineModeBean {
   public boolean isDemo() {
     return EngineMode.is(EngineMode.DEMO) || EngineMode.is(EngineMode.DESIGNER_EMBEDDED);
@@ -18,30 +14,5 @@ public class EngineModeBean {
 
   public boolean isMaintenance() {
     return EngineMode.is(EngineMode.MAINTENANCE);
-  }
-
-  public boolean hasDashboardWarning() {
-    return (isDemo() || isMaintenance());
-  }
-
-  public String getDashboardWarningSummary() {
-    return isDemo() ? "Demo Mode!" : "Maintenance Mode!";
-  }
-
-  public String getDashboardWarningDetail() {
-    return isDemo() ? getWarningMessage() : getMaintenanceReason();
-  }
-
-  private String getWarningMessage() {
-    var licenceProblemMsg = new LicenceBean().getProblemMessage();
-    if (StringUtils.isNotBlank(licenceProblemMsg)) {
-      return licenceProblemMsg;
-    }
-    return new SystemDatabaseBean().isPersistentDb() ? "Unfinished setup."
-            : "No persistent database configured.";
-  }
-
-  public String getMaintenanceReason() {
-    return MaintenanceReason.getMessage();
   }
 }

--- a/engine-cockpit/webContent/includes/template/template.xhtml
+++ b/engine-cockpit/webContent/includes/template/template.xhtml
@@ -86,45 +86,33 @@
               </li>
             </h:outputText>
             
-            <h:outputText rendered="#{managerBean.restartEngine or engineModeBean.hasDashboardWarning() or ivyAdvisor.releaseCandidate}">
-              <li class="topbar-item topbar-notifications engine-warnings">
+            <h:outputText rendered="#{not empty healthBean.messages}">
+              <li class="topbar-item topbar-notifications health-messages">
                 <a href="#">
                   <i class="topbar-icon si si-road-sign-warning animated swing"></i>
+                  <h:outputText id="health-check-badge" value="#{healthBean.messageCount}" styleClass="health-check-badge" />
                 </a>
                 <ul>
-                  <h:panelGroup rendered="#{managerBean.restartEngine}">
-                    <li class="restart-notification">
-                      <a href="#{managerBean.configLogUrl}">
-                        <i class="si si-lg si-synchronize-arrow-clock"></i>
-                        <span style="max-width: calc(100% - 40px)">You have changed settings that require an engine restart!</span>
-                      </a>
-                    </li>
-                  </h:panelGroup>
-                  <h:panelGroup rendered="#{ivyAdvisor.releaseCandidate}">
-                    <li>
-                      <a href="#">
-                        <i class="si si-lg si-alert-circle"></i>
-                        <span style="max-width: calc(100% - 40px)">
-                          <b>Release Candidate!</b><br/>
-                          Don't use this version in production!
-                        </span>
-                      </a>
-                    </li>
-                  </h:panelGroup>
-                  <h:panelGroup rendered="#{engineModeBean.hasDashboardWarning()}">
-                    <li>
-                      <a href="setup#{engineModeBean.demo ? '-intro' : ''}.xhtml">
-                        <i class="si si-lg si-tools-wench"></i>
-                        <span style="max-width: calc(100% - 40px)">
-                          <b>#{engineModeBean.dashboardWarningSummary}</b><br/>
-                          #{engineModeBean.dashboardWarningDetail} Please use the 'Setup Wizard' to set up your Axon Ivy Engine.
-                        </span>
-                      </a>
-                    </li>
-                  </h:panelGroup>
+                  <ui:repeat var="msg" value="#{healthBean.topMessages}">
+                    <h:panelGroup>
+                      <li>
+                        <a href="#{msg.actionLink}">
+                          <i class="si si-lg #{msg.severityIcon} #{msg.severityClass}"></i>
+                          <span style="max-width: calc(100% - 40px)">
+                            <b>#{msg.message}</b><br/>
+                            #{msg.description}
+                          </span>
+                        </a>
+                      </li>
+                    </h:panelGroup>
+                  </ui:repeat>
+                  <li>
+                    <a href="monitor-health.xhtml">Show health details ...</a>
+                  </li>
                 </ul>
               </li>
             </h:outputText>
+
             <ui:insert name="topbar-items">
               <li class="topbar-item">
                 <a href="#{advisorBean.cockpitEngineGuideUrl}index.html" target="_blank" rel="noopener noreferrer">
@@ -132,6 +120,7 @@
                 </a>
               </li>
             </ui:insert>
+
             <li class="topbar-item themeswitch-item">
               <p:commandLink id="themeSwitcher" onclick="PrimeFaces.FreyaConfigurator.changeLayout('ivy', '#{ivyFreyaTheme.mode == 'light' ? 'dark' : 'light'}');"
                 style="text-decoration: none;">
@@ -139,6 +128,7 @@
                 <p:ajax onstart="PrimeFaces.FreyaConfigurator.beforeResourceChange();" listener="#{ivyFreyaTheme.toggleTheme}" update="themeSwitcher" />
               </p:commandLink>
             </li>
+
             <li class="topbar-item user-profile">
               <a href="#">
                 <span class="profile-image-wrapper">

--- a/engine-cockpit/webContent/resources/css/engine-cockpit.css
+++ b/engine-cockpit/webContent/resources/css/engine-cockpit.css
@@ -333,7 +333,9 @@ body .ui-datatable .ui-datatable-header {
 .search-machine-health-yellow,
 .licence-messages i.warning,
 .health-low,
-.health-high {
+.health-high,
+.layout-topbar-light .layout-topbar .layout-topbar-wrapper .layout-topbar-right .layout-topbar-actions > li > ul > li > a i.health-low,
+.layout-topbar-light .layout-topbar .layout-topbar-wrapper .layout-topbar-right .layout-topbar-actions > li > ul > li > a i.health-high {
   color: var(--warning-color, #ffce29);
 }
 .state-inactive,
@@ -342,7 +344,8 @@ body .ui-datatable .ui-datatable-header {
 .search-machine-health-red,
 .licence-messages i.error, 
 .thread-deadlocked,
-.health-critical {
+.health-critical,
+.layout-topbar-light .layout-topbar .layout-topbar-wrapper .layout-topbar-right .layout-topbar-actions > li > ul > li > a i.health-critical {
   color: var(--error-color, #d23636);
 }
 .unused-column {
@@ -587,4 +590,24 @@ body .migration-question-select-button > div.ui-button {
 
 body .ui-tooltip .ui-panelgrid .ui-panelgrid-cell {
   color: #EAEBEC;
+}
+
+.health-check-badge {
+  width:22px; 
+  height:20px;
+  font-weight:bold; 
+  font-size:13px; 
+  color:white;
+  position:absolute; 
+  bottom:30px; 
+  left:20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius:10px;
+  background-color:var(--ivy-primary-color);
+}
+
+.layout-topbar-light .layout-topbar .layout-topbar-wrapper .layout-topbar-right .layout-topbar-actions > li > ul {
+  min-width: 350px
 }


### PR DESCRIPTION
Show health messages as top menu item (warning icon with a badge). When you click on it the top 4 messages are shown with a link to the health view.

This replaces the dashboard warnings, release candidate warnings and restart warnings.

Add web test for the new health top menu

![grafik](https://github.com/user-attachments/assets/b068b741-b818-4680-bac8-31984bd0b8be)
