### PR TITLE
Fix connection test styles

### DIFF
--- a/engine-cockpit/webContent/resources/composite/ConnectionTestResult.xhtml
+++ b/engine-cockpit/webContent/resources/composite/ConnectionTestResult.xhtml
@@ -16,21 +16,19 @@
     widgetVar="connectionTestModel" modal="true" responsive="false" closeOnEscape="true" >
     <p:staticMessage rendered="#{cc.attrs.saveHint}" severity="info" summary="Info" detail="Make sure that you saved your changes before you test the connection." />
     <h:form id="connTestForm" styleClass="custom-dialog-form">
-      <h:panelGroup style="height:150px" id="missingCertView" 
-        rendered="#{cc.attrs.bean.hasMissingCerts(cc.attrs.url)}">
-        <jc:TlsTesterMissingCertView id="missing" bean="#{tlsTesterBean}" cert="#{cc.attrs.bean.missingCert}"></jc:TlsTesterMissingCertView>
+      <h:panelGroup style="height:150px" id="missingCertView" rendered="#{cc.attrs.bean.hasMissingCerts(cc.attrs.url)}">
+        <jc:TlsTesterMissingCertView id="missing" bean="#{tlsTesterBean}" cert="#{cc.attrs.bean.missingCert}" />
       </h:panelGroup>
-      <h:panelGrid id="resultLog" columns="1" style="height:450px" styleClass="ui-fluid">
-        <h:panelGroup id="resultConnect">
+      <div style="height:450px;">
+        <h:panelGroup id="resultConnect" layout="block" rendered="#{not empty cc.attrs.result.message}" style="height: 100%;">
           <h:outputText value="#{cc.attrs.result.testResult}"
             style="font-weight: bold; color: #{cc.attrs.result.testResultColor}" />
-          <pre style="max-height: 200px; overflow: auto; margin: 0;">#{cc.attrs.result.message}</pre>
+          <pre style="height: 100%; overflow: auto; margin: 0;">#{cc.attrs.result.message}</pre>
         </h:panelGroup>
-        <h:panelGroup id="resultTLS" styleClass="ui-fluid"
-          rendered="#{tlsTesterBean.tlsTestRendered}">
+        <h:panelGroup id="resultTLS" layout="block" styleClass="ui-fluid" rendered="#{tlsTesterBean.tlsTestRendered}" style="height: 100%;">
           <jc:TlsTester url="#{cc.attrs.url}" />
         </h:panelGroup>
-      </h:panelGrid>
+      </div>
       <div class="custom-dialog-footer">
         <p:commandButton id="closeConTesterDialog" onclick="PF('connectionTestModel').hide(); #{cc.attrs.reset};" 
            value="Close" type="button" update="connTestForm"

--- a/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
+++ b/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
@@ -9,53 +9,50 @@
   <cc:attribute name="url" />
 </cc:interface>
 <cc:implementation>
-  <h:form id="tlsTestForm">
-    <p:growl id="addMissingCertSuccess"
-      for="addMissingCertSuccess">
-      <p:autoUpdate />
-    </p:growl>
-    <p:dataTable value="#{tlsTesterBean.testResult}" var="logEntry"
-      rowKey="#{logEntry.result}"
-      id="logList" lazy="false" scrollable="true" scrollWidth="100%" scrollHeight="100%">
-      <p:column width="1.5em"
+  <p:growl id="addMissingCertSuccess" for="addMissingCertSuccess">
+    <p:autoUpdate />
+  </p:growl>
+  <p:dataTable value="#{tlsTesterBean.testResult}" var="logEntry"
+    rowKey="#{logEntry.result}" styleClass="tls-tester-table"
+    id="logList" lazy="false" scrollable="true" scrollWidth="100%" scrollHeight="100%">
+    <p:column width="2rem"
+    styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
+      <p:rowToggler rendered="#{tlsTesterBean.isExecuted(logEntry.result)}"/>
+    </p:column>
+    <p:column headerText="Tests" 
       styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
