### PR TITLE
Restyle systemdb info page

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
@@ -68,7 +68,7 @@ public class WebTestSystemDb {
   }
 
   @Test
-  void testSystemDb() {
+  void systemDb() {
     $("h2").shouldBe(text("System Database"));
     assertDefaultValues();
     assertSystemDbCreationDialog();
@@ -76,7 +76,7 @@ public class WebTestSystemDb {
   }
 
   @Test
-  void testSaveConfiguration() {
+  void saveConfiguration() {
     $(".sysdb-dynamic-form-user").sendKeys(" ");
     $(".sysdb-dynamic-form-user").clear();
     $(CONNECTION_PANEL).shouldBe(text("Connection state unknown"));
@@ -93,8 +93,8 @@ public class WebTestSystemDb {
   }
 
   @Test
-  void testSystemDbInfo() {
-    $("#systemDb\\:systemDbForm\\:infoDb").shouldBe().click();
+  void systemDbInfo() {
+    $("#infoDb").shouldBe().click();
     $("#overview").shouldBe(text("System Database"));
     $("#jdbc-driver").shouldBe(text("JDBC Driver"));
     $("#tables").shouldBe(text("Tables"));
@@ -103,22 +103,22 @@ public class WebTestSystemDb {
   }
 
   @Test
-  void testConnectionResults() {
+  void connectionResults() {
     assertConnectionResults();
   }
 
   @Test
-  void testDefaultPortSwitch() {
+  void defaultPortSwitch() {
     assertDefaultPortSwitch();
   }
 
   @Test
-  void testDatabaseDropdownSwitch() {
+  void databaseDropdownSwitch() {
     assertDatabaseTypeSwitch();
   }
 
   @Test
-  void testAdditionalProperties() {
+  void additionalProperties() {
     assertAdditionalProperties();
   }
 

--- a/engine-cockpit/webContent/includes/components/systemdb/info.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/info.xhtml
@@ -12,9 +12,9 @@
       </div>
       <p:panelGrid columns="2" columnClasses="col-12 md:col-4 lg:col-4, col-12 md:col-8 lg:col-8" layout="flex"
         styleClass="grey-label-panel ui-fluid">
-        <label>Database Product</label>
+        <label>Product</label>
         <h:outputText value="#{systemDatabaseInfoBean.systemDbDatabaseProduct}" />
-        <label>Database Version</label>
+        <label>Version</label>
         <h:outputText value="#{systemDatabaseInfoBean.systemDbDatabaseVersion}" />
         <label>Disk Size</label>  
         <h:outputText value="#{systemDatabaseInfoBean.formatByteValue(systemDbDiskSize)}"/>

--- a/engine-cockpit/webContent/includes/components/systemdb/jdbc-driver.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/jdbc-driver.xhtml
@@ -12,13 +12,13 @@
       </div>
       <p:panelGrid columns="2" columnClasses="col-12 md:col-4 lg:col-4, col-12 md:col-8 lg:col-8" layout="flex"
         styleClass="grey-label-panel ui-fluid">
-        <label>JDBC Driver Name</label>
+        <label>Name</label>
         <h:outputText value="#{systemDatabaseInfoBean.systemDbDriverName}" />
-        <label>JDBC Driver Version</label>  
+        <label>Version</label>
         <h:outputText value="#{systemDatabaseInfoBean.systemDbDriverVersion}" />
-        <label>JDBC Driver URL</label>  
+        <label>URL</label>
         <h:outputText value="#{systemDatabaseInfoBean.systemDbUrl}" />
-        <label>JDBC Driver User</label>  
+        <label>User</label>
         <h:outputText value="#{systemDatabaseInfoBean.systemDbUser}" />
       </p:panelGrid>
     </div>

--- a/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
@@ -33,8 +33,6 @@
               onstart="$('#connectionIcon').attr('class', 'si si-button-refresh-arrows si-is-spinning');" async="true"
               icon="si si-check-1" update="#{cc.attrs.updateFields}"
               actionListener="#{systemDatabaseBean.testConnection()}" />
-            <p:button outcome="systemdb-info" icon="si si-layout-dashboard" value="Check Storage and Schema"
-              style="width: 220px; margin-right:5px; background-color: #607D8B;" id="infoDb"/>
             <p:commandButton value="Create Database" id="createDatabaseButton" icon="si si-database-settings"
               styleClass="mr-1 wizard-top-button ui-button-secondary" actionListener="#{systemDatabaseBean.initCreator()}"
               update="systemDb:createDatabaseDialog" oncomplete="PF('createDatabaseDialog').show();"

--- a/engine-cockpit/webContent/view/systemdb-info.xhtml
+++ b/engine-cockpit/webContent/view/systemdb-info.xhtml
@@ -9,9 +9,7 @@
         <li>/</li>
         <li><a href="systemdb.xhtml">System Database</a></li>
         <li>/</li>
-        <li><a
-            href="systemdb-info.xhtml">System Database Info</a>
-        </li>
+        <li><a href="systemdb-info.xhtml">Info</a></li>
       </ui:define>
 
       <ui:define name="content">

--- a/engine-cockpit/webContent/view/systemdb.xhtml
+++ b/engine-cockpit/webContent/view/systemdb.xhtml
@@ -23,7 +23,9 @@
         <div class="flex align-items-center mb-3">
           <i class="pr-3 si si-database-settings card-title-icon"></i>
           <h2 class="m-0">System Database</h2>
-          <h:panelGroup id="sysDbSaveButtons" styleClass="ml-auto">
+          <p:linkButton outcome="systemdb-info" icon="si si-layout-dashboard" value="Info"
+              styleClass="ml-auto ui-button-secondary" id="infoDb"/>
+          <h:panelGroup id="sysDbSaveButtons" styleClass="ml-1">
             <p:commandButton actionListener="#{systemDatabaseBean.saveConfiguration}" value="Save"
               icon="si si-floppy-disk" style="width: auto; float: right;" id="saveSystemDbConfig"
               rendered="#{systemDatabaseBean.connectionInfo.successful}" />


### PR DESCRIPTION
- Remove redundant info (like JDBC Driver, Database)
- Move link to info page to the top beside save button (otherwise it will also be visible on the setup wizard