### PR TITLE
Fix tests that are broken because of a changed browser render pane size

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecurityIdentityProvider.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecurityIdentityProvider.java
@@ -196,7 +196,7 @@ class WebTestSecurityIdentityProvider {
     var property = $(By.id("identityProvider:dynamicConfigForm:group:0:property:6:propertyDropdown"))
             .shouldBe(visible)
             .shouldBe(text("DIRECT"));
-    property.click();
+    property.scrollTo().click();
     $(By.id("identityProvider:dynamicConfigForm:group:0:property:6:propertyDropdown_2")).click();
     property.shouldHave(text("TRAVERSE"));
   }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebserviceDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebserviceDetail.java
@@ -90,7 +90,7 @@ class WebTestWebserviceDetail {
   }
 
   private void resetConfiguration() {
-    $("#webserviceConfigurationForm\\:resetConfig").click();
+    $("#webserviceConfigurationForm\\:resetConfig").scrollIntoView(false).click();
     $("#webserviceConfigurationForm\\:resetWsConfirmDialog").shouldBe(visible);
     $("#webserviceConfigurationForm\\:resetWsConfirmYesBtn").click();
     $("#webserviceConfigurationForm\\:wsConfigMsg_container")

--- a/engine-cockpit/webContent/resources/composite/ConnectionTestResult.xhtml
+++ b/engine-cockpit/webContent/resources/composite/ConnectionTestResult.xhtml
@@ -20,7 +20,7 @@
         rendered="#{cc.attrs.bean.hasMissingCerts(cc.attrs.url)}">
         <jc:TlsTesterMissingCertView id="missing" bean="#{tlsTesterBean}" cert="#{cc.attrs.bean.missingCert}"></jc:TlsTesterMissingCertView>
       </h:panelGroup>
-      <h:panelGrid id="resultLog" columns="1" style="height:500px" styleClass="ui-fluid">
+      <h:panelGrid id="resultLog" columns="1" style="height:450px" styleClass="ui-fluid">
         <h:panelGroup id="resultConnect">
           <h:outputText value="#{cc.attrs.result.testResult}"
             style="font-weight: bold; color: #{cc.attrs.result.testResultColor}" />


### PR DESCRIPTION
Seems that a new version of the browser has a slightly smaller render pane, which leads to broken tests because some UI elements are only visible by some pixels but the clickable part is not. Selenide does not scroll to the UI element because it is already visible.

Add an explicit scrollTo fixes the problem.