### PR TITLE
Small info page UI improvements

### DIFF
--- a/engine-cockpit/webContent/includes/template/info-template.xhtml
+++ b/engine-cockpit/webContent/includes/template/info-template.xhtml
@@ -56,7 +56,7 @@
     body {
       height: 100%;
     }
-    .active-nav-page {
+    .active-nav-page > a {
       background-color: var(--primary-lighter-color);
     }
     @media (min-width: 1025px) {

--- a/engine-cockpit/webContent/view/info.xhtml
+++ b/engine-cockpit/webContent/view/info.xhtml
@@ -119,9 +119,7 @@
                   <i class="si si-module icon-app" />
                 </div>
                 <div class="flex flex-1 justify-content-end">
-                  <p:link href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}">
-                    <i class="si si-cog-play icon-dev" />
-                  </p:link>
+                  <p:linkButton href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}" icon="si si-cog-play" styleClass="col-fixed ml-auto rounded-button ui-button-outlined" />
                 </div>
               </div>
               <div>
@@ -168,10 +166,6 @@
           .icon-app {
             font-size: 42px;
             color: var(--ivy-primary-color);
-          }
-          
-          .icon-dev {
-            font-size: 18px;
           }
           
           .layout-content .message-block {


### PR DESCRIPTION
*Rounded corners for active nav element*
Before
![image](https://github.com/user-attachments/assets/96283d88-e98d-46dc-a4ff-0748bbc039d1)

After
![image](https://github.com/user-attachments/assets/a3af2603-51c5-43de-bfd4-ea6eeba342af)


*Button instead of link for dev-wf-ui*
Before
![Screenshot 2024-10-08 at 08 32 51](https://github.com/user-attachments/assets/d88545e2-00f7-465f-ba29-a3be0826868f)

After
![image](https://github.com/user-attachments/assets/5fc1937f-e1c3-4eaa-94c4-7118e338e900)
