### PR TITLE
XIVY-15578 No longer show external name if we are in a ivy security system

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
@@ -32,6 +32,7 @@ public class User implements SecurityMember {
   private Locale language;
   private Locale formattingLanguage;
   private String securityContext;
+  private boolean isIvySecuritySystem;
   private List<Substitute> substitutes;
   private List<Absence> absences;
 
@@ -58,6 +59,7 @@ public class User implements SecurityMember {
     this.formattingLanguage = user.getFormattingLanguage();
     this.securityContext = user.getSecurityContext().getName();
     this.working = !user.isAbsent();
+    this.isIvySecuritySystem = SecuritySystem.isIvySecuritySystem(user.getSecurityContext());
     this.substitutes = substitutesOf(user);
     this.absences = absencesOf(user);
   }
@@ -68,6 +70,7 @@ public class User implements SecurityMember {
     setEmail(admin.getEmail());
     setRealPassword(admin.getPassword());
     setSecurityContext(ISecurityContext.SYSTEM);
+    this.isIvySecuritySystem = true;
     this.gravatarHash = EmailUtil.gravatarHash(admin.getEmail());
   }
 
@@ -227,6 +230,10 @@ public class User implements SecurityMember {
 
   public List<Absence> getAbsences() {
     return absences;
+  }
+  
+  public boolean isIvySecuritySystem() {
+    return isIvySecuritySystem;
   }
 
   private List<Substitute> substitutesOf(IUser user) {

--- a/engine-cockpit/webContent/includes/components/security/users-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/users-table.xhtml
@@ -41,7 +41,7 @@
           </h:panelGroup>
         </h:outputText>
         <h:outputText value="[External: '#{user.externalNameShort}']" title="#{user.externalName}"
-          rendered="#{user.external}" styleClass="ml-1 addition-row-info table-cell-autocut" />
+          rendered="#{user.external and !user.ivySecuritySystem}" styleClass="ml-1 addition-row-info table-cell-autocut" />
         <h:outputText value="[Disabled]" rendered="#{!user.enabled}" styleClass="ml-1 addition-row-info table-cell-autocut" />
       </a>
     </p:column>


### PR DESCRIPTION
Do we really need this information here, or can we show it somehow different? Because the external name is more optional than the external id.

This solution is at least a quick fix and the implementation is now the same as on the user detail page.

More information here.
https://1ivy.atlassian.net/browse/XIVY-15578