-        <p:rowToggler rendered="#{tlsTesterBean.isExecuted(logEntry.result)}"/>
-      </p:column>
-      <p:column headerText="Tests" 
-        styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
-        <h:outputText value="#{logEntry.group}"></h:outputText>
-        <h:panelGroup id="info">
-          <i class="si si-question-circle"></i>
-          <p:tooltip for="info" value="#{logEntry.groupInfo}" />
-        </h:panelGroup>
-      </p:column>
-      <p:column width="5em" styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
-        <h:outputText class="si table-icon si-#{tlsTesterBean.icon(logEntry.result)}"/>
-      </p:column>
-      <p:rowExpansion>
-        <p:dataTable var="logDataEntry" styleClass="noHeader" value="#{logEntry.entryList}"
-          id="taskTable" rowKey="#{logEntry.entryList}">
-          <p:column style="border:0px;" width="1em">
-            <h:outputText value="#{logDataEntry}" />
-            <h:panelGroup id="infos" rendered="#{tlsTesterBean.hasExtendedInformations(logDataEntry)}">
-              <i class="si si-question-circle"></i>
-              <p:tooltip for="infos" escape="false"
-                value="#{tlsTesterBean.getExtendedInformations(logDataEntry)}" />
-            </h:panelGroup>
-          </p:column>
-        </p:dataTable>
-      </p:rowExpansion>
-    </p:dataTable>
-  </h:form>
-    <style>
-    .noHeader.ui-datatable table thead tr {
+      <h:outputText value="#{logEntry.group}"></h:outputText>
+      <h:panelGroup id="info">
+        <i class="si si-question-circle"></i>
+        <p:tooltip for="info" value="#{logEntry.groupInfo}" />
+      </h:panelGroup>
+    </p:column>
+    <p:column width="2rem" styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
+      <h:outputText class="si table-icon si-#{tlsTesterBean.icon(logEntry.result)}"/>
+    </p:column>
+    <p:rowExpansion>
+      <p:dataTable var="logDataEntry" styleClass="noHeader" value="#{logEntry.entryList}"
+        id="taskTable" rowKey="#{logEntry.entryList}">
+        <p:column style="border:0px;" width="1em">
+          <h:outputText value="#{logDataEntry}" />
+          <h:panelGroup id="infos" rendered="#{tlsTesterBean.hasExtendedInformations(logDataEntry)}">
+            <i class="si si-question-circle"></i>
+            <p:tooltip for="infos" escape="false"
+              value="#{tlsTesterBean.getExtendedInformations(logDataEntry)}" />
+          </h:panelGroup>
+        </p:column>
+      </p:dataTable>
+    </p:rowExpansion>
+  </p:dataTable>
+  <style>
+  .tls-tester-table.ui-datatable {
+    .noHeader thead {
       display: none;
     }
-    body .ui-datatable .ui-datatable-data > tr > td {
-      padding-top: 0.2rem;
-      padding-left: 1.5rem;
-      padding-bottom: 0.2rem;
+    .ui-datatable-data > tr > td {
+      padding-block: 0.2rem;
     }
-    </style>
+  }
+  </style>
 </cc:implementation>
 </html>


### PR DESCRIPTION
Just found this little issue. Do we expect some problems with this changes?

Fixed:
- Log message is centered in dialog
- Log message scroll full height
- Tls tester expandrow icon is cut
- It seems that connection tester and tls tester both have a from, form in form is normally not good...

Before:
![Screen Recording 2024-12-03 at 10 42 35](https://github.com/user-attachments/assets/ea7ee80f-dde8-4cf4-b6c7-9c0931100734)

After:
![Screen Recording 2024-12-03 at 10 41 00](https://github.com/user-attachments/assets/aa2eaa10-dbc7-40d8-a8ec-330acc75c42a)
