### PR TITLE
Format and Clean up Java source code as defined in ADR-029

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestCockpitLinkFactory.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestCockpitLinkFactory.java
@@ -35,7 +35,7 @@ public class WebTestCockpitLinkFactory {
   void beforeEach() {
     login();
   }
-  
+
   @TestFactory
   Collection<DynamicTest> link() {
     open(EngineCockpitUtil.testViewUrl("link-factory.xhtml"));
@@ -45,11 +45,11 @@ public class WebTestCockpitLinkFactory {
     for (var link : links.asDynamicIterable()) {
       var url = link.attr("href");
       var name = link.text();
-      tests.add(DynamicTest.dynamicTest(name, () -> link(url))); 
+      tests.add(DynamicTest.dynamicTest(name, () -> link(url)));
     }
     return tests;
   }
-    
+
   private void link(String url) {
     var link = linkFor(url);
     link.click();
@@ -78,14 +78,14 @@ public class WebTestCockpitLinkFactory {
     var links = $$(".ui-link");
     links.shouldHave(CollectionCondition.sizeGreaterThanOrEqual(7));
   }
-  
+
   private ObjectCondition<WebDriver> titles(String... titles) {
     return new Titles(titles);
   }
 
   private static final class Titles implements ObjectCondition<WebDriver> {
 
-    private List<String> expectedTitles;
+    private final List<String> expectedTitles;
 
     public Titles(String[] expectedTitles) {
       this.expectedTitles = List.of(expectedTitles);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestDownload.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestDownload.java
@@ -84,8 +84,8 @@ class WebTestDownload {
     Navigation.toLogs();
     var options = DownloadOptions.file().withTimeout(TIMEOUT).withFilter(FileFilters.withName("ivy.log"));
     var download = $(By.id("logView:fileForm:downloadLog"))
-            .shouldBe(visible)
-            .download(options);
+        .shouldBe(visible)
+        .download(options);
     assertThat(download.getName()).isEqualTo("ivy.log");
     assertThat(download).isNotEmpty();
   }
@@ -97,7 +97,7 @@ class WebTestDownload {
     var appName = Tab.APP.getSelectedTab();
     $(By.id("downloadAllResources")).shouldBe(visible).click();
     $(By.id("downloadDialog:downloadModal")).shouldBe(visible)
-            .shouldHave(text("Download Branding resources of '" + appName + "'"));
+        .shouldHave(text("Download Branding resources of '" + appName + "'"));
     var options = DownloadOptions.file().withTimeout(TIMEOUT).withFilter(FileFilters.withName("branding-" + appName + ".zip"));
     var download = $(By.id("downloadDialog:downloadForm:downloadBtn")).shouldBe(visible).download(options);
     assertThat(download.getName()).isEqualTo("branding-" + appName + ".zip");
@@ -108,7 +108,7 @@ class WebTestDownload {
     Tab.APP.switchToTab("test-ad");
     $(By.id("downloadAllResources")).shouldBe(visible).click();
     $(By.id("downloadDialog:downloadModal")).shouldBe(visible)
-            .shouldHave(text("Download Branding resources of 'test-ad'"));
+        .shouldHave(text("Download Branding resources of 'test-ad'"));
     options = DownloadOptions.file().withTimeout(TIMEOUT);
     $(By.id("downloadDialog:downloadForm:downloadBtn")).shouldBe(visible).download(options);
     $(By.id("msgs_container")).shouldHave(text("No branding resources found for app 'test-ad'"));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestHealthWarning.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestHealthWarning.java
@@ -27,11 +27,11 @@ class WebTestHealthWarning {
     $(By.id("health-check-badge")).shouldHave(matchText("\\d{1}"));
     var health = $(".health-messages");
     health.shouldBe(visible).click();
-    var messages= health.$$("li");
+    var messages = health.$$("li");
     messages.shouldHave(
-            anyMatch("message contains", e -> e.getText().contains("Release Candidate")),
-            anyMatch("message contains", e -> e.getText().contains("Demo Mode")),
-            anyMatch("message contains", e -> e.getText().contains("Show health details")));
+        anyMatch("message contains", e -> e.getText().contains("Release Candidate")),
+        anyMatch("message contains", e -> e.getText().contains("Demo Mode")),
+        anyMatch("message contains", e -> e.getText().contains("Show health details")));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestPages.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/WebTestPages.java
@@ -49,7 +49,7 @@ class WebTestPages {
       var url = viewUrl(xhtml.toString());
       if (url.contains("composite") || url.contains("demo-jsfcomponents")) {
         // better skipping this one. otherwise the ivy.log is full of NPEs
-        //$(".exception-content").shouldHave(text("Null Pointer"));
+        // $(".exception-content").shouldHave(text("Null Pointer"));
       } else {
         System.out.println(url);
         open(url);
@@ -66,10 +66,10 @@ class WebTestPages {
   private static List<Path> getSubDirectoryXhtmlFiles(Path basePath, Predicate<Path> filter) {
     try {
       return Files.walk(basePath)
-              .map(basePath::relativize)
-              .filter(filter)
-              .filter(file -> StringUtils.endsWith(file.getFileName().toString(), ".xhtml"))
-              .collect(Collectors.toList());
+          .map(basePath::relativize)
+          .filter(filter)
+          .filter(file -> StringUtils.endsWith(file.getFileName().toString(), ".xhtml"))
+          .collect(Collectors.toList());
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
@@ -61,7 +61,7 @@ class WebTestApplication {
     $$(".activity-name").shouldBe(size(appCount + 1));
     addNewApplication();
     $("#form\\:applicationMessage_container .ui-growl-message")
-            .shouldHave(text("Application with name '" + NEW_TEST_APP + "' already exists"));
+        .shouldHave(text("Application with name '" + NEW_TEST_APP + "' already exists"));
 
     By newApp = getNewAppId();
     startApplication(newApp);
@@ -99,33 +99,33 @@ class WebTestApplication {
     var app = $$(".activity-name").find(text(appName)).parent().parent().parent();
     var pm = $$(".activity-name").find(text("engine-cockpit-test-data")).parent().parent();
     app.find(".module-state").shouldBe(attribute("title", "ACTIVE"))
-            .findAll("i").shouldHave(size(1));
+        .findAll("i").shouldHave(size(1));
     pm.find("button", 1).click();
     pm.find(".module-state").shouldBe(attribute("title", "INACTIVE"))
-            .findAll("i").shouldHave(size(1));
+        .findAll("i").shouldHave(size(1));
     app.find(".module-state").shouldBe(attribute("title", "ACTIVE\n" +
-            "engine-cockpit-test-data: INACTIVE\n" +
-            "engine-cockpit-test-data$1: INACTIVE"))
-            .findAll("i").shouldHave(size(2));
+        "engine-cockpit-test-data: INACTIVE\n" +
+        "engine-cockpit-test-data$1: INACTIVE"))
+        .findAll("i").shouldHave(size(2));
 
     pm.find("button", 0).click();
     pm.find(".module-state").shouldBe(attribute("title", "ACTIVE"))
-            .findAll("i").shouldHave(size(1));
+        .findAll("i").shouldHave(size(1));
     app.find(".module-state").shouldBe(attribute("title", "ACTIVE"))
-            .findAll("i").shouldHave(size(1));
+        .findAll("i").shouldHave(size(1));
   }
 
   @Test
   void showOverrideProjectIconInTree() {
     expandAppTree();
-    //project of app test has override configured
+    // project of app test has override configured
     $$(".activity-name").find(exactText("portal-components")).parent().find(".table-icon")
-            .shouldHave(cssClass("si-move-to-bottom"))
-            .shouldHave(attribute("title", "This PM is configured as strict override project"));
-    //project of app test-ad has no override configured
+        .shouldHave(cssClass("si-move-to-bottom"))
+        .shouldHave(attribute("title", "This PM is configured as strict override project"));
+    // project of app test-ad has no override configured
     $$(".activity-name").find(exactText("portal-user-examples")).parent().find(".table-icon")
-            .shouldHave(cssClass("si-module-three-2"))
-            .shouldHave(attribute("title", "PM"));
+        .shouldHave(cssClass("si-module-three-2"))
+        .shouldHave(attribute("title", "PM"));
   }
 
   @Test
@@ -173,11 +173,11 @@ class WebTestApplication {
   void notDeletableMessage() {
     expandAppTree();
     $$("#form:tree:0:deleteBtn").get(1)
-            .shouldHave(attribute("title", "App 'designer' can not be deleted"));
+        .shouldHave(attribute("title", "App 'designer' can not be deleted"));
     $$("#form:tree:0_0:deleteBtn").get(1)
-            .shouldHave(attribute("title", "'dev-workflow-ui' is required by 'dev-workflow-ui-web-test', 'dev-workflow-ui-test'"));
+        .shouldHave(attribute("title", "'dev-workflow-ui' is required by 'dev-workflow-ui-web-test', 'dev-workflow-ui-test'"));
     $$("#form:tree:0_0_0:deleteBtn").get(2)
-            .shouldHave(attribute("title", "Is required by 'dev-workflow-ui-web-test', 'dev-workflow-ui-test'\nIs in state RELEASED but must be one of [CREATED, PREPARED, ARCHIVED]"));
+        .shouldHave(attribute("title", "Is required by 'dev-workflow-ui-web-test', 'dev-workflow-ui-test'\nIs in state RELEASED but must be one of [CREATED, PREPARED, ARCHIVED]"));
   }
 
   private void filter(String search) {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplicationDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplicationDetail.java
@@ -81,11 +81,11 @@ class WebTestApplicationDetail {
     $("#appDetailSecurityForm\\:synchronizeSecurity").shouldBe(visible, enabled).click();
     $$("#appDetailSecurityForm\\:synchronizeSecurity span").first().shouldHave(cssClass("si-is-spinning"));
     $$("#appDetailSecurityForm\\:synchronizeSecurity span").first()
-            .shouldHave(not(cssClass("si-is-spinning")), Duration.ofSeconds(20));
+        .shouldHave(not(cssClass("si-is-spinning")), Duration.ofSeconds(20));
 
     $("#appDetailSecurityForm\\:showAdSyncLogBtn").click();
     $$(".ui-panel-titlebar").find(text("usersynch.log")).parent()
-            .find(".ui-panel-content").shouldBe(visible);
+        .find(".ui-panel-content").shouldBe(visible);
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestPmvDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestPmvDetail.java
@@ -55,7 +55,7 @@ class WebTestPmvDetail {
   private void deactivatePortalComponent() {
     $(By.id("form:expandAll")).shouldBe(visible).click();
     var portalComponentVersionId = "form:tree:" + $$(".activity-name").find(exactText("core$1")).parent()
-            .parent().parent().shouldBe(visible).attr("data-rk");
+        .parent().parent().shouldBe(visible).attr("data-rk");
     $(By.id(portalComponentVersionId + ":deactivateButton")).shouldBe(visible).click();
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestBusinessCalendar.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestBusinessCalendar.java
@@ -39,11 +39,11 @@ public class WebTestBusinessCalendar {
     $$(".business-calendar-box").shouldHave(size(7)).first().shouldHave(text("Monday"));
     $$(".business-calendar-box .free").shouldHave(texts("Saturday", "Sunday"));
     $("#workingTimeTable").shouldHave(
-            text("morning"), text("08:00:00 - 12:00:00"),
-            text("afternoon"), text("13:00:00 - 17:00:00"));
+        text("morning"), text("08:00:00 - 12:00:00"),
+        text("afternoon"), text("13:00:00 - 17:00:00"));
     $("#freeDaysTable").shouldHave(
-            text("Christmas Day"), text("12-25"),
-            text("Ascension Day"), text("easter + 39"));
+        text("Christmas Day"), text("12-25"),
+        text("Ascension Day"), text("easter + 39"));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestConfiguration.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestConfiguration.java
@@ -130,7 +130,7 @@ class WebTestConfiguration {
 
       table.clickButtonForEntry(config, "editConfigBtn");
       PrimeUi.selectOne(By.id("config:editConfigurationForm:editConfigurationValue"))
-              .selectItemByLabel("SSL");
+          .selectItemByLabel("SSL");
       $("#config\\:editConfigurationForm\\:saveEditConfiguration").click();
       table.row(config).shouldNotHave(cssClass("default-value"));
 
@@ -138,7 +138,7 @@ class WebTestConfiguration {
       table.firstColumnShouldBe(itemWithText(config));
       assertResetConfig(config);
       table.firstColumnShouldBe(noneMatch("Config no longer listed under defined values",
-              e -> e.getText().equals(config)));
+          e -> e.getText().equals(config)));
     }
 
     @Test
@@ -166,18 +166,18 @@ class WebTestConfiguration {
     void restartHint() {
       var config = "Connector.HTTP.Address";
       assertEditConfig(config, "", "hi", "For servers with more than one IP address");
-      Selenide.sleep(100); //restart will be evaluated by async file watcher
+      Selenide.sleep(100); // restart will be evaluated by async file watcher
       refresh();
       table.valueForEntryShould(config, 2, exactText("hi"));
       var health = $(".health-messages");
       Selenide.Wait()
-        .withTimeout(Duration.ofSeconds(5))
-        .ignoring(AssertionError.class)
-        .until(webDriver -> {
-          health.find("a").click();
-          Selenide.sleep(10);
-          return health.attr("class").contains("active-topmenuitem");
-        });
+          .withTimeout(Duration.ofSeconds(5))
+          .ignoring(AssertionError.class)
+          .until(webDriver -> {
+            health.find("a").click();
+            Selenide.sleep(10);
+            return health.attr("class").contains("active-topmenuitem");
+          });
       health.$$("li").shouldHave(anyMatch("message contains", e -> e.getText().contains("Restart is required")));
       assertResetConfig(config);
     }
@@ -234,12 +234,12 @@ class WebTestConfiguration {
 
     private void assertShowAppConfigFilter(String filter, String config) {
       table.firstColumnShouldBe(noneMatch("Config should not be listed in the config table per default: " + config,
-              element -> StringUtils.equals(element.getText(), config)));
+          element -> StringUtils.equals(element.getText(), config)));
       toggleFilter(List.of(filter));
       table.firstColumnShouldBe(itemWithText(config));
       resetContentFilter();
       table.firstColumnShouldBe(noneMatch("Config should not be listed in the config table after reset filter: " + config,
-              element -> StringUtils.equals(element.getText(), config)));
+          element -> StringUtils.equals(element.getText(), config)));
     }
 
     @Test
@@ -248,8 +248,8 @@ class WebTestConfiguration {
       var dynamic = "RestClients.second-rest.Properties.appKey";
       table.clickButtonForEntry(dynamic, "editConfigBtn");
       new ConfigAssert("config")
-              .assertDefault("${ivy.var.password}")
-              .assertValue("${ivy.var.password}");
+          .assertDefault("${ivy.var.password}")
+          .assertValue("${ivy.var.password}");
     }
 
     @Test
@@ -265,7 +265,7 @@ class WebTestConfiguration {
       table.clickButtonForEntry(config, "editConfigBtn");
       assertThatConfigEditModalIsVisible(config, " ", "Defines a project containing overriding SubProcesses", "");
       $(By.id("config:editConfigurationForm:editConfigurationValue"))
-              .shouldHave(cssClass("ui-selectonemenu"));
+          .shouldHave(cssClass("ui-selectonemenu"));
     }
   }
 
@@ -344,17 +344,17 @@ class WebTestConfiguration {
   }
 
   private void assertThatConfigEditModalIsVisible(String key, String value, String desc,
-          String defaultValue) {
+      String defaultValue) {
     assertThatConfigEditModalIsVisible("config", key, value, desc, defaultValue);
   }
 
   public static void assertThatConfigEditModalIsVisible(String idPrefix, String key, String value,
-          String desc, String defaultValue) {
+      String desc, String defaultValue) {
     new ConfigAssert(idPrefix)
-            .assertKey(key)
-            .assertDesc(desc)
-            .assertDefault(defaultValue)
-            .assertValue(value);
+        .assertKey(key)
+        .assertDesc(desc)
+        .assertDefault(defaultValue)
+        .assertValue(value);
   }
 
   private void resetContentFilter() {
@@ -385,7 +385,7 @@ class WebTestConfiguration {
         $(By.id(idPrefix + ":editConfigurationForm:editConfigurationDefaultValue")).shouldNot(exist);
       } else {
         $(By.id(idPrefix + ":editConfigurationForm:editConfigurationDefaultValue"))
-                .shouldBe(exactText(defaultValue));
+            .shouldBe(exactText(defaultValue));
       }
       return this;
     }
@@ -404,10 +404,10 @@ class WebTestConfiguration {
       String classAttr = configValue.getAttribute("class");
       if (StringUtils.contains(classAttr, "ui-chkbox")) {
         PrimeUi.selectBooleanCheckbox(By.id(idPrefix + ":editConfigurationForm:editConfigurationValue"))
-                .shouldBeChecked(Boolean.valueOf(value));
+            .shouldBeChecked(Boolean.parseBoolean(value));
       } else if (StringUtils.contains(classAttr, "ui-inputnumber")) {
         $(By.id(idPrefix + ":editConfigurationForm:editConfigurationValue_input"))
-                .shouldBe(exactValue(value));
+            .shouldBe(exactValue(value));
       } else if (StringUtils.contains(classAttr, "ui-selectonemenu")) {
         SelectOneMenu menu = PrimeUi.selectOne(By.id(idPrefix + ":editConfigurationForm:editConfigurationValue"));
         menu.selectedItemShould(exactText(value));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestVariables.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/configuration/WebTestVariables.java
@@ -34,7 +34,7 @@ public class WebTestVariables {
   void testInitialVariables() {
     var table = variableTable();
     table.firstColumnShouldBe(textsInAnyOrder("boolean", "daytime", "enum", "globVar", "number", "password",
-            "PORTAL_DASHBOARD", "variable"));
+        "PORTAL_DASHBOARD", "variable"));
     assertVariable("globVar", "data", true);
     assertVariable("variable", "hello", true);
   }
@@ -93,13 +93,13 @@ public class WebTestVariables {
     variableTable().clickButtonForEntry(config, "editConfigBtn");
     String onelineJson = "{ \"name\": \"this is a json file\" }";
     String editJson = "{\n"
-            + "  \"name\": \"this is a json file\"\n"
-            + "}";
+        + "  \"name\": \"this is a json file\"\n"
+        + "}";
     assertConfig()
-            .assertKey(config)
-            .assertDesc("Default Dashboard")
-            .assertValue(editJson)
-            .assertDefault(onelineJson);
+        .assertKey(config)
+        .assertDesc("Default Dashboard")
+        .assertValue(editJson)
+        .assertDefault(onelineJson);
   }
 
   @Test
@@ -138,9 +138,9 @@ public class WebTestVariables {
       return;
     }
     $(By.id(activeTabPanel() + "config:editConfigurationForm:editConfigurationKey"))
-            .shouldBe(exactText(name));
+        .shouldBe(exactText(name));
     $(By.id(activeTabPanel() + "config:editConfigurationForm:editConfigurationValue"))
-            .shouldBe(exactValue(oldValue));
+        .shouldBe(exactValue(oldValue));
   }
 
   private void assertVariable(String name, String value, boolean isDefault) {
@@ -156,10 +156,10 @@ public class WebTestVariables {
 
   private void assertThatConfigEditModalIsVisible(String config, String value, String desc) {
     assertConfig()
-            .assertKey(config)
-            .assertDesc(desc)
-            .assertValue(value)
-            .assertDefault(value);
+        .assertKey(config)
+        .assertDesc(desc)
+        .assertValue(value)
+        .assertDefault(value);
   }
 
   private ConfigAssert assertConfig() {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/docu/WebDocuScreenshot.java
@@ -197,11 +197,11 @@ class WebDocuScreenshot {
     takeScreenshot("configuration-businesscalendar", new Dimension(SCREENSHOT_WIDTH, 500));
     Navigation.toBusinessCalendarDetail("Luzern");
     takeScreenshot("configuration-businesscalendar-detail",
-            new Dimension(SCREENSHOT_WIDTH, 550));
+        new Dimension(SCREENSHOT_WIDTH, 550));
     Navigation.toBranding();
     takeScreenshot("branding", new Dimension(SCREENSHOT_WIDTH, 800));
     takeDialogScreenshot("branding-custom-css",
-            By.id("apps:applicationTabView:" + Tab.APP.getSelectedTabIndex() + ":form:editCustomCssBtn"));
+        By.id("apps:applicationTabView:" + Tab.APP.getSelectedTabIndex() + ":form:editCustomCssBtn"));
   }
 
   @Test
@@ -214,7 +214,7 @@ class WebDocuScreenshot {
     Navigation.toSecuritySystemProvider("test-ad");
     takeScreenshot("security-system-ldap", new Dimension(SCREENSHOT_WIDTH, 900));
     takeDialogScreenshot("dialog-ldap-browser",
-            By.id("identityProvider:dynamicConfigForm:group:1:property:0:browseDirectory"));
+        By.id("identityProvider:dynamicConfigForm:group:1:property:0:browseDirectory"));
     Navigation.toUsers();
     Tab.SECURITY_SYSTEM.switchToDefault();
     takeScreenshot("users", new Dimension(SCREENSHOT_WIDTH, 600));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/fileupload/WebTestDeployment.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/fileupload/WebTestDeployment.java
@@ -92,11 +92,11 @@ class WebTestDeployment {
     var targetDir = Path.of(System.getProperty("basedir")).getParent().resolve("engine-cockpit-test-data").resolve("target");
     try (var walker = Files.walk(targetDir, 1)) {
       return walker.filter(Files::isRegularFile)
-              .filter(f -> {
-                var fileName = f.getFileName().toString();
-                return fileName.startsWith("engine-cockpit-test-data-") && fileName.endsWith(".iar");
-              })
-              .findFirst().orElseThrow();
+          .filter(f -> {
+            var fileName = f.getFileName().toString();
+            return fileName.startsWith("engine-cockpit-test-data-") && fileName.endsWith(".iar");
+          })
+          .findFirst().orElseThrow();
     } catch (IOException | NoSuchElementException ex) {
       throw new RuntimeException("Couldn't find the engine-cockpit-test-data.iar project", ex);
     }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestClassHistogram.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestClassHistogram.java
@@ -40,7 +40,7 @@ public class WebTestClassHistogram {
 
   @Test
   void view() {
-    if (! classTable.body().text().contains("Press refresh")) {
+    if (!classTable.body().text().contains("Press refresh")) {
       clear();
       Navigation.toClassHistogram();
     }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestHealth.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestHealth.java
@@ -30,8 +30,8 @@ public class WebTestHealth {
     messagesTable = new Table(By.id("form:messagesTable"));
     messagesTable.rows().shouldHave(sizeGreaterThanOrEqual(2));
     messagesTable.rows().shouldHave(
-            anyMatch("row contains", e -> e.getText().contains("HIGH Release Candidate Don't use this version in production it is a release candidate Release Candidate")),
-            anyMatch("row contains", e -> e.getText().contains("LOW Demo Mode No or invalid license installed.")));
+        anyMatch("row contains", e -> e.getText().contains("HIGH Release Candidate Don't use this version in production it is a release candidate Release Candidate")),
+        anyMatch("row contains", e -> e.getText().contains("LOW Demo Mode No or invalid license installed.")));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestHealthCheck.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestHealthCheck.java
@@ -33,9 +33,9 @@ public class WebTestHealthCheck {
     checksTable = new Table(By.id("form:checkTable"));
     checksTable.rows().shouldHave(sizeGreaterThanOrEqual(3));
     checksTable.rows().shouldHave(
-            anyMatch("row contains", e -> e.getText().contains("HIGH Release Candidate Checks if this is a release candidate version n.a. (n.a.)")),
-            anyMatch("row contains", e -> e.getText().contains("LOW Engine Mode Checks if the engine is running in Demo or Maintenance mode n.a. (n.a.)")),
-            anyMatch("row contains", e -> e.getText().contains("HEALTHY High Memory Usage Checks if memory usage was higher than 90% during the last 10 minutes n.a. (n.a.)")));
+        anyMatch("row contains", e -> e.getText().contains("HIGH Release Candidate Checks if this is a release candidate version n.a. (n.a.)")),
+        anyMatch("row contains", e -> e.getText().contains("LOW Engine Mode Checks if the engine is running in Demo or Maintenance mode n.a. (n.a.)")),
+        anyMatch("row contains", e -> e.getText().contains("HEALTHY High Memory Usage Checks if memory usage was higher than 90% during the last 10 minutes n.a. (n.a.)")));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestIntermediateEvents.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestIntermediateEvents.java
@@ -104,7 +104,7 @@ class WebTestIntermediateEvents {
     $(By.id("form:beanTable:0:start")).shouldBe(disabled);
     $(By.id("form:beanTable:0:stop")).shouldBe(enabled);
   }
-  
+
   @Test
   void details_threads() {
     navigateToDetails("188B95440FE25CA6-f6");
@@ -114,7 +114,7 @@ class WebTestIntermediateEvents {
   }
 
   private void navigateToDetails(String element) {
-    element = EngineCockpitUtil.getAppName()+"/engine-cockpit-test-data$1/"+element;
+    element = EngineCockpitUtil.getAppName() + "/engine-cockpit-test-data$1/" + element;
     $(By.id("form:beanTable:globalFilter")).sendKeys(element);
     table.rows().shouldHave(CollectionCondition.size(1));
     table.tableEntry(1, 1).shouldBe(visible, enabled).find(By.tagName("a")).click();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJobs.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJobs.java
@@ -38,7 +38,7 @@ class WebTestJobs {
   private static final String DATE_TIME_STR = "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}";
   private static final String CRON = "(([0-9][0-9]?|\\*|\\?)\\s){5}";
   private static final Pattern NEXT_EXECUTION = Pattern.compile(DURATION_STR + "\\s" + "\\(" + DATE_TIME_STR + "\\)");
-  private static final Pattern CONFIGURATION = Pattern.compile("("+DURATION_STR+"\\s|"+CRON+")\\(.*\\)");
+  private static final Pattern CONFIGURATION = Pattern.compile("(" + DURATION_STR + "\\s|" + CRON + ")\\(.*\\)");
 
   private static final By TABLE_ID = By.id("form:jobTable");
   private Table table;
@@ -125,7 +125,7 @@ class WebTestJobs {
     table.tableEntry(1, 1).shouldBe(visible, enabled).click();
     $("#jobDialog").shouldBe(visible);
     var stackTrace = $("#job\\:lastError").text();
-    if (! stackTrace.equals("n.a.")) {
+    if (!"n.a.".equals(stackTrace)) {
       stackTrace = stackTrace.replace("\n ", "\n\t") + "\n";
     }
     $("#job\\:copyError").shouldBe(visible, enabled).click();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJvm.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestJvm.java
@@ -31,22 +31,22 @@ public class WebTestJvm {
   @Test
   void cpuContent() {
     $("#cpu")
-            .shouldHave(text("CPU Load"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("CPU Load"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
   @Test
   void classesContent() {
     $("#classes")
-            .shouldHave(text("Classes"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("Classes"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
   @Test
   void threadsContent() {
     $("#threads")
-            .shouldHave(text("Threads"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("Threads"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestLogs.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestLogs.java
@@ -35,7 +35,7 @@ class WebTestLogs {
   void view() {
     $$(".ui-panel").shouldHave(size(1));
     $$(".ui-panel-titlebar").find(text("ivy.log")).parent()
-            .find(".ui-panel-content").shouldBe(visible);
+        .find(".ui-panel-content").shouldBe(visible);
     var logPanel = $$(".ui-panel-titlebar").find(text("ivy.log")).parent();
     logPanel.find(".ui-panel-title > span").click();
     logPanel.find(".ui-panel-content").shouldBe(visible);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestMBeans.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestMBeans.java
@@ -75,8 +75,8 @@ public class WebTestMBeans {
 
   private static void expandMBeanNodeWithText(String treeNodeText) {
     var toggler = getTreeNodeWithText(treeNodeText)
-            .parent()
-            .find(".ui-tree-toggler");
+        .parent()
+        .find(".ui-tree-toggler");
     toggler.shouldBe(visible);
     if (toggler.attr("class").contains("ui-icon-triangle-1-e")) // not yet
                                                                 // expanded

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestMemory.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestMemory.java
@@ -31,21 +31,21 @@ public class WebTestMemory {
   @Test
   void gcContent() {
     $("#gc")
-            .shouldHave(text("Garbage Collection"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("Garbage Collection"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
   @Test
   void heapMemoryContent() {
     $("#heapMemory")
-            .shouldHave(text("Heap Memory"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("Heap Memory"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
   @Test
   void nonHeapMemoryContent() {
     $("#nonHeapMemory")
-            .shouldHave(text("Non Heap Memory"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("Non Heap Memory"))
+        .find(".ui-chart").shouldBe(visible);
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestOs.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestOs.java
@@ -31,29 +31,29 @@ public class WebTestOs {
   @Test
   void cpuContent() {
     $("#cpu")
-            .shouldHave(text("CPU Load"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("CPU Load"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
   @Test
   void memoryContent() {
     $("#memory")
-            .shouldHave(text("Memory"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("Memory"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
   @Test
   void networkContent() {
     $("#network")
-            .shouldHave(text("Network"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("Network"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
   @Test
   void ioContent() {
     $("#io")
-            .shouldHave(text("IO"))
-            .find(".ui-chart").shouldBe(visible);
+        .shouldHave(text("IO"))
+        .find(".ui-chart").shouldBe(visible);
   }
 
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestProcessExecution.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestProcessExecution.java
@@ -181,7 +181,7 @@ public class WebTestProcessExecution {
   }
 
   private String getFirstColumnElement() {
-    return tableBody()+"/tr/td[1]";
+    return tableBody() + "/tr/td[1]";
   }
 
   private String tableBody() {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestSessions.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestSessions.java
@@ -7,19 +7,23 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+
 import com.axonivy.ivy.webtest.IvyWebTest;
 import com.axonivy.ivy.webtest.engine.EngineUrl;
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.Selenide;
+
 import ch.ivyteam.enginecockpit.util.EngineCockpitUtil;
 import ch.ivyteam.enginecockpit.util.Navigation;
 import ch.ivyteam.enginecockpit.util.Table;
@@ -119,7 +123,7 @@ class WebTestSessions {
   private void openLogin() {
     var url = rootUri()
 
-            .toUrl();
+        .toUrl();
     Selenide.open(url);
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestStartEvents.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestStartEvents.java
@@ -44,7 +44,7 @@ class WebTestStartEvents {
 
   private static final String DURATION_STR = "[0-9][0-9]?[0-9]? (us|ms|s|m|h|d)";
   private static final String DATE_TIME_STR = "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}";
-  private static final Pattern NEXT_EXECUTION = Pattern.compile("("+DURATION_STR + "\\s" + "\\(" + DATE_TIME_STR + "\\))|(n\\.a\\. \\(n\\.a\\.\\))");
+  private static final Pattern NEXT_EXECUTION = Pattern.compile("(" + DURATION_STR + "\\s" + "\\(" + DATE_TIME_STR + "\\))|(n\\.a\\. \\(n\\.a\\.\\))");
   private static final Pattern REQUEST_PATH = Pattern.compile("[^\\/]+\\/[^\\$]+\\$[0-9]+\\/[0-9A-F]+\\/[^\\.]+\\.ivp");
   private static final Pattern DURATION = Pattern.compile(DURATION_STR);
   private static final Pattern DURATIONS = Pattern.compile(DURATION_STR + "\\s\\/\\s" + DURATION_STR + "\\s\\/\\s" + DURATION_STR);
@@ -71,10 +71,10 @@ class WebTestStartEvents {
     Table table = new Table(TABLE_ID, true);
     table.rows().shouldHave(CollectionCondition.sizeGreaterThan(1));
     for (int row = 1; row < table.rows().size(); row++) {
-      if (table.tableEntry(row, 1).text().equals("TimerBean")) {
-        $(By.id("form:beanTable:"+(row-1)+":stop")).shouldBe(enabled);
-        $(By.id("form:beanTable:"+(row-1)+":stop")).click();
-        $(By.id("form:beanTable:"+(row-1)+":stop")).shouldBe(disabled);
+      if ("TimerBean".equals(table.tableEntry(row, 1).text())) {
+        $(By.id("form:beanTable:" + (row - 1) + ":stop")).shouldBe(enabled);
+        $(By.id("form:beanTable:" + (row - 1) + ":stop")).click();
+        $(By.id("form:beanTable:" + (row - 1) + ":stop")).shouldBe(disabled);
       }
     }
   }
@@ -84,10 +84,10 @@ class WebTestStartEvents {
     Table table = new Table(TABLE_ID, true);
     table.rows().shouldHave(CollectionCondition.sizeGreaterThan(1));
     for (int row = 1; row < table.rows().size(); row++) {
-      if (table.tableEntry(row, 1).text().equals("TimerBean")) {
-        $(By.id("form:beanTable:"+(row-1)+":start")).shouldBe(enabled);
-        $(By.id("form:beanTable:"+(row-1)+":start")).click();
-        $(By.id("form:beanTable:"+(row-1)+":start")).shouldBe(disabled);
+      if ("TimerBean".equals(table.tableEntry(row, 1).text())) {
+        $(By.id("form:beanTable:" + (row - 1) + ":start")).shouldBe(enabled);
+        $(By.id("form:beanTable:" + (row - 1) + ":start")).click();
+        $(By.id("form:beanTable:" + (row - 1) + ":start")).shouldBe(disabled);
       }
     }
   }
@@ -137,13 +137,13 @@ class WebTestStartEvents {
   void refresh() {
     var content = table.rows().texts();
     Wait()
-      .withTimeout(Duration.ofSeconds(10))
-      .ignoring(AssertionError.class)
-      .until(webDriver -> {
-        $(By.id("refresh")).click();
-        assertThat(table.rows().texts()).isNotEqualTo(content);
-        return true;
-      });
+        .withTimeout(Duration.ofSeconds(10))
+        .ignoring(AssertionError.class)
+        .until(webDriver -> {
+          $(By.id("refresh")).click();
+          assertThat(table.rows().texts()).isNotEqualTo(content);
+          return true;
+        });
   }
 
   @Test
@@ -332,14 +332,14 @@ class WebTestStartEvents {
     var threadTable = new Table(THREAD_TABLE_ID, true);
     threadTable.rows().shouldHave(CollectionCondition.sizeGreaterThan(0));
     for (int row = 1; row <= threadTable.rows().size(); row++) {
-        threadTable.tableEntry(row, 4).shouldHave(text("Error in event bean thread"));
+      threadTable.tableEntry(row, 4).shouldHave(text("Error in event bean thread"));
     }
     $(By.id("threads:eventBeanThreads:threadTable:0:error:showDetails")).click();
     assertErrorDialog("Error in event bean thread");
   }
 
   private void navigateToDetails(String link) {
-    link = EngineCockpitUtil.getAppName()+"/engine-cockpit-test-data$1/188AE871FC5C4A58/"+link;
+    link = EngineCockpitUtil.getAppName() + "/engine-cockpit-test-data$1/188AE871FC5C4A58/" + link;
     $(By.id("form:beanTable:globalFilter")).sendKeys(link);
     table.rows().shouldHave(CollectionCondition.size(1));
     table.tableEntry(1, 1).shouldBe(visible, enabled).find(By.tagName("a")).click();
@@ -380,7 +380,7 @@ class WebTestStartEvents {
   }
 
   private void filter(String filter) {
-    $(By.id("form:beanTable:globalFilter")).sendKeys(EngineCockpitUtil.getAppName()+"/engine-cockpit-test-data$1/" + filter);
+    $(By.id("form:beanTable:globalFilter")).sendKeys(EngineCockpitUtil.getAppName() + "/engine-cockpit-test-data$1/" + filter);
   }
 
   private void filterAndAssertOne(String filter) {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/monitor/WebTestThreads.java
@@ -32,7 +32,7 @@ import ch.ivyteam.enginecockpit.util.Table;
 public class WebTestThreads {
 
   private static final Duration TWENTY_SECONDS = Duration.ofSeconds(20);
-  
+
   private Table threadsTable;
 
   @BeforeEach
@@ -53,7 +53,7 @@ public class WebTestThreads {
   @Test
   void refreshButton() {
     String oldTableContent = threadsTable.body().text();
-    
+
     Wait()
         .withTimeout(TWENTY_SECONDS)
         .ignoring(AssertionError.class)
@@ -73,18 +73,18 @@ public class WebTestThreads {
     threadsTable.search("http");
     threadsTable.rows().shouldBe(sizeLessThan(all));
   }
-  
+
   @Test
   void deadlock() {
     threadsTable.body().$$(By.className("deadlocked")).shouldBe(size(0));
-    
+
     EngineCockpitUtil.deadlock();
     EngineCockpitUtil.openDashboard();
     Navigation.toThreads();
-    
+
     Wait().withTimeout(TWENTY_SECONDS)
         .ignoring(AssertionError.class)
-        .until(webDriver -> { 
+        .until(webDriver -> {
           $(id("form:refresh"))
               .shouldBe(visible, enabled)
               .click();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestManyRoles.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestManyRoles.java
@@ -56,7 +56,7 @@ class WebTestManyRoles {
     $("#rolesOfUserForm\\:globalFilter").sendKeys("role-");
     $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").shouldBe(size(21));
     $$("#rolesOfUserForm\\:rolesTree .ui-node-level-1").last()
-            .shouldHave(text("The current search has more than 20 results."));
+        .shouldHave(text("The current search has more than 20 results."));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestPermission.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestPermission.java
@@ -24,14 +24,14 @@ import ch.ivyteam.enginecockpit.util.Tab;
 @IvyWebTest
 class WebTestPermission {
   private static final String threeStateButton = "permissionsForm:permissionTable:0:ajaxTriState";
-  
-  private static interface Icon {
+
+  private interface Icon {
     String grant = "#permissionsForm\\:permissionTable_node_0 .permission-icon #grant";
     String someGrant = "#permissionsForm\\:permissionTable_node_0 .permission-icon #someGrant";
     String deny = "#permissionsForm\\:permissionTable_node_0 .permission-icon #deny";
     String someDeny = "#permissionsForm\\:permissionTable_node_0 .permission-icon #someDeny";
     String everybody = "#permissionsForm\\:permissionTable_node_0 .permission-icon #everybody";
-    }
+  }
 
   @BeforeEach
   void beforeEach() {
@@ -115,16 +115,16 @@ class WebTestPermission {
 
     $(By.id("permissionsForm:globalFilter")).shouldBe(enabled).sendKeys("CaseWriteName");
     $(By.id("permissionsForm:permissionTable"))
-            .shouldHave(Condition.text("CaseWriteName"))
-            .findAll("tbody tr").shouldHave(size(1));
+        .shouldHave(Condition.text("CaseWriteName"))
+        .findAll("tbody tr").shouldHave(size(1));
     $(By.id("permissionsForm:permissionTable:0:ajaxTriState")).click();
     $(By.id("permissionsForm:permissionTable_node_0")).find(".permission-icon > i")
-            .shouldHave(attribute("title", "Permission granted"));
+        .shouldHave(attribute("title", "Permission granted"));
 
     $(By.id("permissionsForm:permissionTable:0:ajaxTriState")).click();
     $(By.id("permissionsForm:permissionTable:0:ajaxTriState")).click();
     $(By.id("permissionsForm:permissionTable_node_0")).find(".permission-icon > i")
-            .shouldNot(exist);
+        .shouldNot(exist);
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoleDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoleDetail.java
@@ -346,11 +346,11 @@ class WebTestRoleDetail {
     Selenide.refresh();
     assertCurrentUrlContains("roledetail.xhtml?system=test-ad&name=" + DETAIL_ROLE_NAME);
     $("#usersOfRoleForm\\:roleUserTable\\:0\\:removeUserFromRoleBtn")
-            .shouldNotHave(cssClass("ui-state-disabled")).click();
+        .shouldNotHave(cssClass("ui-state-disabled")).click();
     $("#usersOfRoleForm\\:roleUserTable\\:0\\:removeUserFromRoleBtn")
-            .shouldNotHave(cssClass("ui-state-disabled")).click();
+        .shouldNotHave(cssClass("ui-state-disabled")).click();
     $("#usersOfRoleForm\\:roleUserTable\\:0\\:removeUserFromRoleBtn")
-            .shouldNotHave(cssClass("ui-state-disabled")).click();
+        .shouldNotHave(cssClass("ui-state-disabled")).click();
   }
 
   private void checkIfRoleIsExternal() {
@@ -379,13 +379,13 @@ class WebTestRoleDetail {
     $(DIRECTORY_BROWSER_FORM + "tree\\:0 .ui-tree-toggler").click();
     $(DIRECTORY_BROWSER_FORM + "tree\\:0 .ui-treenode-children").findAll(".ui-treenode").shouldHave(size(11));
     $(DIRECTORY_BROWSER_FORM + "tree\\:0 .ui-treenode-children").findAll(".ui-treenode-label")
-            .find(text("CN=role1")).click();
+        .find(text("CN=role1")).click();
     $(DIRECTORY_BROWSER_FORM + "tree\\:0 .ui-treenode-children").findAll(".ui-treenode-label")
-            .find(text("CN=role1")).parent().shouldHave(cssClass("ui-state-highlight"));
+        .find(text("CN=role1")).parent().shouldHave(cssClass("ui-state-highlight"));
     $(By.id("directoryBrowser:chooseDirectoryName")).click();
     $(By.id(DIRECTORY_BROWSER_DIALOG)).shouldNotBe(visible);
     $(By.id("roleInformationForm:externalSecurityName"))
-            .shouldHave(value("CN=role1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan"));
+        .shouldHave(value("CN=role1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan"));
   }
 
   @Test
@@ -394,15 +394,15 @@ class WebTestRoleDetail {
     Tab.SECURITY_SYSTEM.switchToTab("test-ad");
     Navigation.toRoleDetail("test-ad", DETAIL_ROLE_NAME);
     $(By.id("roleInformationForm:externalSecurityName"))
-            .sendKeys("CN=role1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan");
+        .sendKeys("CN=role1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan");
     $(By.id("roleInformationForm:browseExternalName")).shouldNotBe(disabled).click();
 
     $(By.id(DIRECTORY_BROWSER_DIALOG)).shouldBe(visible);
     $$(DIRECTORY_BROWSER_FORM + "tree .ui-treenode-label").find(exactText("CN=role1")).parent()
-            .shouldBe(visible, cssClass("ui-state-highlight"));
+        .shouldBe(visible, cssClass("ui-state-highlight"));
     Table table = new Table(By.id("directoryBrowser:directoryBrowserForm:nodeAttrTable"));
     table.tableEntry("distinguishedName", 2)
-            .shouldBe(exactText("CN=role1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan"));
+        .shouldBe(exactText("CN=role1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan"));
   }
 
   private void clearRoleInfoInputs() {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoles.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoles.java
@@ -51,18 +51,18 @@ class WebTestRoles {
     $("#form\\:syncMoreBtn_menuButton").click();
     $("#form\\:userSyncLog").shouldBe(visible).click();
     $$(".ui-panel-titlebar").find(text("usersynch.log")).parent()
-            .find(".ui-panel-content").shouldBe(visible);
+        .find(".ui-panel-content").shouldBe(visible);
   }
 
   @Test
   void expandCollapseTree() {
     getVisibleTreeNodes().as("Everybody, boss, worker, AXONIVY_PORTAL_ADMIN")
-      .shouldBe(sizeGreaterThanOrEqual(3))
-      .shouldBe(sizeLessThan(5));
+        .shouldBe(sizeGreaterThanOrEqual(3))
+        .shouldBe(sizeLessThan(5));
     $(getTreeFormId() + "\\:expandAll").shouldBe(visible).click();
     getVisibleTreeNodes().as("Everybody, boss, worker, AXONIVY_PORTAL_ADMIN, manager")
-      .shouldBe(sizeGreaterThanOrEqual(4))
-      .shouldBe(sizeLessThan(6));
+        .shouldBe(sizeGreaterThanOrEqual(4))
+        .shouldBe(sizeLessThan(6));
     $(getTreeFormId() + "\\:collapseAll").shouldBe(visible).click();
     getVisibleTreeNodes().shouldBe(size(1));
   }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecurityIdentityProvider.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecurityIdentityProvider.java
@@ -90,40 +90,40 @@ class WebTestSecurityIdentityProvider {
 
     // add
     $(By.id("identityProvider:dynamicConfigForm:group:1:newPropertyKeyValue"))
-            .shouldBe(visible)
-            .click();
+        .shouldBe(visible)
+        .click();
     $(By.id("identityProvider:dynamicConfigKeyValueForm:attributeNameInput"))
-            .should(visible)
-            .sendKeys("user property");
+        .should(visible)
+        .sendKeys("user property");
     $(By.id("identityProvider:dynamicConfigKeyValueForm:attributeValueInput"))
-            .should(visible)
-            .sendKeys("azure property");
+        .should(visible)
+        .sendKeys("azure property");
     $(By.id("identityProvider:dynamicConfigKeyValueForm:savePropertyKeyAttribute"))
-            .should(visible)
-            .click();
+        .should(visible)
+        .click();
     success();
     table.columnShouldBe(1, CollectionCondition.exactTexts("user property"));
     table.columnShouldBe(2, CollectionCondition.exactTexts("azure property"));
 
     // edit
     $(By.id("identityProvider:dynamicConfigForm:group:1:property:0:keyValueTable:0:editPropertyBtn"))
-            .should(visible)
-            .click();
+        .should(visible)
+        .click();
     $(By.id("identityProvider:dynamicConfigKeyValueForm:attributeNameInput")).should(Condition.disabled);
     var p = $(By.id("identityProvider:dynamicConfigKeyValueForm:attributeValueInput"))
-      .should(visible);
+        .should(visible);
     p.clear();
     p.sendKeys("changed azure property");
     $(By.id("identityProvider:dynamicConfigKeyValueForm:savePropertyKeyAttribute"))
-      .should(visible)
-      .click();
+        .should(visible)
+        .click();
     success();
     table.columnShouldBe(1, CollectionCondition.exactTexts("user property"));
     table.columnShouldBe(2, CollectionCondition.exactTexts("changed azure property"));
 
     // delete
     $(By.id("identityProvider:dynamicConfigForm:group:1:property:0:keyValueTable:0:deleteKeyValueBtn"))
-      .click();
+        .click();
     success();
     table.firstColumnShouldBe(CollectionCondition.empty);
   }
@@ -142,11 +142,11 @@ class WebTestSecurityIdentityProvider {
   }
 
   @Test
-  void directoryBrowser(){
+  void directoryBrowser() {
     $(By.id("identityProvider:dynamicConfigForm:group:0:property:2:browseDirectory")).should(visible)
-    .click();
+        .click();
     $(By.id("directoryBrowser:directoryBrowserForm:tree:0")).should(visible)
-    .click();
+        .click();
     $(By.id("directoryBrowser:directoryBrowserForm:tree:0")).shouldHave(text("Group A"));
     By.id("directoryBrowser:directoryBrowserForm:tree:0");
     $(By.className("ui-tree-toggler")).click();
@@ -165,7 +165,7 @@ class WebTestSecurityIdentityProvider {
     var bool = $(By.cssSelector(".ui-chkbox-box.ui-widget.ui-corner-all.ui-state-default")).should(visible);
     bool.click();
     PrimeUi.selectBooleanCheckbox(By.id("identityProvider:dynamicConfigForm:group:0:property:4:propertyBoolean"))
-    .shouldBeChecked(true);
+        .shouldBeChecked(true);
     save();
     success();
   }
@@ -174,7 +174,7 @@ class WebTestSecurityIdentityProvider {
   void booleanPropertyDefaultValue() {
     $(By.id("identityProvider:dynamicConfigForm:group:0:property:5:propertyBoolean")).should(visible);
     PrimeUi.selectBooleanCheckbox(By.id("identityProvider:dynamicConfigForm:group:0:property:5:propertyBoolean"))
-    .shouldBeChecked(true);
+        .shouldBeChecked(true);
     save();
     success();
   }
@@ -194,8 +194,8 @@ class WebTestSecurityIdentityProvider {
   @Test
   void dropdownProperty() {
     var property = $(By.id("identityProvider:dynamicConfigForm:group:0:property:6:propertyDropdown"))
-            .shouldBe(visible)
-            .shouldBe(text("DIRECT"));
+        .shouldBe(visible)
+        .shouldBe(text("DIRECT"));
     property.scrollTo().click();
     $(By.id("identityProvider:dynamicConfigForm:group:0:property:6:propertyDropdown_2")).click();
     property.shouldHave(text("TRAVERSE"));
@@ -204,8 +204,8 @@ class WebTestSecurityIdentityProvider {
   @Test
   void browseEscapedNames() {
     $(By.id("identityProvider:dynamicConfigForm:group:0:property:2:browseDirectory"))
-      .should(visible)
-      .click();
+        .should(visible)
+        .click();
     $(By.id("directoryBrowser:directoryBrowserDialog")).shouldBe(visible);
     var treeNode = $$(DIRECTORY_BROWSER_FORM + "tree .ui-treenode-label").find(exactText("Group A"));
     treeNode.shouldBe(visible);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecuritySystem.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecuritySystem.java
@@ -52,7 +52,7 @@ class WebTestSecuritySystem {
     $("#newSecuritySystemForm\\:newSecuritySystemNameMessage").shouldBe(empty);
     $("#newSecuritySystemModal").shouldNotBe(visible);
     $("#form\\:msgs_container .ui-growl-message")
-            .shouldHave(text("Security Context Name 'invalid?!' must match pattern"));
+        .shouldHave(text("Security Context Name 'invalid?!' must match pattern"));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecuritySystemDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecuritySystemDetail.java
@@ -271,7 +271,7 @@ public class WebTestSecuritySystemDetail {
     checkbox(ON_SCHEDULE_IMPORT_USERS).shouldBeChecked(true);
   }
 
-  private void saveInvalidonScheduleTimeAndAssert( String time) {
+  private void saveInvalidonScheduleTimeAndAssert(String time) {
     setonScheduleTime(time);
     $(SAVE_PROVIDER_BTN).click();
     $(SYNC_TIME_MESSAGE).shouldBe(visible);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecuritySystemLdap.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestSecuritySystemLdap.java
@@ -58,17 +58,17 @@ public class WebTestSecuritySystemLdap {
   @Test
   void adldapBrowser_chooseDefaultContext() {
     $(By.id("identityProvider:dynamicConfigForm:group:1:property:0:browseDirectory"))
-      .should(visible).click();
+        .should(visible).click();
     $(By.id("directoryBrowser:directoryBrowserForm:tree:0"))
-      .should(visible);
+        .should(visible);
     $(By.id("directoryBrowser:directoryBrowserForm:tree")).shouldHave(text("OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan"));
     $(By.id("directoryBrowser:directoryBrowserForm:tree:0_0"))
-      .shouldHave(text("fullusername1")).click();
+        .shouldHave(text("fullusername1")).click();
 
     $(By.id("directoryBrowser:cancelDirectoryBrowser")).should(visible);
     $(By.id("directoryBrowser:chooseDirectoryName")).should(visible).click();
     $(By.id("identityProvider:dynamicConfigForm:group:1:property:0:propertyString"))
-      .shouldHave(value("CN=fullusername1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan"));
+        .shouldHave(value("CN=fullusername1,OU=IvyTeam Test-OU,DC=zugtstdomain,DC=wan"));
   }
 
   @Test
@@ -106,13 +106,13 @@ public class WebTestSecuritySystemLdap {
       $$(DIRECTORY_BROWSER_FORM + "tree > ul > li").shouldHave(size(1));
       $(DIRECTORY_BROWSER_FORM + "tree\\:0 .ui-tree-toggler").click();
       $(DIRECTORY_BROWSER_FORM + "tree\\:0 .ui-treenode-children").findAll(".ui-treenode")
-        .shouldHave(size(10));
+          .shouldHave(size(10));
       $(By.id("directoryBrowser:directoryBrowserForm:tree:0_0"))
-        .shouldHave(text("cn=role1")).click();
+          .shouldHave(text("cn=role1")).click();
       $(By.id(DIRECTORY_BROWSER_CHOOSE)).scrollTo().click();
       $(By.id(DIRECTORY_BROWSER_DIALOG)).shouldNotBe(visible);
       $(By.id("identityProvider:dynamicConfigForm:group:1:property:0:propertyString"))
-        .shouldBe(exactValue("cn=role1,ou=IvyTeam Test-OU,o=zugtstorg"));
+          .shouldBe(exactValue("cn=role1,ou=IvyTeam Test-OU,o=zugtstorg"));
     }
   }
 
@@ -131,8 +131,8 @@ public class WebTestSecuritySystemLdap {
     openDefaultLdapBrowser();
     try {
       $(By.id("directoryBrowser:directoryBrowserForm:directoryBrowserMessage"))
-        .shouldBe(visible)
-        .shouldNotBe(empty);
+          .shouldBe(visible)
+          .shouldNotBe(empty);
     } finally {
       $(By.id("directoryBrowser:cancelDirectoryBrowser")).click();
     }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
@@ -173,7 +173,7 @@ class WebTestUserDetail {
     var webNewTaskCheckbox = $(By.id("notificationsForm:notificationChannelsTable:0:channels:0:subscriptionCheckbox")).lastChild().lastChild();
 
     table.firstColumnShouldBe(size(2));
-    table.tableEntry(1,1).shouldHave(text("task"));
+    table.tableEntry(1, 1).shouldHave(text("task"));
     table.headerShouldBe(size(2));
     table.headerShouldBe(exactTexts("Event", "Web"));
 
@@ -220,13 +220,13 @@ class WebTestUserDetail {
   }
 
   private void shouldHaveSubscribedByDefaultState(SelenideElement webNewTaskIcon,
-          SelenideElement webNewTaskCheckbox) {
+      SelenideElement webNewTaskCheckbox) {
     iconShouldHaveState(webNewTaskIcon, true, true, "Subscribed by default");
     checkboxShouldHaveState(webNewTaskCheckbox, 0);
   }
 
   private void shouldHaveNotSubscribedByDefaultState(SelenideElement webNewTaskIcon,
-          SelenideElement webNewTaskCheckbox) {
+      SelenideElement webNewTaskCheckbox) {
     iconShouldHaveState(webNewTaskIcon, false, true, "Not subscribed by default");
     checkboxShouldHaveState(webNewTaskCheckbox, 0);
   }
@@ -237,13 +237,13 @@ class WebTestUserDetail {
   }
 
   private void shouldHaveNotSubscribedState(SelenideElement webNewTaskIcon,
-          SelenideElement webNewTaskCheckbox) {
+      SelenideElement webNewTaskCheckbox) {
     iconShouldHaveState(webNewTaskIcon, false, false, "Not subscribed");
     checkboxShouldHaveState(webNewTaskCheckbox, 2);
   }
 
   private void iconShouldHaveState(SelenideElement webNewTaskIcon, boolean iconSubscribedState,
-          boolean iconByDefaultState, String iconTitle) {
+      boolean iconByDefaultState, String iconTitle) {
     iconShouldHaveSubscribedState(webNewTaskIcon, iconSubscribedState);
     iconShouldHaveByDefaultState(webNewTaskIcon, iconByDefaultState);
     iconShouldHaveTitle(webNewTaskIcon, iconTitle);
@@ -323,7 +323,7 @@ class WebTestUserDetail {
   void rolesAddRemove() {
     Navigation.toUserDetail(USER_FOO);
     String boss = Selenide.$$(".role-name").find(Condition.text("boss")).parent().parent().parent()
-            .getAttribute("id");
+        .getAttribute("id");
     By bossId = By.id(boss);
     $(bossId).find(ROLE_EXPANDER).click();
     By managerId = By.id(boss + "_0");

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUsers.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUsers.java
@@ -40,10 +40,10 @@ class WebTestUsers {
 
   private static final String SECURITY_SYSTEM_TAB_VIEW = "#securitySystems\\:securitySystemTabView\\:";
 
-  private String user = "test";
-  private String fullName = "test user";
-  private String email = "test@test.ch";
-  private String password = "password";
+  private final String user = "test";
+  private final String fullName = "test user";
+  private final String email = "test@test.ch";
+  private final String password = "password";
 
   @BeforeEach
   void beforeEach() {
@@ -218,7 +218,7 @@ class WebTestUsers {
     $("#form\\:syncMoreBtn_menuButton").click();
     $("#form\\:userSyncLog").shouldBe(visible).click();
     $$(".ui-panel-titlebar").find(text("usersynch.log")).parent()
-            .find(".ui-panel-content").shouldBe(visible);
+        .find(".ui-panel-content").shouldBe(visible);
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestBackendApi.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestBackendApi.java
@@ -37,7 +37,7 @@ class WebTestBackendApi {
     Selenide.switchTo().frame("apiBrowser");
     $("#select").shouldBe(visible, value(APP));
     $$(".opblock-summary")
-      .shouldBe(sizeGreaterThanOrEqual(1));
+        .shouldBe(sizeGreaterThanOrEqual(1));
 
     Selenide.switchTo().defaultContent();
     $("#configRestBackend").shouldBe(visible).click();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseDetail.java
@@ -81,7 +81,7 @@ class WebTestDatabaseDetail {
     Selenide.refresh();
     checkConfiguration("jdbc:mysql://localhost:3306/test-db", "com.mysql.cj.jdbc.Driver", "user", "5");
   }
-  
+
   @Test
   void addProperty() {
     var editor = new PropertyEditor("databasePropertiesForm:databasePropertiesTable:newPropertyEditor:");
@@ -90,7 +90,7 @@ class WebTestDatabaseDetail {
     $(By.id("databasePropertiesForm:databasePropertiesTable")).shouldHave(text("testValue"));
     $(By.id("databasePropertiesForm:databasePropertiesTable:1:editPropertyEditor:deletePropertyBtn")).click();
   }
-  
+
   @Test
   void editProperty() {
     var editor = new PropertyEditor("databasePropertiesForm:databasePropertiesTable:0:editPropertyEditor:");
@@ -102,7 +102,7 @@ class WebTestDatabaseDetail {
   @Test
   void liveStats() {
     EngineCockpitUtil.assertLiveStats(List.of("Database Connections", "Database Queries",
-            "Database Query Execution Time"), "test-db", false);
+        "Database Query Execution Time"), "test-db", false);
   }
 
   private void setConfiguration(String url, String driverName, String username, String connections) {
@@ -121,7 +121,7 @@ class WebTestDatabaseDetail {
 
     $("#databaseConfigurationForm\\:saveDatabaseConfig").click();
     $("#databaseConfigurationForm\\:databaseConfigMsg_container")
-            .shouldBe(text("Database configuration saved"));
+        .shouldBe(text("Database configuration saved"));
   }
 
   private void checkConfiguration(String url, String driverName, String username, String connections) {
@@ -136,7 +136,7 @@ class WebTestDatabaseDetail {
     $("#databaseConfigurationForm\\:resetDbConfirmDialog").shouldBe(visible);
     $("#databaseConfigurationForm\\:resetDbConfirmYesBtn").click();
     $("#databaseConfigurationForm\\:databaseConfigMsg_container")
-            .shouldBe(text("Database configuration reset"));
+        .shouldBe(text("Database configuration reset"));
   }
 
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseHistory.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseHistory.java
@@ -40,9 +40,9 @@ class WebTestDatabaseHistory {
   @Test
   void connectionAndHistory() {
     new Table(By.id("databaseConnectionForm:databaseConnectionsTable"))
-            .firstColumnShouldBe(sizeGreaterThan(0));
+        .firstColumnShouldBe(sizeGreaterThan(0));
     new Table(By.id("databaseExecHistoryForm:databaseExecHistoryTable"))
-            .firstColumnShouldBe(sizeGreaterThan(0));
+        .firstColumnShouldBe(sizeGreaterThan(0));
 
     $(".si-copy-paste").shouldBe(visible).click();
     var copyPasteAlert = switchTo().alert();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabases.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabases.java
@@ -26,7 +26,7 @@ class WebTestDatabases {
   @Test
   void databasesInTable() {
     Table table = new Table(By.id("tabs:applicationTabView:" +
-            Tab.APP.getSelectedTabIndex() + ":form:databasesTable"), true);
+        Tab.APP.getSelectedTabIndex() + ":form:databasesTable"), true);
     table.firstColumnShouldBe(size(3));
 
     table.search(table.getFirstColumnEntries().get(0));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotification.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotification.java
@@ -33,7 +33,6 @@ class WebTestNotification {
 
   private static final String ANY_USERS = "Developer|foo|bar|jon|guest|demo|admin|disableduser|test|neo";
 
-
   @BeforeEach
   void beforeEach() {
     EngineCockpitUtil.createNotification();
@@ -61,8 +60,8 @@ class WebTestNotification {
     notifications.rows().should(size(1));
     notifications.tableEntry(1, 7).click();
     $(By.id("payloadModal"))
-            .should(visible)
-            .should(text("taskId"));
+        .should(visible)
+        .should(text("taskId"));
     notifications.tableEntry(1, 1).should(matchText(".*-.*-.*"));
   }
 
@@ -91,7 +90,7 @@ class WebTestNotification {
     delivery.tableEntry(1, 2).shouldBe(text("Web"));
     delivery.tableEntry(1, 3).should(matchText(ANY_USERS));
     delivery.tableEntry(1, 4).shouldBe(matchText("DELIVERED|PENDING"));
-    if (delivery.tableEntry(1, 4).text().equals("DELIVERED")) {
+    if ("DELIVERED".equals(delivery.tableEntry(1, 4).text())) {
       delivery.tableEntry(1, 5).shouldBe(not(empty));
     } else {
       delivery.tableEntry(1, 5).shouldBe(empty);
@@ -102,8 +101,8 @@ class WebTestNotification {
 
     delivery.search("non-existing-value");
     delivery.rows()
-            .should(size(1))
-            .should(textsInAnyOrder("No records found"));
+        .should(size(1))
+        .should(textsInAnyOrder("No records found"));
 
     delivery.search("Web");
     delivery.rows().should(sizeGreaterThanOrEqual(1));
@@ -218,7 +217,6 @@ class WebTestNotification {
     delivery.tableEntry(2, 8).shouldBe(text("2"));
     delivery.tableEntry(2, 8).shouldBe(Condition.matchText("[0-9]+ [smhd]"));
   }
-
 
   private void enableMailChannel() {
     Navigation.toNotificationChannelDetail("mail");

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
@@ -136,7 +136,7 @@ public class WebTestNotificationChannelDetail {
   void eventsInTable() {
     Table table = new Table(By.id("form:events"));
     table.firstColumnShouldBe(size(2));
-    table.tableEntry(1,1).shouldHave(text("task"));
+    table.tableEntry(1, 1).shouldHave(text("task"));
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannels.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannels.java
@@ -29,7 +29,7 @@ public class WebTestNotificationChannels {
   @Test
   void channelsInTable() {
     Table table = new Table(By.id("securitySystems:securitySystemTabView:" +
-            Tab.SECURITY_SYSTEM.getSelectedTabIndex() + ":tableForm:" + TABLE_ID), true);
+        Tab.SECURITY_SYSTEM.getSelectedTabIndex() + ":tableForm:" + TABLE_ID), true);
     table.firstColumnShouldBe(size(3));
     table.firstColumnShouldBe(CollectionCondition.exactTexts("Microsoft Teams", "Web", "Email"), 2);
   }
@@ -37,7 +37,7 @@ public class WebTestNotificationChannels {
   @Test
   void channelFilter() {
     Table table = new Table(By.id("securitySystems:securitySystemTabView:" +
-            Tab.SECURITY_SYSTEM.getSelectedTabIndex() + ":tableForm:" + TABLE_ID), true);
+        Tab.SECURITY_SYSTEM.getSelectedTabIndex() + ":tableForm:" + TABLE_ID), true);
     table.firstColumnShouldBe(size(3));
 
     table.search("Web");

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestRestClientHistory.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestRestClientHistory.java
@@ -38,7 +38,7 @@ class WebTestRestClientHistory {
   @Test
   void liveStats() {
     EngineCockpitUtil.assertLiveStats(List.of("REST Client Connections", "REST Client Calls",
-            "REST Client Execution Time"), "engine-rest", false);
+        "REST Client Execution Time"), "engine-rest", false);
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestRestClients.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestRestClients.java
@@ -26,7 +26,7 @@ class WebTestRestClients {
   @Test
   void restClientsInTable() {
     Table table = new Table(By.id("tabs:applicationTabView:" +
-            Tab.APP.getSelectedTabIndex() + ":form:restClientsTable"), true);
+        Tab.APP.getSelectedTabIndex() + ":form:restClientsTable"), true);
     table.firstColumnShouldBe(size(3));
 
     table.search(table.getFirstColumnEntries().get(0));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
@@ -61,7 +61,7 @@ class WebTestSearchEngine {
   void indicies() {
     Table table = new Table(By.id("searchEngineIndexForm:indiciesTable"), true);
     assertThat(table.getFirstColumnEntriesForSpanClass("index-name")).hasSizeGreaterThanOrEqualTo(2)
-            .contains(dossierIndex, addressIndex);
+        .contains(dossierIndex, addressIndex);
     checkIndexValues(table, dossierIndex, "10");
     checkIndexValues(table, addressIndex, "1");
     $(By.id("searchEngineIndexForm:indiciesTable:indexName")).shouldBe(visible).click();
@@ -74,11 +74,11 @@ class WebTestSearchEngine {
     var table = new Table(By.id("tableForm:docTable"));
     table.search("ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ");
     $(By.id("tableForm:docTable:0:showDocument"))
-            .shouldBe(not(exist));
+        .shouldBe(not(exist));
     table.search("");
     $(By.id("tableForm:docTable:0:showDocument"))
-            .shouldBe(visible)
-            .click();
+        .shouldBe(visible)
+        .click();
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestTlsTester.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestTlsTester.java
@@ -43,8 +43,8 @@ class WebTestTlsTester {
     $(By.id("restClientConfigurationForm:saveRestConfig")).click();
     $(By.id("restClientConfigurationForm:testRestBtn")).click();
     $(By.id("connResult:connTestForm:testTlsConectionBtn")).click();
-     try {
-       $(By.id("connResult:connTestForm:resultTLS")).shouldHave(text("Connect, with Ivy SSLContext "));
+    try {
+      $(By.id("connResult:connTestForm:resultTLS")).shouldHave(text("Connect, with Ivy SSLContext "));
     } finally {
       $(By.id("connResult:connTestForm:closeConTesterDialog")).click();
       $(By.id("restClientConfigurationForm:url")).setValue("http://test-webservices.ivyteam.io:8090/api/v3");

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebserviceDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebserviceDetail.java
@@ -75,7 +75,7 @@ class WebTestWebserviceDetail {
     executeJs("scroll(0,0);");
     $("#webserviceConfigurationForm\\:saveWsConfig").click();
     $("#webserviceConfigurationForm\\:wsConfigMsg_container")
-            .shouldBe(text("Web Service configuration saved"));
+        .shouldBe(text("Web Service configuration saved"));
   }
 
   private void checkConfiguration(String username) {
@@ -87,7 +87,7 @@ class WebTestWebserviceDetail {
     $("#webserviceConfigurationForm\\:resetWsConfirmDialog").shouldBe(visible);
     $("#webserviceConfigurationForm\\:resetWsConfirmYesBtn").click();
     $("#webserviceConfigurationForm\\:wsConfigMsg_container")
-            .shouldBe(text("Web Service configuration reset"));
+        .shouldBe(text("Web Service configuration reset"));
   }
 
   @Test
@@ -111,7 +111,7 @@ class WebTestWebserviceDetail {
     $("#connResult\\:connectionTestModel").shouldNotBe(visible);
     Table table = new Table(By.id("webservcieEndPointForm:webserviceEndpointTable"), "", "data-rk");
     table.clickButtonForEntry(table.getFirstColumnEntriesForSpanClass("endpoint-entry").get(1),
-            "testWsEndpointBtn");
+        "testWsEndpointBtn");
     $("#connResult\\:connectionTestModel").shouldBe(visible);
     $("#connResult\\:connTestForm\\:testConnectionBtn").click();
     $("#connResult\\:connTestForm\\:resultConnect").shouldBe(text(title));
@@ -123,7 +123,7 @@ class WebTestWebserviceDetail {
   @Test
   void editEndpointsInvalid() {
     new Table(By.id("webservcieEndPointForm:webserviceEndpointTable"), "", "data-rk")
-            .clickButtonForEntry("SampleWebServiceSoap", "editEndpointBtn");
+        .clickButtonForEntry("SampleWebServiceSoap", "editEndpointBtn");
     $("#editEndpointModalForm\\:defaultInput").clear();
     $("#editEndpointModalForm\\:saveEndpoint").click();
     $("#editEndpointModalForm\\:defaultInputMessage").shouldBe(text("Value is required"));
@@ -206,7 +206,7 @@ class WebTestWebserviceDetail {
 
   private void setEndPoint(String defaultLink, String... fallbacks) {
     new Table(By.id("webservcieEndPointForm:webserviceEndpointTable"), "", "data-rk")
-            .clickButtonForEntry("SampleWebServiceSoap", "editEndpointBtn");
+        .clickButtonForEntry("SampleWebServiceSoap", "editEndpointBtn");
     $("#editEndpointModal").shouldBe(visible);
 
     $("#editEndpointModalForm\\:defaultInput").clear();
@@ -214,7 +214,7 @@ class WebTestWebserviceDetail {
     $("#editEndpointModalForm\\:fallBackInput").clear();
 
     $("#editEndpointModalForm\\:fallBackInput")
-            .sendKeys(Arrays.stream(fallbacks).collect(Collectors.joining("\n")));
+        .sendKeys(Arrays.stream(fallbacks).collect(Collectors.joining("\n")));
 
     $("#editEndpointModalForm\\:saveEndpoint").click();
     $("#webserviceConfigurationForm\\:wsConfigMsg_container").shouldBe(text("EndPoint saved"));
@@ -222,14 +222,14 @@ class WebTestWebserviceDetail {
 
   private void checkEndPoint(String... links) {
     assertThat(new Table(By.id("webservcieEndPointForm:webserviceEndpointTable"), "", "data-rk")
-            .getFirstColumnEntriesForSpanClass("endpoint-entry"))
-                    .containsAll(Arrays.asList(links));
+        .getFirstColumnEntriesForSpanClass("endpoint-entry"))
+            .containsAll(Arrays.asList(links));
   }
 
   private void checkEndPointDoesNotContain(String... links) {
     assertThat(new Table(By.id("webservcieEndPointForm:webserviceEndpointTable"), "", "data-rk")
-            .getFirstColumnEntriesForSpanClass("endpoint-entry"))
-                    .doesNotContainAnyElementsOf(Arrays.asList(links));
+        .getFirstColumnEntriesForSpanClass("endpoint-entry"))
+            .doesNotContainAnyElementsOf(Arrays.asList(links));
   }
 
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebservices.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestWebservices.java
@@ -26,7 +26,7 @@ class WebTestWebservices {
   @Test
   void webserviesInTable() {
     Table table = new Table(By.id("tabs:applicationTabView:" +
-            Tab.APP.getSelectedTabIndex() + ":form:webservicesTable"), true);
+        Tab.APP.getSelectedTabIndex() + ":form:webservicesTable"), true);
     table.firstColumnShouldBe(size(2));
 
     table.search("second-web");

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/setup/WebTestWizard.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/setup/WebTestWizard.java
@@ -77,7 +77,7 @@ public class WebTestWizard {
   public static void navigateToStep(String step) {
     login("setup.xhtml");
     String stepIndex = $$("#stepForm\\:wizardSteps .ui-steps-title").find(text(step)).parent()
-            .find(".ui-steps-number").getText();
+        .find(".ui-steps-number").getText();
     String activeStep = $(WebTestWizard.ACTIVE_WIZARD_STEP + " .ui-steps-title").should(exist).getText();
     if (!activeStep.equals(step)) {
       $$("#stepForm\\:wizardSteps li > a").find(text("1")).click();
@@ -90,11 +90,11 @@ public class WebTestWizard {
 
   public static void activeStepShouldBeOk() {
     $(WebTestWizard.ACTIVE_WIZARD_STEP + " > a").shouldHave(not(cssClass("step-warning")),
-            cssClass("step-ok"));
+        cssClass("step-ok"));
   }
 
   public static void activeStepShouldHaveWarnings() {
     $(WebTestWizard.ACTIVE_WIZARD_STEP + " > a").shouldHave(cssClass("step-warning"),
-            not(cssClass("step-ok")));
+        not(cssClass("step-ok")));
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestConfigFileEditor.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestConfigFileEditor.java
@@ -59,15 +59,14 @@ class WebTestConfigFileEditor {
       $(By.className("monaco-editor")).shouldBe(visible);
 
       var idpName = $(By.xpath("//div[@class='view-line']//span[@class='mtk22' and text()='Name']"))
-        .as("selected SecuritySystems.test-ad.IdentityProvider.Name")
-        .shouldBe(visible);
+          .as("selected SecuritySystems.test-ad.IdentityProvider.Name")
+          .shouldBe(visible);
       idpName.hover();
 
       $(By.className("code-hover-contents")).shouldBe(visible)
-        .as("config-editor shows key specific help, provided by json-schemas")
-        .shouldHave(Condition.partialText("The Security System manages the user and roles in the system database."));
-    }
-    finally {
+          .as("config-editor shows key specific help, provided by json-schemas")
+          .shouldHave(Condition.partialText("The Security System manages the user and roles in the system database."));
+    } finally {
       driver.switchTo().defaultContent();
       setMonacoValue(original);
     }
@@ -92,9 +91,8 @@ class WebTestConfigFileEditor {
 
       setMonacoValue(newEditorContent);
       saveEditor();
-      $("#editorMessage_container .ui-growl-message").shouldHave(text("Saved "+APP_YAML+" Successfully"));
-    }
-    finally {
+      $("#editorMessage_container .ui-growl-message").shouldHave(text("Saved " + APP_YAML + " Successfully"));
+    } finally {
       setMonacoValue(original);
       saveEditor();
     }
@@ -175,7 +173,7 @@ class WebTestConfigFileEditor {
     fileChooserInput.clear();
     fileChooserInput.shouldBe(visible).sendKeys(elementName);
     var autocompleteElement = $(By.className("ui-autocomplete-item"))
-      .shouldHave(Condition.attribute("data-item-label", elementName));
+        .shouldHave(Condition.attribute("data-item-label", elementName));
     autocompleteElement.click();
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSSL.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSSL.java
@@ -50,11 +50,11 @@ class WebTestSSL {
     @Test
     void useCustomKeyStore() {
       PrimeUi.selectBooleanCheckbox(By.id(Key.USE_CUSTOM))
-      .shouldBeChecked(false);
+          .shouldBeChecked(false);
       $(By.id(Key.FILE)).shouldHave(cssClass("ui-state-disabled"));
       PrimeUi.selectBooleanCheckbox(By.id(Key.USE_CUSTOM)).setChecked();
       PrimeUi.selectBooleanCheckbox(By.id(Key.USE_CUSTOM))
-      .shouldBeChecked(true);
+          .shouldBeChecked(true);
       $(By.id(Key.FILE)).shouldNotHave(cssClass("ui-state-disabled"));
     }
 
@@ -170,7 +170,7 @@ class WebTestSSL {
     @Test
     void enableInsecureSSL() {
       PrimeUi.selectBooleanCheckbox(By.id(ENABLE_INSECURE_SSL))
-      .shouldBeChecked(false);
+          .shouldBeChecked(false);
       PrimeUi.selectBooleanCheckbox(By.id(ENABLE_INSECURE_SSL)).setChecked();
 
       saveTrustStore();
@@ -178,7 +178,7 @@ class WebTestSSL {
       Navigation.toSSL();
 
       PrimeUi.selectBooleanCheckbox(By.id(ENABLE_INSECURE_SSL))
-      .shouldBeChecked(true);
+          .shouldBeChecked(true);
     }
 
     @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
@@ -42,7 +42,7 @@ import ch.ivyteam.enginecockpit.util.Table;
 @IvyWebTest
 public class WebTestSystemDb {
   private static final String SYS_DB = System.getProperty("db.host",
-          "db host not set via ${db.host} system property");
+      "db host not set via ${db.host} system property");
   private static final String SYS_DB_PW = "1234";
   private static final String SYS_DB_USER = "root";
   private static final String CONNECTION_BUTTON = "#systemDb\\:systemDbForm\\:checkConnectionButton";
@@ -128,7 +128,7 @@ public class WebTestSystemDb {
   }
 
   private static void insertDbConnection(String database, String driverName, String host,
-          String databaseName, String user, String password) {
+      String databaseName, String user, String password) {
     SelectOneMenu dbType = PrimeUi.selectOne(By.id("systemDb:systemDbForm:databaseType"));
     SelectOneMenu dbDriver = PrimeUi.selectOne(By.id("systemDb:systemDbForm:databaseDriver"));
     dbType.selectItemByLabel(database);
@@ -150,7 +150,7 @@ public class WebTestSystemDb {
     insertDbConnection("MySQL", "mySQL", SYS_DB, TEST_DB_NAME, SYS_DB_USER, SYS_DB_PW);
     $(CONNECTION_BUTTON).click();
     $(CONNECTION_PANEL)
-            .shouldBe(text("Missing Database/Schema"), text("Create system database."));
+        .shouldBe(text("Missing Database/Schema"), text("Create system database."));
     $("#systemDb\\:systemDbForm\\:createDatabaseButton").shouldBe(enabled);
 
     $("#systemDb\\:systemDbForm\\:createDatabaseButton").click();
@@ -162,9 +162,9 @@ public class WebTestSystemDb {
     $(By.id("systemDb:createDatabaseForm:confirmCreateButton")).click();
     $(By.id("systemDb:createDatabaseForm:confirmCreateButton")).shouldNotBe(enabled);
     $("#systemDb\\:createDatabaseForm\\:confirmCreateButton > .ui-icon")
-            .shouldHave(cssClass("si-is-spinning"));
+        .shouldHave(cssClass("si-is-spinning"));
     $("#systemDb\\:createDatabaseForm\\:closeCreationButton")
-            .shouldBe(and("wait until db created", appear, enabled), Duration.ofSeconds(20));
+        .shouldBe(and("wait until db created", appear, enabled), Duration.ofSeconds(20));
     $("#systemDb\\:createDatabaseForm\\:creationError").shouldNot(exist);
     $("#systemDb\\:createDatabaseForm\\:creationInfo").shouldBe(text("The database was created successfully"));
     $("#systemDb\\:createDatabaseForm\\:closeCreationButton").click();
@@ -186,7 +186,7 @@ public class WebTestSystemDb {
     Selenide.refresh();
     insertDbConnection("MySQL", "mySQL", SYS_DB, TEST_DB_NAME, SYS_DB_USER, SYS_DB_PW);
     SelectBooleanCheckbox defaultPort = PrimeUi.selectBooleanCheckbox(
-            By.cssSelector(".sysdb-dynamic-form-port-default-checkbox"));
+        By.cssSelector(".sysdb-dynamic-form-port-default-checkbox"));
     defaultPort.removeChecked();
     $(".sysdb-dynamic-form-port input").shouldBe(enabled);
     $(".sysdb-dynamic-form-port input").clear();
@@ -253,7 +253,7 @@ public class WebTestSystemDb {
     $(".sysdb-dynamic-form-port input").shouldBe(visible);
 
     SelectBooleanCheckbox defaultPort = PrimeUi.selectBooleanCheckbox(
-            By.cssSelector(".sysdb-dynamic-form-port-default-checkbox"));
+        By.cssSelector(".sysdb-dynamic-form-port-default-checkbox"));
     $(".sysdb-dynamic-form-port input").shouldNotBe(enabled);
     defaultPort.shouldBeChecked(true);
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestWebServer.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestWebServer.java
@@ -59,7 +59,7 @@ public class WebTestWebServer {
   @Test
   void checkData() {
     $("#coreRequestData").shouldHave(text(EngineUrl.base()),
-            text("/engine-cockpit/faces/webserver.xhtml"));
+        text("/engine-cockpit/faces/webserver.xhtml"));
     $(By.id("form:requestHeaderTable")).shouldNot(exist);
     $("#form\\:showHeaders").shouldBe(visible).click();
     $("#form\\:showHeaders").shouldNotBe(visible);
@@ -134,7 +134,7 @@ public class WebTestWebServer {
   }
 
   private static void setConnector(SelectBooleanCheckbox checkbox, String input, boolean enabled,
-          String value, String growlMessage) {
+      String value, String growlMessage) {
     if (enabled) {
       checkbox.setChecked();
     } else {
@@ -154,7 +154,7 @@ public class WebTestWebServer {
   }
 
   private static void assertConnector(SelectBooleanCheckbox checkbox, String input, boolean enabled,
-          String value) {
+      String value) {
     $(By.id(WEB_SERVER_FORM + input + "_input")).shouldBe(value(value));
     checkbox.shouldBeChecked(enabled);
   }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Conditions.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Conditions.java
@@ -18,7 +18,7 @@ public class Conditions {
   }
 
   public static WebElementCondition satisfiesText(IntConsumer consumer) {
-    return new  IntegerCondition(consumer);
+    return new IntegerCondition(consumer);
   }
 
   public static final WebElementCondition INTEGER_TEXT = new IntegerCondition();
@@ -26,7 +26,7 @@ public class Conditions {
 
   private static class IntegerCondition extends WebElementCondition {
 
-    private IntConsumer consumer;
+    private final IntConsumer consumer;
 
     public IntegerCondition() {
       this(i -> {});
@@ -44,7 +44,7 @@ public class Conditions {
         var i = Integer.parseInt(element.getText());
         consumer.accept(i);
         return new CheckResult(true, text);
-      } catch(AssertionError | RuntimeException ex) {
+      } catch (AssertionError | RuntimeException ex) {
         return new CheckResult(false, text);
       }
     }
@@ -52,10 +52,10 @@ public class Conditions {
 
   private static class MatchText extends WebElementCondition {
 
-    private Pattern pattern;
+    private final Pattern pattern;
 
     public MatchText(Pattern pattern) {
-      super("Text match pattern " +pattern);
+      super("Text match pattern " + pattern);
       this.pattern = pattern;
     }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/EngineCockpitUtil.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/EngineCockpitUtil.java
@@ -228,7 +228,7 @@ public class EngineCockpitUtil {
 
   private static void runTestProcess(String processLink) {
     open(create().app(getAppName()).servlet(SERVLET.PROCESS).path("engine-cockpit-test-data/" + processLink)
-            .toUrl());
+        .toUrl());
     assertCurrentUrlContains(isDesigner() ? "/dev-workflow-ui/faces" : "end");
   }
 
@@ -237,7 +237,7 @@ public class EngineCockpitUtil {
   }
 
   public static String viewUrl(String page, Map<String, String> queryParams) {
-    var urlBuilder = create();//.staticView(parts.path)
+    var urlBuilder = create();// .staticView(parts.path)
     if (isDesigner()) {
       // test it in designer as PMV
       urlBuilder = urlBuilder.staticView("engine-cockpit/" + page);
@@ -268,14 +268,14 @@ public class EngineCockpitUtil {
   }
 
   public static void assertLiveStats(List<String> expectedChartTitles, String jmxSourceMessage,
-          boolean emptyGraphs) {
+      boolean emptyGraphs) {
     $("#layout-config-button").shouldBe(visible).click();
     $(".layout-config h3").shouldBe(visible, text("Live Stats"));
     $$(".layout-config h4").shouldHave(
-            texts(expectedChartTitles));
+        texts(expectedChartTitles));
     if (!emptyGraphs) {
       $$(".layout-config .ui-chart").shouldBe(
-              size(expectedChartTitles.size()));
+          size(expectedChartTitles.size()));
     }
     if (jmxSourceMessage != null) {
       $(".layout-config .ui-staticmessage").shouldHave(text(jmxSourceMessage));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/FeatureEditor.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/FeatureEditor.java
@@ -7,18 +7,18 @@ import org.openqa.selenium.By;
 
 public class FeatureEditor {
 
-  private String featureEditor;
+  private final String featureEditor;
 
   public FeatureEditor(String featureEditor) {
     this.featureEditor = featureEditor;
   }
-  
+
   public void addFeature(String feature) {
     $(By.id(featureEditor + "newFeatureEditor:newServiceFeatureBtn")).shouldBe(visible).click();
     $(By.id(featureEditor + "newFeatureEditor:featureForm:nameInput")).sendKeys(feature);
     $(By.id(featureEditor + "newFeatureEditor:featureForm:saveFeature")).click();
   }
-  
+
   public void editFeature(String value, Integer editFeatureNumber, Integer nameInputNumber) {
     $(By.id(featureEditor + editFeatureNumber + ":editFeatureEditor:editFeatureBtn")).shouldBe(visible).click();
     $(By.id(featureEditor + nameInputNumber + ":editFeatureEditor:featureForm:nameInput")).clear();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/HttpAsserter.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/HttpAsserter.java
@@ -18,7 +18,7 @@ public class HttpAsserter {
 
   public static class HttpAssert {
 
-    private String url;
+    private final String url;
 
     private HttpAssert(String url) {
       this.url = url;
@@ -54,9 +54,9 @@ public class HttpAsserter {
 
     private Set<String> findDeadLinks(Set<String> linksToCheck, Set<String> linksAlreadyChecked, String sessionId) {
       return linksToCheck.stream()
-              .filter(link -> !containsQueryParamIgnore(linksAlreadyChecked, link))
-              .filter(link -> !check(link, sessionId))
-              .collect(Collectors.toSet());
+          .filter(link -> !containsQueryParamIgnore(linksAlreadyChecked, link))
+          .filter(link -> !check(link, sessionId))
+          .collect(Collectors.toSet());
     }
 
     private static Set<String> parseLinks(String url, String sessionId) {
@@ -73,7 +73,7 @@ public class HttpAsserter {
           if (StringUtils.isEmpty(href)) {
             continue;
           }
-          var u = URI.create(href.replaceAll(" ", "+"));
+          var u = URI.create(href.replace(' ', '+'));
           if (u.isAbsolute()) {
             result.add(href);
           } else {
@@ -95,15 +95,15 @@ public class HttpAsserter {
     }
 
     private boolean check(String urlToCheck, String sessionId) {
-        System.out.println("check " + urlToCheck);
-        try {
-          var con = Jsoup.connect(urlToCheck);
-          con.cookie("JSESSIONID", sessionId);
-          con.get();
-          return true;
-        } catch (IOException ex) {
-          return false;
-        }
+      System.out.println("check " + urlToCheck);
+      try {
+        var con = Jsoup.connect(urlToCheck);
+        con.cookie("JSESSIONID", sessionId);
+        con.get();
+        return true;
+      } catch (IOException ex) {
+        return false;
+      }
     }
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -96,10 +96,10 @@ public class Navigation {
 
   private static void openAppTreeActivity(String appName) {
     $$(".activity-name").find(exactText(appName))
-            .parent()
-            .parent()
-            .find(".ui-treetable-toggler").shouldBe(visible)
-            .click();
+        .parent()
+        .parent()
+        .find(".ui-treetable-toggler").shouldBe(visible)
+        .click();
   }
 
   private static void clickAppTreeActivity(String appName) {
@@ -193,7 +193,7 @@ public class Navigation {
     toRoles();
     $(Tab.SECURITY_SYSTEM.activePanelCss + " .expand-all").shouldBe(visible).click();
     $$(Tab.SECURITY_SYSTEM.activePanelCss + " .role-name").find(text(roleName)).shouldBe(visible).click();
-    assertCurrentUrlContains("roledetail.xhtml?system="+system+"&name=" + roleName);
+    assertCurrentUrlContains("roledetail.xhtml?system=" + system + "&name=" + roleName);
     menuShouldBeActive(SECURITY_ROLES_MENU);
   }
 
@@ -410,7 +410,6 @@ public class Navigation {
   public static void toJfr() {
     toSubSubMenu(MONITOR_MENU, MONITOR_JAVA_MENU, MONITOR_JAVA_JFR);
   }
-
 
   private static void toMenu(String menuItemPath) {
     closeMenus();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/PropertyEditor.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/PropertyEditor.java
@@ -7,19 +7,19 @@ import org.openqa.selenium.By;
 
 public class PropertyEditor {
 
-  private String propertyEditor;
+  private final String propertyEditor;
 
   public PropertyEditor(String propertyEditor) {
     this.propertyEditor = propertyEditor;
   }
-  
+
   public void addProperty(String key, String value) {
     $(By.id(propertyEditor + "newServicePropertyBtn")).shouldBe(visible).click();
     $(By.id(propertyEditor + "propertyForm:nameInput")).sendKeys(key);
     $(By.id(propertyEditor + "propertyForm:valueInput")).sendKeys(value);
     $(By.id(propertyEditor + "propertyForm:saveProperty")).click();
   }
-  
+
   public void editProperty(String value) {
     $(By.id(propertyEditor + "editPropertyBtn")).shouldBe(visible).click();
     $(By.id(propertyEditor + "propertyForm:valueInput")).clear();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
@@ -13,24 +13,25 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import com.codeborne.selenide.SelenideElement;
+
 public class Tab {
 
   public static String DEFAULT_APP = isDesigner() ? DESIGNER : "test";
 
   public static final Tab SECURITY_SYSTEM = new Tab(
-          "li.security-system-tab > a",
-          "li.security-system-tab",
-          "li.security-system-tab.ui-state-active",
-          ".ui-tabs-panel:not(.ui-helper-hidden)",
-          tab -> tab.switchToTab("default"));
+      "li.security-system-tab > a",
+      "li.security-system-tab",
+      "li.security-system-tab.ui-state-active",
+      ".ui-tabs-panel:not(.ui-helper-hidden)",
+      tab -> tab.switchToTab("default"));
 
   public static final Tab APP = new Tab(
-          "li.application-tab > a",
-          "li.application-tab",
-          "li.application-tab.ui-state-active",
-          ".ui-tabs-panel:not(.ui-helper-hidden)",
-          tab -> tab.switchToTab(DEFAULT_APP));
-  
+      "li.application-tab > a",
+      "li.application-tab",
+      "li.application-tab.ui-state-active",
+      ".ui-tabs-panel:not(.ui-helper-hidden)",
+      tab -> tab.switchToTab(DEFAULT_APP));
 
   private final String tab;
   private final String li;
@@ -52,8 +53,8 @@ public class Tab {
 
   public List<String> getTabs() {
     return $$(tab).asDynamicIterable().stream()
-            .map(e -> e.getText())
-            .collect(Collectors.toList());
+        .map(SelenideElement::getText)
+        .collect(Collectors.toList());
   }
 
   public int getSelectedTabIndex() {
@@ -78,7 +79,7 @@ public class Tab {
       $$(tab).get(index).click();
     }
     $$(selectedTab).find(cssClass("ui-state-active"))
-            .shouldHave(attribute("data-index", String.valueOf(index)));
+        .shouldHave(attribute("data-index", String.valueOf(index)));
   }
 
   public void switchToTab(String securitySystemName) {
@@ -86,9 +87,9 @@ public class Tab {
       return;
     }
     $$(tab).asDynamicIterable().stream()
-            .filter(e -> e.has(exactText(securitySystemName)))
-            .findFirst()
-            .ifPresent(app -> app.click());
+        .filter(e -> e.has(exactText(securitySystemName)))
+        .findFirst()
+        .ifPresent(SelenideElement::click);
     $(selectedTab).shouldBe(exactText(securitySystemName));
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Table.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Table.java
@@ -20,10 +20,10 @@ import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.WebElementsCondition;
 
 public class Table {
-  private String id;
-  private String rowNumberField;
+  private final String id;
+  private final String rowNumberField;
   private String subElement = "";
-  private String globalFilter;
+  private final String globalFilter;
 
   public Table(By by) {
     this(by, "", "data-ri");
@@ -46,7 +46,7 @@ public class Table {
 
   public List<String> getFirstColumnEntries() {
     return $$x(getFirstColumnSpanElement()).asDynamicIterable().stream()
-            .map(e -> e.getText()).collect(Collectors.toList());
+        .map(SelenideElement::getText).collect(Collectors.toList());
   }
 
   public void headerShouldBe(WebElementsCondition cond) {
@@ -56,16 +56,18 @@ public class Table {
   public void firstColumnShouldBe(WebElementsCondition cond) {
     firstColumnShouldBe(cond, 1);
   }
+
   public void firstColumnShouldBe(WebElementsCondition cond, int indexOfSpanElement) {
     $$x(getFirstColumnSpanElement(indexOfSpanElement)).shouldBe(cond, Duration.ofSeconds(10));
   }
+
   public void columnShouldBe(int col, WebElementsCondition cond) {
     $$x(getColumnSpanElement(col)).shouldBe(cond, Duration.ofSeconds(10));
   }
 
   public List<String> getFirstColumnEntriesForSpanClass(String span) {
     return $$x(getFirstColumnSpanElement() + "[@class='" + span + "']").asDynamicIterable().stream()
-            .map(e -> e.getText()).collect(Collectors.toList());
+        .map(SelenideElement::getText).collect(Collectors.toList());
   }
 
   public void valueForEntryShould(String entry, int column, WebElementCondition condition) {
@@ -75,23 +77,21 @@ public class Table {
   public SelenideElement tableEntry(String entry, int column) {
     return tableEntry(entry, column, 1);
   }
+
   public SelenideElement tableEntry(String entry, int column, int indexOfSpanElement) {
     return $x(findColumnOverEntry(entry, indexOfSpanElement) + "/td[" + column + "]");
   }
 
-  public SelenideElement tableEntry(int row, int column)
-  {
+  public SelenideElement tableEntry(int row, int column) {
     return $x(getBody() + "/tr[" + row + "]/td[" + column + "]");
   }
-
 
   public SelenideElement row(String entry) {
     return $x(findColumnOverEntry(entry));
   }
 
-  public ElementsCollection rows()
-  {
-    return $$x(getBody()+"/tr");
+  public ElementsCollection rows() {
+    return $$x(getBody() + "/tr");
   }
 
   public SelenideElement body() {
@@ -125,16 +125,17 @@ public class Table {
 
   private String getRowNumber(String entry) {
     return $x(findColumnOverEntry(entry))
-            .getAttribute(rowNumberField);
+        .getAttribute(rowNumberField);
   }
 
   private String getHeaderSpanElement() {
-    return getHeader()+"/tr/th/span[1]";
+    return getHeader() + "/tr/th/span[1]";
   }
 
   private String getFirstColumnSpanElement() {
     return getFirstColumnSpanElement(1);
   }
+
   private String getFirstColumnSpanElement(int indexOfSpanElement) {
     return getColumnSpanElement(1, indexOfSpanElement);
   }
@@ -142,17 +143,18 @@ public class Table {
   private String getColumnSpanElement(int col) {
     return getColumnSpanElement(col, 1);
   }
+
   private String getColumnSpanElement(int col, int indexOfSpanElement) {
     if (StringUtils.isNotBlank(subElement)) {
       if (col > 1) {
-        return getBody()+"/tr/td["+col+"]/" + subElement + "";
+        return getBody() + "/tr/td[" + col + "]/" + subElement + "";
       }
-      return getBody()+"/tr/td["+col+"]/" + subElement + "/span[" + indexOfSpanElement + "]";
+      return getBody() + "/tr/td[" + col + "]/" + subElement + "/span[" + indexOfSpanElement + "]";
     }
     if (col > 1) {
-      return getBody()+"/tr/td["+col+"]";
+      return getBody() + "/tr/td[" + col + "]";
     }
-    return getBody()+"/tr/td["+col+"]/span";
+    return getBody() + "/tr/td[" + col + "]/span";
   }
 
   private String getHeader() {
@@ -166,6 +168,7 @@ public class Table {
   private String findColumnOverEntry(String entry) {
     return findColumnOverEntry(entry, 1);
   }
+
   private String findColumnOverEntry(String entry, int indexOfSpanElement) {
     String parentTdFromSpan = "/../..";
     if (StringUtils.isNotBlank(subElement)) {
@@ -188,6 +191,6 @@ public class Table {
   }
 
   public void sortByColumn(String column) {
-    $x("//div[@id='" + id + "']//thead//tr//span[text()='"+column+"']").click();
+    $x("//div[@id='" + id + "']//thead//tr//span[text()='" + column + "']").click();
   }
 }

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/LinkFactoryBean.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/LinkFactoryBean.java
@@ -23,13 +23,12 @@ public class LinkFactoryBean {
   private static final String DESIGNER_APP_CONTEXT = "/" + IApplication.DESIGNER_APPLICATION_NAME;
 
   public List<Link> getLinks() {
-    var links = new ArrayList<Link>();
-    links.addAll(Stream.of(CockpitLinkFactory.class.getMethods())
-            .filter(m -> Modifier.isPublic(m.getModifiers()) && Modifier.isStatic(m.getModifiers()))
-            .filter(m -> m.getParameterCount() == 0)
-            .filter(m -> m.getReturnType().equals(WebLink.class))
-            .map(this::toLink)
-            .toList());
+    var links = new ArrayList<>(Stream.of(CockpitLinkFactory.class.getMethods())
+        .filter(m -> Modifier.isPublic(m.getModifiers()) && Modifier.isStatic(m.getModifiers()))
+        .filter(m -> m.getParameterCount() == 0)
+        .filter(m -> m.getReturnType().equals(WebLink.class))
+        .map(this::toLink)
+        .toList());
     links.add(externalDatabase());
     links.add(restService());
     return links;
@@ -48,7 +47,7 @@ public class LinkFactoryBean {
     ExternalContext externalContext = FacesContext.getCurrentInstance().getExternalContext();
     var appContext = externalContext.getRequestContextPath();
     String path;
-    if (!appContext.equals(DESIGNER_APP_CONTEXT)) {
+    if (!DESIGNER_APP_CONTEXT.equals(appContext)) {
       path = "/system/engine-cockpit/faces/" + link.getRelative();
     } else {
       path = appContext + externalContext.getRequestServletPath() + externalContext.getRequestPathInfo();
@@ -57,7 +56,7 @@ public class LinkFactoryBean {
     link = WebLink.of(path);
     return new Link(title, link.getAbsolute());
   }
-  
+
   private Link externalDatabase() {
     return toLink("External Database realDb", CockpitLinkFactory.externalDatabase(applicationName(), "realdb"));
   }
@@ -74,8 +73,8 @@ public class LinkFactoryBean {
 
   public static class Link {
 
-    private String title;
-    private String href;
+    private final String title;
+    private final String href;
 
     public Link(String title, String href) {
       this.title = title;

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/Deadlock.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/Deadlock.java
@@ -4,7 +4,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public class Deadlock {
 
-  private ReentrantLock lock = new ReentrantLock();
+  private final ReentrantLock lock = new ReentrantLock();
   private Deadlock other;
 
   public static void start() {
@@ -24,8 +24,7 @@ public class Deadlock {
         Thread.sleep(5000);
         other.monitor(++count);
       }
-    } catch (InterruptedException e) {
-    }
+    } catch (InterruptedException e) {}
   }
 
   private void reentrantLock(int count) {
@@ -35,8 +34,7 @@ public class Deadlock {
         Thread.sleep(5000);
         other.reentrantLock(++count);
       }
-    } catch (InterruptedException ex) {
-    } finally {
+    } catch (InterruptedException ex) {} finally {
       lock.unlock();
     }
   }

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/InitError.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/InitError.java
@@ -4,7 +4,6 @@ import ch.ivyteam.ivy.process.eventstart.AbstractProcessStartEventBean;
 import ch.ivyteam.ivy.process.eventstart.IProcessStartEventBeanRuntime;
 import ch.ivyteam.ivy.process.extension.ProgramConfig;
 
-
 public class InitError extends AbstractProcessStartEventBean {
 
   public InitError() {
@@ -15,5 +14,5 @@ public class InitError extends AbstractProcessStartEventBean {
   public void initialize(IProcessStartEventBeanRuntime eventRuntime, ProgramConfig configuration) {
     throw new RuntimeException("Exception in initialize method");
   }
-  
+
 }

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollError.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollError.java
@@ -2,7 +2,6 @@ package ch.ivyteam.enginecockpit.monitor;
 
 import ch.ivyteam.ivy.process.eventstart.AbstractProcessStartEventBean;
 
-
 public class PollError extends AbstractProcessStartEventBean {
 
   public PollError() {

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollErrorIntermediateClass.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/PollErrorIntermediateClass.java
@@ -16,6 +16,7 @@ public class PollErrorIntermediateClass extends AbstractProcessIntermediateEvent
     eventRuntime.threads().boundToEventLifecycle(() -> {});
 
   }
+
   @Override
   public void poll() {
     getEventBeanRuntime().poll().disable();

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/StartError.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/StartError.java
@@ -5,7 +5,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import ch.ivyteam.ivy.process.eventstart.AbstractProcessStartEventBean;
 import ch.ivyteam.ivy.service.ServiceException;
 
-
 public class StartError extends AbstractProcessStartEventBean {
 
   public StartError() {

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/StopError.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/StopError.java
@@ -5,7 +5,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import ch.ivyteam.ivy.process.eventstart.AbstractProcessStartEventBean;
 import ch.ivyteam.ivy.service.ServiceException;
 
-
 public class StopError extends AbstractProcessStartEventBean {
 
   public StopError() {

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/ThreadBean.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/monitor/ThreadBean.java
@@ -9,16 +9,15 @@ public class ThreadBean extends AbstractProcessStartEventBean {
   public ThreadBean() {
     super("ThreadBean", "Description of ThreadBean");
   }
-  
+
   @Override
   public void initialize(IProcessStartEventBeanRuntime eventRuntime, ProgramConfig configuration) {
     super.initialize(eventRuntime, configuration);
     eventRuntime.threads().boundToEventLifecycle(() -> {
-      synchronized(this) {
+      synchronized (this) {
         try {
           wait();
-        } catch (InterruptedException e) {
-        }
+        } catch (InterruptedException e) {}
       }
     });
   }

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/services/RenewLicenceService.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/services/RenewLicenceService.java
@@ -24,7 +24,7 @@ public class RenewLicenceService {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   public Response create(@FormDataParam("oldLicense") InputStream oldLicenseStream,
-          @FormDataParam("oldLicense") FormDataContentDisposition oldLicenseDetail) {
+      @FormDataParam("oldLicense") FormDataContentDisposition oldLicenseDetail) {
     try {
       API.checkNotNull(oldLicenseDetail, "oldLicenseDetail");
       SignedLicence.load().fromInputStream(oldLicenseStream);

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/system/database/SystemDatabaseCreator.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/system/database/SystemDatabaseCreator.java
@@ -33,16 +33,15 @@ public class SystemDatabaseCreator {
   private static DatabaseConnectionConfiguration getDbConfig(String dbName) {
     var dbHost = System.getProperty("db.host", "db host not set via system property db.host");
     return new DatabaseConnectionConfiguration(
-            "jdbc:mysql://" + dbHost + ":3306/" + dbName,
-            "com.mysql.cj.jdbc.Driver", "root", "1234");
+        "jdbc:mysql://" + dbHost + ":3306/" + dbName,
+        "com.mysql.cj.jdbc.Driver", "root", "1234");
   }
 
   private static void deleteSystemDb(String dbName) {
     try (Connection connection = DatabaseUtil.openConnection(getDbConfig(dbName))) {
       Statement stmt = connection.createStatement();
       stmt.execute("DROP DATABASE " + dbName);
-    } catch (SQLException ex) {
-    }
+    } catch (SQLException ex) {}
   }
 
   private static void createSystemDb(String dbName) throws SQLException {

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/testdata/businessdata/TestDataCreator.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/testdata/businessdata/TestDataCreator.java
@@ -11,22 +11,22 @@ public class TestDataCreator {
 
     if (dossierCount == 0) {
       createDemoDossier("HEISENBERG DE", "Werner", "Heisenberg", new Date(1901, 12, 5), "97070", "Würzburg",
-              "Germany");
+          "Germany");
       createDemoDossier("PAULI AT", "Wolfgang", "Pauli", new Date(1900, 04, 25), "1010", "Wien", "Austria");
       createDemoDossier("NOETHER DE", "Emmy", "Noether", new Date(1882, 03, 23), "91052", "Erlangen",
-              "Germany");
+          "Germany");
       createDemoDossier("TURING GB", "Alan", "Turing", new Date(1912, 06, 23), "10000", "London", "England");
       createDemoDossier("RAMANUJAN IN", "Srinivasa", "Ramanujan", new Date(1887, 12, 22), "30000", "Erode",
-              "India");
+          "India");
       createDemoDossier("LOVELACE GB", "Ada", "Lovelace", new Date(1815, 12, 10), "20000", "London",
-              "England");
+          "England");
       createDemoDossier("POINCARE FR", "Henri", "Poincaré", new Date(1854, 04, 29), "54000", "Nancy",
-              "France");
+          "France");
       createDemoDossier("EULER CH", "Leonhard", "Euler", new Date(1707, 04, 15), "4000", "Basel",
-              "Switzerland");
+          "Switzerland");
       createDemoDossier("VOLTA IT", "Alessandro", "Volta", new Date(1745, 02, 18), "22100", "Como", "Italy");
       createDemoDossier("NEUMANN HU", "John", "von Neumann", new Date(1903, 12, 28), "1011", "Budapest",
-              "Hungary");
+          "Hungary");
       waitForDossierCount(repo, 10);
 
       Address address = new Address();
@@ -38,13 +38,11 @@ public class TestDataCreator {
   }
 
   private static void waitForDossierCount(BusinessDataRepository repo, int count) {
-    long dossierCount;
-    dossierCount = countDossier(repo);
+    long dossierCount = countDossier(repo);
     while (dossierCount < count) {
       try {
         Thread.sleep(500);
-      } catch (InterruptedException e) {
-      }
+      } catch (InterruptedException e) {}
       dossierCount = countDossier(repo);
     }
   }
@@ -58,7 +56,7 @@ public class TestDataCreator {
   }
 
   private static void createDemoDossier(String dossierName, String firstName, String lastName, Date birthdate,
-          String zip, String city, String country) {
+      String zip, String city, String country) {
     Dossier dossier = new Dossier();
     dossier.name = dossierName;
 

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/testdata/security/DynamicRoles.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/testdata/security/DynamicRoles.java
@@ -15,8 +15,8 @@ public class DynamicRoles {
       var roles = context().roles();
       for (var i = 0; i < 110; i++) {
         var newRole = NewRole.create("role-" + UUID.randomUUID())
-          .displayName("dynamic role")
-          .toNewRole();
+            .displayName("dynamic role")
+            .toNewRole();
         roles.create(newRole);
       }
     });
@@ -38,7 +38,7 @@ public class DynamicRoles {
 
   private static ISecurityContext context() {
     return IApplicationRepository.instance()
-              .findByName("test").orElseThrow()
-              .getSecurityContext();
+        .findByName("test").orElseThrow()
+        .getSecurityContext();
   }
 }

--- a/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/testdata/security/identity/DummyIdentityProvider.java
+++ b/engine-cockpit-test-data/src/ch/ivyteam/enginecockpit/testdata/security/identity/DummyIdentityProvider.java
@@ -51,30 +51,27 @@ public class DummyIdentityProvider implements IdentityProvider {
     @Override
     public List<DirectoryNode> root() {
       return List.of(
-              new DummyDirectoryNode("Group A"),
-              new DummyDirectoryNode("Group B"),
-              new DummyDirectoryNode("Group C")
-      );
+          new DummyDirectoryNode("Group A"),
+          new DummyDirectoryNode("Group B"),
+          new DummyDirectoryNode("Group C"));
     }
 
     @Override
     public List<DirectoryNode> children(DirectoryNode node) {
-      if (node.displayName().equals("Group A")) {
+      if ("Group A".equals(node.displayName())) {
         return List.of(
-                new DummyDirectoryNode("Group A.1"),
-                new DummyDirectoryNode("Group A.2")
-        );
+            new DummyDirectoryNode("Group A.1"),
+            new DummyDirectoryNode("Group A.2"));
       }
       return List.of();
     }
 
     @Override
     public List<Property> properties(DirectoryNode node) {
-      if (node.displayName().equals("Group A.1")) {
+      if ("Group A.1".equals(node.displayName())) {
         return List.of(
-                new Property("location", "Zug"),
-                new Property("teamMembers", "8")
-        );
+            new Property("location", "Zug"),
+            new Property("teamMembers", "8"));
       }
       return null;
     }

--- a/engine-cockpit-test-data/src/com/axonivy/engine/cockpit/testdata/rest/MyFakeOAuthFeature.java
+++ b/engine-cockpit-test-data/src/com/axonivy/engine/cockpit/testdata/rest/MyFakeOAuthFeature.java
@@ -8,7 +8,6 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
-
 public class MyFakeOAuthFeature implements Feature {
 
   @Override

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/application/TestProcessModelVersion.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/application/TestProcessModelVersion.java
@@ -28,7 +28,7 @@ public class TestProcessModelVersion {
   }
 
   @SuppressWarnings("unused")
-  private static Object invoke( Object proxy, Method method, Object[] args) throws Throwable {
+  private static Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
     if ("getId".equals(method.getName())) {
       return 0l;
     }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/health/TestHealthBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/health/TestHealthBean.java
@@ -15,7 +15,7 @@ class TestHealthBean {
 
   @AfterEach
   void after() {
-    ((IManager)HealthChecker.instance()).stop();
+    ((IManager) HealthChecker.instance()).stop();
   }
 
   @Test
@@ -34,7 +34,7 @@ class TestHealthBean {
 
   @Test
   void check() {
-    var check = testee.getChecks().stream().filter(c -> c.getName().equals("Release Candidate")).findAny().orElseThrow();
+    var check = testee.getChecks().stream().filter(c -> "Release Candidate".equals(c.getName())).findAny().orElseThrow();
     assertThat(check.getName()).isEqualTo("Release Candidate");
     assertThat(check.getDescription()).isEqualTo("Checks if this is a release candidate version");
     assertThat(check.getSeverity()).isEqualTo(HealthSeverity.HEALTHY);
@@ -69,7 +69,7 @@ class TestHealthBean {
     assertThat(testee.getMessage()).isEqualTo("No problems detected. Engine is healthy.");
     assertThat(testee.getMessages()).isEmpty();
 
-    ((IManager)HealthChecker.instance()).start();
+    ((IManager) HealthChecker.instance()).start();
     testee.refresh();
 
     assertThat(testee.getMessageCount()).isEqualTo(1);
@@ -79,7 +79,7 @@ class TestHealthBean {
 
   @Test
   void message() {
-    ((IManager)HealthChecker.instance()).start();
+    ((IManager) HealthChecker.instance()).start();
     testee.refresh();
 
     var msg = testee.getMessages().get(0);
@@ -98,7 +98,7 @@ class TestHealthBean {
     assertThat(testee.getSeverityIcon()).isEqualTo("si si-check-1");
     assertThat(testee.getSeverityName()).isEqualTo("HEALTHY");
 
-    ((IManager)HealthChecker.instance()).start();
+    ((IManager) HealthChecker.instance()).start();
     testee.refresh();
 
     assertThat(testee.getSeverityClass()).isEqualTo("health-high");
@@ -110,7 +110,7 @@ class TestHealthBean {
   void checkNow() {
     assertThat(testee.getMessageCount()).isEqualTo(0);
 
-    ((IManager)HealthChecker.instance()).start();
+    ((IManager) HealthChecker.instance()).start();
     testee.checkNow();
 
     assertThat(testee.getMessageCount()).isEqualTo(1);

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestClusterMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestClusterMonitorBean.java
@@ -26,17 +26,17 @@ public class TestClusterMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var mails = (LineChartDataSet)dataSet.get(0);
+    var mails = (LineChartDataSet) dataSet.get(0);
     assertThat(mails.getLabel()).isEqualTo("Sent");
     assertThat(mails.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Errors");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getSendMessagesMonitor().getInfo())
-            .isEqualTo("Sent Messages: -, Total 3, Errors -, Errors Total 4");
+        .isEqualTo("Sent Messages: -, Total 3, Errors -, Errors Total 4");
   }
 
   @Test
@@ -48,22 +48,22 @@ public class TestClusterMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Min");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(5.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Avg");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var max = (LineChartDataSet)dataSet.get(2);
+    var max = (LineChartDataSet) dataSet.get(2);
     assertThat(max.getLabel()).isEqualTo("Max");
     assertThat(max.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(7.0D));
 
     assertThat(testee.getSendProcessingTimeMonitor().getInfo())
-            .isEqualTo("Send Processing Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
+        .isEqualTo("Send Processing Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
   }
 
   @Test
@@ -75,17 +75,17 @@ public class TestClusterMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var mails = (LineChartDataSet)dataSet.get(0);
+    var mails = (LineChartDataSet) dataSet.get(0);
     assertThat(mails.getLabel()).isEqualTo("Received");
     assertThat(mails.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Errors");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getReceiveMessagesMonitor().getInfo())
-            .isEqualTo("Received Messages: -, Total 10, Errors -, Errors Total 11");
+        .isEqualTo("Received Messages: -, Total 10, Errors -, Errors Total 11");
   }
 
   @Test
@@ -97,22 +97,22 @@ public class TestClusterMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Min");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(12.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Avg");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var max = (LineChartDataSet)dataSet.get(2);
+    var max = (LineChartDataSet) dataSet.get(2);
     assertThat(max.getLabel()).isEqualTo("Max");
     assertThat(max.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(14.0D));
 
     assertThat(testee.getReceiveProcessingTimeMonitor().getInfo())
-            .isEqualTo("Receive Processing Time: Min 12 us, Avg -, Max 14 us, Total 13 us");
+        .isEqualTo("Receive Processing Time: Min 12 us, Avg -, Max 14 us, Total 13 us");
   }
 
   @MBean("ivy Engine:type=Cluster Channel")

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestDatabaseMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestDatabaseMonitorBean.java
@@ -52,12 +52,12 @@ class TestDatabaseMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var openConnections = (LineChartDataSet)dataSet.get(0);
+    var openConnections = (LineChartDataSet) dataSet.get(0);
     assertThat(openConnections.getLabel()).isEqualTo("Open");
     assertThat(openConnections.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(2.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var usedConnections = (LineChartDataSet)dataSet.get(1);
+    var usedConnections = (LineChartDataSet) dataSet.get(1);
     assertThat(usedConnections.getLabel()).isEqualTo("Used");
     assertThat(usedConnections.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(1.0D));
 
@@ -73,17 +73,17 @@ class TestDatabaseMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var queries = (LineChartDataSet)dataSet.get(0);
+    var queries = (LineChartDataSet) dataSet.get(0);
     assertThat(queries.getLabel()).isEqualTo("Queries");
     assertThat(queries.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Errors");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getQueriesMonitor().getInfo())
-            .isEqualTo("Queries: -, Total 3, Errors -, Errors Total 4");
+        .isEqualTo("Queries: -, Total 3, Errors -, Errors Total 4");
   }
 
   @Test
@@ -95,22 +95,22 @@ class TestDatabaseMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Min");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(5.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Avg");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var max = (LineChartDataSet)dataSet.get(2);
+    var max = (LineChartDataSet) dataSet.get(2);
     assertThat(max.getLabel()).isEqualTo("Max");
     assertThat(max.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(7.0D));
 
     assertThat(testee.getExecutionTimeMonitor().getInfo())
-            .isEqualTo("Execution Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
+        .isEqualTo("Execution Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
   }
 
   @MBean("ivy Engine:type=External Database,application=test,name=#{name}")

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestEmailMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestEmailMonitorBean.java
@@ -26,12 +26,12 @@ public class TestEmailMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var mails = (LineChartDataSet)dataSet.get(0);
+    var mails = (LineChartDataSet) dataSet.get(0);
     assertThat(mails.getLabel()).isEqualTo("Mails");
     assertThat(mails.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Errors");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
@@ -47,22 +47,22 @@ public class TestEmailMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Min");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(5.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Avg");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var max = (LineChartDataSet)dataSet.get(2);
+    var max = (LineChartDataSet) dataSet.get(2);
     assertThat(max.getLabel()).isEqualTo("Max");
     assertThat(max.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(7.0D));
 
     assertThat(testee.getExecutionTimeMonitor().getInfo())
-            .isEqualTo("Execution Time: Min 5 us Avg - Max 7 us Total 6 us");
+        .isEqualTo("Execution Time: Min 5 us Avg - Max 7 us Total 6 us");
   }
 
   @MBean("ivy Engine:name=External Mail Server")

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestRestClientMonitor.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestRestClientMonitor.java
@@ -52,12 +52,12 @@ class TestRestClientMonitor {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var openConnections = (LineChartDataSet)dataSet.get(0);
+    var openConnections = (LineChartDataSet) dataSet.get(0);
     assertThat(openConnections.getLabel()).isEqualTo("Open");
     assertThat(openConnections.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(2.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var usedConnections = (LineChartDataSet)dataSet.get(1);
+    var usedConnections = (LineChartDataSet) dataSet.get(1);
     assertThat(usedConnections.getLabel()).isEqualTo("Used");
     assertThat(usedConnections.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(1.0D));
 
@@ -73,12 +73,12 @@ class TestRestClientMonitor {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var calls = (LineChartDataSet)dataSet.get(0);
+    var calls = (LineChartDataSet) dataSet.get(0);
     assertThat(calls.getLabel()).isEqualTo("Calls");
     assertThat(calls.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Errors");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
@@ -95,22 +95,22 @@ class TestRestClientMonitor {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Min");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(5.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Avg");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var max = (LineChartDataSet)dataSet.get(2);
+    var max = (LineChartDataSet) dataSet.get(2);
     assertThat(max.getLabel()).isEqualTo("Max");
     assertThat(max.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(7.0D));
 
     assertThat(testee.getExecutionTimeMonitor().getInfo())
-            .isEqualTo("Execution Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
+        .isEqualTo("Execution Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
   }
 
   @MBean("ivy Engine:type=External REST Web Service,application=test,name=\"#{name}\"")

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestSystemDatabaseMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestSystemDatabaseMonitorBean.java
@@ -26,12 +26,12 @@ public class TestSystemDatabaseMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var openConnections = (LineChartDataSet)dataSet.get(0);
+    var openConnections = (LineChartDataSet) dataSet.get(0);
     assertThat(openConnections.getLabel()).isEqualTo("Open");
     assertThat(openConnections.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(2.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var usedConnections = (LineChartDataSet)dataSet.get(1);
+    var usedConnections = (LineChartDataSet) dataSet.get(1);
     assertThat(usedConnections.getLabel()).isEqualTo("Used");
     assertThat(usedConnections.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(1.0D));
 
@@ -47,17 +47,17 @@ public class TestSystemDatabaseMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var transactions = (LineChartDataSet)dataSet.get(0);
+    var transactions = (LineChartDataSet) dataSet.get(0);
     assertThat(transactions.getLabel()).isEqualTo("Transactions");
     assertThat(transactions.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Errors");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getTransactionsMonitor().getInfo())
-            .isEqualTo("Transactions: -, Total 3, Errors -, Errors Total 4");
+        .isEqualTo("Transactions: -, Total 3, Errors -, Errors Total 4");
   }
 
   @Test
@@ -69,22 +69,22 @@ public class TestSystemDatabaseMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Min");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(5.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Avg");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var max = (LineChartDataSet)dataSet.get(2);
+    var max = (LineChartDataSet) dataSet.get(2);
     assertThat(max.getLabel()).isEqualTo("Max");
     assertThat(max.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(7.0D));
 
     assertThat(testee.getProcessingTimeMonitor().getInfo())
-            .isEqualTo("Processing Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
+        .isEqualTo("Processing Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
   }
 
   @MBean("ivy Engine:type=Database Persistency Service")

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestWebServiceMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestWebServiceMonitorBean.java
@@ -49,12 +49,12 @@ class TestWebServiceMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var calls = (LineChartDataSet)dataSet.get(0);
+    var calls = (LineChartDataSet) dataSet.get(0);
     assertThat(calls.getLabel()).isEqualTo("Calls");
     assertThat(calls.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Errors");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
@@ -70,22 +70,22 @@ class TestWebServiceMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Min");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(5.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Avg");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var max = (LineChartDataSet)dataSet.get(2);
+    var max = (LineChartDataSet) dataSet.get(2);
     assertThat(max.getLabel()).isEqualTo("Max");
     assertThat(max.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(7.0D));
 
     assertThat(testee.getExecutionTimeMonitor().getInfo())
-            .isEqualTo("Execution Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
+        .isEqualTo("Execution Time: Min 5 us, Avg -, Max 7 us, Total 6 us");
   }
 
   @MBean("ivy Engine:type=External Web Service,application=test,name=\"#{name}\"")

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/TestJvmMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/TestJvmMonitorBean.java
@@ -14,12 +14,12 @@ public class TestJvmMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var calls = (LineChartDataSet)dataSet.get(0);
+    var calls = (LineChartDataSet) dataSet.get(0);
     assertThat(calls.getLabel()).isEqualTo("System");
     assertThat(calls.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Process");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
@@ -34,17 +34,17 @@ public class TestJvmMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var active = (LineChartDataSet)dataSet.get(0);
+    var active = (LineChartDataSet) dataSet.get(0);
     assertThat(active.getLabel()).isEqualTo("Active");
     assertThat(active.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var daemons = (LineChartDataSet)dataSet.get(1);
+    var daemons = (LineChartDataSet) dataSet.get(1);
     assertThat(daemons.getLabel()).isEqualTo("Daemons");
     assertThat(daemons.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class)); // delta
 
     assertThat(testee.getThreadsMonitor().getInfo()).contains("Threads: Active ", ", Daemons  ", ", Peak ",
-            ", Total Started ");
+        ", Total Started ");
   }
 
   @Test
@@ -55,16 +55,16 @@ public class TestJvmMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var loaded = (LineChartDataSet)dataSet.get(0);
+    var loaded = (LineChartDataSet) dataSet.get(0);
     assertThat(loaded.getLabel()).isEqualTo("Loaded");
     assertThat(loaded.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var unloaded = (LineChartDataSet)dataSet.get(1);
+    var unloaded = (LineChartDataSet) dataSet.get(1);
     assertThat(unloaded.getLabel()).isEqualTo("Unloaded");
     assertThat(unloaded.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(testee.getClassesMonitor().getInfo()).contains("Classes: Loaded ", ", Unloaded  ",
-            ", Total Loaded ");
+        ", Total Loaded ");
   }
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/TestMemoryMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/TestMemoryMonitorBean.java
@@ -14,17 +14,17 @@ public class TestMemoryMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var calls = (LineChartDataSet)dataSet.get(0);
+    var calls = (LineChartDataSet) dataSet.get(0);
     assertThat(calls.getLabel()).isEqualTo("Used");
     assertThat(calls.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var errors = (LineChartDataSet)dataSet.get(1);
+    var errors = (LineChartDataSet) dataSet.get(1);
     assertThat(errors.getLabel()).isEqualTo("Committed");
     assertThat(errors.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(testee.getHeapMemoryMonitor().getInfo()).contains("Heap Memory: Used", ", Committed ",
-            ", Init ", ", Max ");
+        ", Init ", ", Max ");
   }
 
   @Test
@@ -35,12 +35,12 @@ public class TestMemoryMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var min = (LineChartDataSet)dataSet.get(0);
+    var min = (LineChartDataSet) dataSet.get(0);
     assertThat(min.getLabel()).isEqualTo("Used");
     assertThat(min.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var avg = (LineChartDataSet)dataSet.get(1);
+    var avg = (LineChartDataSet) dataSet.get(1);
     assertThat(avg.getLabel()).isEqualTo("Committed");
     assertThat(avg.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class)); // delta
 
@@ -55,21 +55,21 @@ public class TestMemoryMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var young = (LineChartDataSet)dataSet.get(0);
+    var young = (LineChartDataSet) dataSet.get(0);
     assertThat(young.getLabel()).isEqualTo("G1 Young Generation");
     assertThat(young.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var old = (LineChartDataSet)dataSet.get(1);
+    var old = (LineChartDataSet) dataSet.get(1);
     assertThat(old.getLabel()).isEqualTo("G1 Old Generation");
     assertThat(old.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
-    
+
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var concurrent = (LineChartDataSet)dataSet.get(2);
+    var concurrent = (LineChartDataSet) dataSet.get(2);
     assertThat(concurrent.getLabel()).isEqualTo("G1 Concurrent GC");
     assertThat(concurrent.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isInstanceOf(Number.class));
 
     assertThat(testee.getGarbageCollectorsMonitor().getInfo())
-            .contains("Garbage Collection: G1 Young Generation ", "Count", ", G1 Old Generation", "Count");
+        .contains("Garbage Collection: G1 Young Generation ", "Count", ", G1 Old Generation", "Count");
   }
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/TestRequestMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/TestRequestMonitorBean.java
@@ -34,17 +34,17 @@ public class TestRequestMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var http = (LineChartDataSet)dataSet.get(0);
+    var http = (LineChartDataSet) dataSet.get(0);
     assertThat(http.getLabel()).isEqualTo("Http");
     assertThat(http.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var https = (LineChartDataSet)dataSet.get(1);
+    var https = (LineChartDataSet) dataSet.get(1);
     assertThat(https.getLabel()).isEqualTo("Https");
     assertThat(https.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getRequestsMonitor().getInfo())
-            .isEqualTo("Requests: Http -, Http Total 300, Https -, Https Total 300");
+        .isEqualTo("Requests: Http -, Http Total 300, Https -, Https Total 300");
   }
 
   @Test
@@ -55,17 +55,17 @@ public class TestRequestMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var http = (LineChartDataSet)dataSet.get(0);
+    var http = (LineChartDataSet) dataSet.get(0);
     assertThat(http.getLabel()).isEqualTo("Http");
     assertThat(http.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var https = (LineChartDataSet)dataSet.get(1);
+    var https = (LineChartDataSet) dataSet.get(1);
     assertThat(https.getLabel()).isEqualTo("Https");
     assertThat(https.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getErrorsMonitor().getInfo())
-            .isEqualTo("Errors: Http -, Http Total 4, Https -, Https Total 4");
+        .isEqualTo("Errors: Http -, Http Total 4, Https -, Https Total 4");
   }
 
   @Test
@@ -76,27 +76,27 @@ public class TestRequestMonitorBean {
     assertThat(dataSet).hasSize(4);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var httpSent = (LineChartDataSet)dataSet.get(0);
+    var httpSent = (LineChartDataSet) dataSet.get(0);
     assertThat(httpSent.getLabel()).isEqualTo("Http Sent");
     assertThat(httpSent.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var httpReceived = (LineChartDataSet)dataSet.get(1);
+    var httpReceived = (LineChartDataSet) dataSet.get(1);
     assertThat(httpReceived.getLabel()).isEqualTo("Http Received");
     assertThat(httpReceived.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var httpsSent = (LineChartDataSet)dataSet.get(2);
+    var httpsSent = (LineChartDataSet) dataSet.get(2);
     assertThat(httpsSent.getLabel()).isEqualTo("Https Sent");
     assertThat(httpsSent.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(3)).isInstanceOf(LineChartDataSet.class);
-    var httpsReceived = (LineChartDataSet)dataSet.get(3);
+    var httpsReceived = (LineChartDataSet) dataSet.get(3);
     assertThat(httpsReceived.getLabel()).isEqualTo("Https Received");
     assertThat(httpsReceived.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getBytesMonitor().getInfo()).isEqualTo(
-            "Bytes: Http Sent -/1000 B, Http Received -/2000 B, Https Sent -/1000 B, Https Received -/2000 B");
+        "Bytes: Http Sent -/1000 B, Http Received -/2000 B, Https Sent -/1000 B, Https Received -/2000 B");
   }
 
   @Test
@@ -107,17 +107,17 @@ public class TestRequestMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var http = (LineChartDataSet)dataSet.get(0);
+    var http = (LineChartDataSet) dataSet.get(0);
     assertThat(http.getLabel()).isEqualTo("Http");
     assertThat(http.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var https = (LineChartDataSet)dataSet.get(1);
+    var https = (LineChartDataSet) dataSet.get(1);
     assertThat(https.getLabel()).isEqualTo("Https");
     assertThat(https.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(0.0D)); // delta
 
     assertThat(testee.getProcessingTimeMonitor().getInfo())
-            .isEqualTo("Processing Time: Http -, Http Total 5000 ms, Https -, Https Total 5000 ms");
+        .isEqualTo("Processing Time: Http -, Http Total 5000 ms, Https -, Https Total 5000 ms");
   }
 
   @Test
@@ -128,17 +128,17 @@ public class TestRequestMonitorBean {
     assertThat(dataSet).hasSize(2);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var http = (LineChartDataSet)dataSet.get(0);
+    var http = (LineChartDataSet) dataSet.get(0);
     assertThat(http.getLabel()).isEqualTo("Http");
     assertThat(http.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(2.0));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var https = (LineChartDataSet)dataSet.get(1);
+    var https = (LineChartDataSet) dataSet.get(1);
     assertThat(https.getLabel()).isEqualTo("Https");
     assertThat(https.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(1.0));
 
     assertThat(testee.getConnectionsMonitor().getInfo())
-            .isEqualTo("Connections: Http 2, Http Max 8192, Https 1, Https Max 4096");
+        .isEqualTo("Connections: Http 2, Http Max 8192, Https 1, Https Max 4096");
   }
 
   @MBean("ivy:type=GlobalRequestProcessor,name=#{name}")
@@ -197,12 +197,12 @@ public class TestRequestMonitorBean {
 
     @MAttribute
     public long getConnectionCount() {
-      return protocol.equals("http") ? 2 : 1;
+      return "http".equals(protocol) ? 2 : 1;
     }
 
     @MAttribute
     public long getMaxConnections() {
-      return protocol.equals("http") ? 8192 : 4096;
+      return "http".equals(protocol) ? 8192 : 4096;
     }
   }
 

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/TestSessionMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/TestSessionMonitorBean.java
@@ -33,22 +33,22 @@ public class TestSessionMonitorBean {
     assertThat(dataSet).hasSize(3);
 
     assertThat(dataSet.get(0)).isInstanceOf(LineChartDataSet.class);
-    var licensedSessions = (LineChartDataSet)dataSet.get(0);
+    var licensedSessions = (LineChartDataSet) dataSet.get(0);
     assertThat(licensedSessions.getLabel()).isEqualTo("Licensed Sessions");
     assertThat(licensedSessions.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(5.0D));
 
     assertThat(dataSet.get(1)).isInstanceOf(LineChartDataSet.class);
-    var sessions = (LineChartDataSet)dataSet.get(1);
+    var sessions = (LineChartDataSet) dataSet.get(1);
     assertThat(sessions.getLabel()).isEqualTo("Sessions");
     assertThat(sessions.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(7.0D));
 
     assertThat(dataSet.get(2)).isInstanceOf(LineChartDataSet.class);
-    var httpSessions = (LineChartDataSet)dataSet.get(2);
+    var httpSessions = (LineChartDataSet) dataSet.get(2);
     assertThat(httpSessions.getLabel()).isEqualTo("Http Sessions");
     assertThat(httpSessions.getData()).hasSize(1).allSatisfy(v -> assertThat(v).isEqualTo(6.0D));
 
     assertThat(testee.getSessionsMonitor().getInfo())
-            .isEqualTo("Sessions: Licensed Sessions 5, Sessions 7, Http Sessions 6, Licensed Users 100");
+        .isEqualTo("Sessions: Licensed Sessions 5, Sessions 7, Http Sessions 6, Licensed Users 100");
   }
 
   @MBean("ivy:type=Manager,host=localhost,context=#{context}")

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TestProcessExecutionBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TestProcessExecutionBean.java
@@ -25,7 +25,7 @@ class TestProcessExecutionBean {
 
   @BeforeEach
   void beforeEach() {
-    DiCore.installModules(new AbstractModule() {
+    DiCore.installModules(new AbstractModule(){
       @Override
       protected void configure() {
         super.configure();
@@ -230,7 +230,7 @@ class TestProcessExecutionBean {
     assertThat(uiStat.getInternalExecutionsBackground())
         .isEqualTo(background(IProcessElementExecutionStatistic::getExecutions));
     assertThat(uiStat.getTotalInternalExecutionTimeBackground())
-         .isEqualTo(background(IProcessElementExecutionStatistic::getProcessEngineExecutionTime));
+        .isEqualTo(background(IProcessElementExecutionStatistic::getProcessEngineExecutionTime));
     assertThat(uiStat.getMinInternalExecutionTimeBackground())
         .isEqualTo(background(IProcessElementExecutionStatistic::getMinProcessEngineExecutionTime));
     assertThat(uiStat.getAvgInternalExecutionTimeBackground())
@@ -254,8 +254,8 @@ class TestProcessExecutionBean {
     var max = Stream.of(TstExecutionStatistic.TWO_ELEMENT).mapToLong(mapping).max().getAsLong();
     var value = mapping.applyAsLong(TstExecutionStatistic.TWO_ELEMENT[0]);
     var percentage = value * 100 / max;
-    var end = Math.min(percentage+ 20, 100);
+    var end = Math.min(percentage + 20, 100);
     var color = 120 - percentage * 120 / 100;
-    return "linear-gradient(90deg, hsl(" + color + ", 100%, 70%) " + percentage + "%, var(--surface-a, #FFFFFF) "+ end +"%)";
+    return "linear-gradient(90deg, hsl(" + color + ", 100%, 70%) " + percentage + "%, var(--surface-a, #FFFFFF) " + end + "%)";
   }
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TstBpmEngineManager.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TstBpmEngineManager.java
@@ -19,19 +19,16 @@ import ch.ivyteam.ivy.request.RequestException;
 @Singleton
 final class TstBpmEngineManager implements IBpmEngineManager {
 
-  private IExecutionStatistic executionStatistic = new TstExecutionStatistic();
+  private final IExecutionStatistic executionStatistic = new TstExecutionStatistic();
 
   @Override
-  public void handleRequest(IRequest request, IResponse response) throws RequestException {
-  }
+  public void handleRequest(IRequest request, IResponse response) throws RequestException {}
 
   @Override
-  public void start() {
-  }
+  public void start() {}
 
   @Override
-  public void stop() {
-  }
+  public void stop() {}
 
   @Override
   public String getName() {
@@ -69,10 +66,8 @@ final class TstBpmEngineManager implements IBpmEngineManager {
   }
 
   @Override
-  public void setBpmEngineStarter(IBpmEngineStarter bpmEngineStarter) {
-  }
+  public void setBpmEngineStarter(IBpmEngineStarter bpmEngineStarter) {}
 
   @Override
-  public void requestEngineStart(IProcessModelVersion processModelVersion) {
-  }
+  public void requestEngineStart(IProcessModelVersion processModelVersion) {}
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TstExecutionStatistic.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TstExecutionStatistic.java
@@ -8,8 +8,8 @@ import ch.ivyteam.ivy.process.model.value.PID;
 @SuppressWarnings("restriction")
 class TstExecutionStatistic implements IExecutionStatistic {
 
-  static final IProcessElementExecutionStatistic[] EMPTY = new IProcessElementExecutionStatistic[0];
-  static final IProcessElementExecutionStatistic[] TWO_ELEMENT = new IProcessElementExecutionStatistic[] {new TstProcessElementExecStat(), new TstProcessElementExecStat()};
+  static final IProcessElementExecutionStatistic[] EMPTY = {};
+  static final IProcessElementExecutionStatistic[] TWO_ELEMENT = {new TstProcessElementExecStat(), new TstProcessElementExecStat()};
   boolean isRunning;
   IProcessElementExecutionStatistic[] statistic = EMPTY;
   boolean startCalled;
@@ -43,7 +43,7 @@ class TstExecutionStatistic implements IExecutionStatistic {
 
   @Override
   public IProcessElementExecutionStatistic getFirstProcessElementExecutionStatistic(
-          IProcessModelVersion processModelVersion, PID processElementId) {
+      IProcessModelVersion processModelVersion, PID processElementId) {
     return null;
   }
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TstProcessElementExecStat.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TstProcessElementExecStat.java
@@ -158,8 +158,7 @@ final class TstProcessElementExecStat implements IProcessElementExecutionStatist
     }
 
     @Override
-    public void addErrorCatcher(ErrorCatcher errorCatcher) {
-    }
+    public void addErrorCatcher(ErrorCatcher errorCatcher) {}
 
     @Override
     public String toDisplayString() {

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/system/overview/TestTrafficGraphBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/system/overview/TestTrafficGraphBean.java
@@ -19,8 +19,8 @@ import ch.ivyteam.ivy.trace.Span;
 import ch.ivyteam.ivy.trace.SpanResult;
 
 class TestTrafficGraphBean {
-  private TrafficGraphBean bean = new TrafficGraphBean();
-  private TraceBean trace = new TraceBean();
+  private final TrafficGraphBean bean = new TrafficGraphBean();
+  private final TraceBean trace = new TraceBean();
 
   @RegisterExtension
   TracerAccess tracer = new TracerAccess();
@@ -36,8 +36,7 @@ class TestTrafficGraphBean {
     trace.start();
     assertThat(bean.getModel().getConnections()).isEmpty();
     assertThat(bean.getModel().getElements()).hasSize(1);
-    try (var span = Span.open(() -> new TstSpan("HTTP GET", List.of(attribute("url", "http://localhost:8080/"))))) {
-    }
+    try (var span = Span.open(() -> new TstSpan("HTTP GET", List.of(attribute("url", "http://localhost:8080/"))))) {}
     bean.refresh();
     assertConnections(1, 0);
 
@@ -95,8 +94,7 @@ class TestTrafficGraphBean {
     trace.start();
     assertThat(bean.getModel().getConnections()).isEmpty();
     assertThat(bean.getModel().getElements()).hasSize(1);
-    try (var span = Span.open(() -> new TstSpan("HTTP GET", List.of(attribute("url", "http://localhost:8080/"))))) {
-    }
+    try (var span = Span.open(() -> new TstSpan("HTTP GET", List.of(attribute("url", "http://localhost:8080/"))))) {}
 
     assertThat(bean.getModel().getConnections()).isEmpty();
     assertThat(bean.getModel().getElements()).hasSize(1);
@@ -110,8 +108,7 @@ class TestTrafficGraphBean {
   @Test
   void clear() {
     trace.start();
-    try (var span = Span.open(() -> new TstSpan("HTTP GET", List.of(attribute("url", "http://localhost:8080/"))))) {
-    }
+    try (var span = Span.open(() -> new TstSpan("HTTP GET", List.of(attribute("url", "http://localhost:8080/"))))) {}
     bean.refresh();
 
     assertThat(bean.getModel().getConnections()).hasSize(1);
@@ -128,7 +125,7 @@ class TestTrafficGraphBean {
     return con
         .getOverlays()
         .stream()
-        .filter(overlay -> overlay instanceof LabelOverlay)
+        .filter(LabelOverlay.class::isInstance)
         .map(LabelOverlay.class::cast)
         .findAny()
         .orElseThrow(() -> new AssertionError("Label of connection is missing"));
@@ -138,8 +135,8 @@ class TestTrafficGraphBean {
     assertThat(bean.getModel().getConnections()).hasSize(1);
     var con = bean.getModel().getConnections().get(0);
     assertThat(con.getConnector().getPaintStyle()).startsWith("{stroke:'hsl(").endsWith(", 100%, 70%)', strokeWidth:20}");
-    var label =  toLabel(con);
-    assertThat(label.getLabel()).startsWith(requests+" requests / "+errors+" errors / ");
+    var label = toLabel(con);
+    assertThat(label.getLabel()).startsWith(requests + " requests / " + errors + " errors / ");
   }
 
   private void assertSystem(Element ivy, String name, String styleClass) {

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/trace/TestSpanBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/trace/TestSpanBean.java
@@ -14,7 +14,7 @@ import ch.ivyteam.ivy.trace.Attribute;
 import ch.ivyteam.ivy.trace.Tracer;
 
 class TestSpanBean {
-  private SpanBean bean = new SpanBean();
+  private final SpanBean bean = new SpanBean();
   private String traceId;
 
   @RegisterExtension
@@ -23,8 +23,8 @@ class TestSpanBean {
   @BeforeEach
   void beforeEach() {
     try (var undef = ch.ivyteam.ivy.trace.Span.open(() -> new TstSpan("undef", List.of(attribute("attr", 1234), attribute("hello", "world"))))) {
-      try (var ok = ch.ivyteam.ivy.trace.Span.open(() -> new TstSpan("ok"))){
-        try (var error = ch.ivyteam.ivy.trace.Span.open(() -> new TstSpan("error"))){
+      try (var ok = ch.ivyteam.ivy.trace.Span.open(() -> new TstSpan("ok"))) {
+        try (var error = ch.ivyteam.ivy.trace.Span.open(() -> new TstSpan("error"))) {
           error.error(new Throwable());
         }
         ok.result(null);

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/trace/TestTraceBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/trace/TestTraceBean.java
@@ -13,7 +13,7 @@ import ch.ivyteam.ivy.trace.Span;
 import ch.ivyteam.ivy.trace.SpanResult;
 
 class TestTraceBean {
-  private TraceBean bean = new TraceBean();
+  private final TraceBean bean = new TraceBean();
 
   @RegisterExtension
   TracerAccess tracer = new TracerAccess();
@@ -56,8 +56,7 @@ class TestTraceBean {
     assertThat(bean.isNotCleanable()).isTrue();
     bean.start();
     assertThat(bean.isNotCleanable()).isTrue();
-    try (var span = Span.open(() -> new TstSpan("test"))) {
-    }
+    try (var span = Span.open(() -> new TstSpan("test"))) {}
     bean.refresh();
     assertThat(bean.isNotCleanable()).isFalse();
     bean.stop();
@@ -70,8 +69,7 @@ class TestTraceBean {
   void slowTraces() {
     bean.start();
     assertThat(bean.getSlowTraces()).isEmpty();
-    try (var span = Span.open(() -> new TstSpan("test name"))) {
-    }
+    try (var span = Span.open(() -> new TstSpan("test name"))) {}
     bean.refresh();
     assertThat(bean.getSlowTraces()).hasSize(1);
   }
@@ -80,8 +78,7 @@ class TestTraceBean {
   void trace_undef() {
     bean.start();
     assertThat(bean.getSlowTraces()).isEmpty();
-    try (var span = Span.open(() -> new TstSpan("test name", List.of(attribute("attr", 1234), attribute("hello", "world"))))) {
-    }
+    try (var span = Span.open(() -> new TstSpan("test name", List.of(attribute("attr", 1234), attribute("hello", "world"))))) {}
     bean.refresh();
     assertThat(bean.getSlowTraces()).hasSize(1);
     var trc = bean.getSlowTraces().get(0);

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/trace/TracerAccess.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/trace/TracerAccess.java
@@ -24,7 +24,6 @@ public class TracerAccess implements BeforeEachCallback, AfterEachCallback {
     ACCESS_LOCK.unlock();
   }
 
-
   private void start() {
     Tracer.instance().start();
     Tracer.instance().slowTraces().clear();

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/value/TestValueProvider.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/value/TestValueProvider.java
@@ -13,19 +13,19 @@ public class TestValueProvider {
   @Test
   public void format_integer() {
     assertThatNextValue(ValueProvider.format("value %d", () -> new Value(1234, Unit.BYTES)))
-            .isEqualTo("value 1234 B");
+        .isEqualTo("value 1234 B");
     assertThatNextValue(ValueProvider.format("%d value", () -> new Value(123456789, Unit.BYTES)))
-            .isEqualTo("123456789 B value");
+        .isEqualTo("123456789 B value");
     assertThatNextValue(ValueProvider.format("value %3d", () -> new Value(1234, Unit.BYTES)))
-            .isEqualTo("value 1 KiB");
+        .isEqualTo("value 1 KiB");
     assertThatNextValue(ValueProvider.format("value %3d", () -> new Value(12345, Unit.BYTES)))
-            .isEqualTo("value 12 KiB");
+        .isEqualTo("value 12 KiB");
     assertThatNextValue(ValueProvider.format("value %3d", () -> new Value(12345678, Unit.BYTES)))
-            .isEqualTo("value 11 MiB");
+        .isEqualTo("value 11 MiB");
     assertThatNextValue(ValueProvider.format("value %4d", () -> new Value(12345678, Unit.BYTES)))
-            .isEqualTo("value 11 MiB");
+        .isEqualTo("value 11 MiB");
     assertThatNextValue(ValueProvider.format("value %5d", () -> new Value(12345678, Unit.BYTES)))
-            .isEqualTo("value 12056 KiB");
+        .isEqualTo("value 12056 KiB");
 
     assertThatNextValue(ValueProvider.format("value %d", () -> Value.NO_VALUE)).isEqualTo("value -");
   }
@@ -33,9 +33,9 @@ public class TestValueProvider {
   @Test
   public void format_decimal() {
     assertThatNextValue(ValueProvider.format("value %f", () -> new Value(1.234, Unit.KILO_BYTES)))
-            .isEqualTo("value 1.234000 KiB");
+        .isEqualTo("value 1.234000 KiB");
     assertThatNextValue(ValueProvider.format("value %.1f", () -> new Value(1.234, Unit.KILO_BYTES)))
-            .isEqualTo("value 1.2 KiB");
+        .isEqualTo("value 1.2 KiB");
 
     assertThatNextValue(ValueProvider.format("value %f", () -> Value.NO_VALUE)).isEqualTo("value -");
   }
@@ -43,25 +43,25 @@ public class TestValueProvider {
   @Test
   public void format_time() {
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(1234, Unit.MICRO_SECONDS)))
-            .isEqualTo("value 1234 us");
+        .isEqualTo("value 1234 us");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(12345, Unit.MICRO_SECONDS)))
-            .isEqualTo("value 12 ms");
+        .isEqualTo("value 12 ms");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(123456, Unit.MICRO_SECONDS)))
-            .isEqualTo("value 123 ms");
+        .isEqualTo("value 123 ms");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(1234567, Unit.MICRO_SECONDS)))
-            .isEqualTo("value 1234 ms");
+        .isEqualTo("value 1234 ms");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(12345678, Unit.MICRO_SECONDS)))
-            .isEqualTo("value 12 s");
+        .isEqualTo("value 12 s");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(123456789, Unit.MICRO_SECONDS)))
-            .isEqualTo("value 123 s");
+        .isEqualTo("value 123 s");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(1234567, Unit.MILLI_SECONDS)))
-            .isEqualTo("value 20 m");
+        .isEqualTo("value 20 m");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(12345678, Unit.MILLI_SECONDS)))
-            .isEqualTo("value 205 m");
+        .isEqualTo("value 205 m");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(123456789, Unit.MILLI_SECONDS)))
-            .isEqualTo("value 34 h");
+        .isEqualTo("value 34 h");
     assertThatNextValue(ValueProvider.format("value %t", () -> new Value(1234567, Unit.SECONDS)))
-            .isEqualTo("value 14 d");
+        .isEqualTo("value 14 d");
 
     assertThatNextValue(ValueProvider.format("value %t", () -> Value.NO_VALUE)).isEqualTo("value -");
   }
@@ -119,7 +119,7 @@ public class TestValueProvider {
   @Test
   public void derivation() {
     ValueProvider derivation = ValueProvider
-            .derivation(ValueProvider.value(() -> counter * counter, Unit.ONE), increase());
+        .derivation(ValueProvider.value(() -> counter * counter, Unit.ONE), increase());
     assertThat(derivation.nextValue()).isEqualTo(Value.NO_VALUE);
     assertThatNextValue(derivation).isEqualTo(1L);
     assertThatNextValue(derivation).isEqualTo(3L);

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/security/export/ExcelAssertions.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/security/export/ExcelAssertions.java
@@ -5,15 +5,14 @@ import org.assertj.core.api.Assertions;
 import ch.ivyteam.enginecockpit.security.export.excel.Sheet;
 
 public class ExcelAssertions {
-  private Sheet sheet;
+  private final Sheet sheet;
 
   private ExcelAssertions(Sheet actual) {
     this.sheet = actual;
   }
 
   public static ExcelAssertions assertThat(Sheet actual) {
-    ExcelAssertions a = new ExcelAssertions(actual);
-    return a;
+    return new ExcelAssertions(actual);
   }
 
   public void isNotNull() {

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/security/export/TestSecurityExport.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/security/export/TestSecurityExport.java
@@ -62,21 +62,21 @@ class TestSecurityExport {
     ceoRole = roles.create(ceo);
 
     NewUser rolf = NewUser.create("Rolf").fullName("Rolf Stephan").mailAddress("rolf.stephan@axonivy.com")
-            .toNewUser();
+        .toNewUser();
     userRolf = users.create(rolf);
     userRolf.addRole(ceoRole);
 
     NewUser reto = NewUser.create("Reto").fullName("Reto Weiss").mailAddress("reto.weiss@axonivy.com")
-            .toNewUser();
+        .toNewUser();
     userReto = users.create(reto);
     userReto.setProperty("User without External Property", "no external");
     userReto.setProperty("Sharedproperty", "Shared");
     userReto.addRole(managerRole);
 
     NewUser cedric = NewUser.create("Cedric").fullName("Cedric Weiss").externalId("123456789")
-            .externalName("cn=Cedric Weiss,ou=development,dc=ivyteam,dc=ch")
-            .mailAddress("cedric.weiss@axonivy.com")
-            .toNewUser();
+        .externalName("cn=Cedric Weiss,ou=development,dc=ivyteam,dc=ch")
+        .mailAddress("cedric.weiss@axonivy.com")
+        .toNewUser();
     userCedric = users.create(cedric);
     userCedric.setProperty("Testproperty", "Test");
     userCedric.setProperty("Sharedproperty", "Shared");
@@ -95,16 +95,16 @@ class TestSecurityExport {
   void exportUsers() {
     var userSheet = excel.getSheet("Users");
 
-    String[][] userData = new String[][] {
-      {"Name", "Displayname", "Fullname", "Email", "SecurityId", "ExternalId", "External Name", "Testproperty", "Sharedproperty",
-        "User without External Property"},
-      {userCedric.getName(), userCedric.getDisplayName(), userCedric.getFullName(), userCedric.getEMailAddress(),
-        userCedric.getSecurityMemberId(), userCedric.getExternalId(),
-        userCedric.getExternalName(), "Test", "Shared", null },
-      {userReto.getName(), userReto.getDisplayName(), userReto.getFullName(), userReto.getEMailAddress(),
-        userReto.getSecurityMemberId(), "", "", null, "Shared", "no external"},
-      {userRolf.getName(), userRolf.getDisplayName(), userRolf.getFullName(), userRolf.getEMailAddress(),
-          userRolf.getSecurityMemberId(), "", "", null, null, null}
+    String[][] userData = {
+        {"Name", "Displayname", "Fullname", "Email", "SecurityId", "ExternalId", "External Name", "Testproperty", "Sharedproperty",
+            "User without External Property"},
+        {userCedric.getName(), userCedric.getDisplayName(), userCedric.getFullName(), userCedric.getEMailAddress(),
+            userCedric.getSecurityMemberId(), userCedric.getExternalId(),
+            userCedric.getExternalName(), "Test", "Shared", null},
+        {userReto.getName(), userReto.getDisplayName(), userReto.getFullName(), userReto.getEMailAddress(),
+            userReto.getSecurityMemberId(), "", "", null, "Shared", "no external"},
+        {userRolf.getName(), userRolf.getDisplayName(), userRolf.getFullName(), userRolf.getEMailAddress(),
+            userRolf.getSecurityMemberId(), "", "", null, null, null}
     };
     ExcelAssertions.assertThat(userSheet).contains(userData);
   }
@@ -113,13 +113,13 @@ class TestSecurityExport {
   void exportRoles() {
     var rolesSheet = excel.getSheet("Roles");
 
-    String[][] rolesData = new String[][] {
-      {"Name", "Displayname", "Description", "Security Member Id", "External Name", "Testproperty",
-        "Sharedproperty", "Role without External Property"},
-      {"CEO", "CEO", "CEO" , ceoRole.getSecurityMemberId(), "CEO",  null, null, null},
-      {"Employee", "Employee", "Employee" , employeeRole.getSecurityMemberId(), "Employee",  "Test", "Shared", null},
-      {"Everybody", "Everybody", "Top level role" , everybodyRole.getSecurityMemberId(), "",  null, "Shared", "no external"},
-      {"Manager", "Manager", "Manager" , managerRole.getSecurityMemberId(), "Manager",  null, null, null},
+    String[][] rolesData = {
+        {"Name", "Displayname", "Description", "Security Member Id", "External Name", "Testproperty",
+            "Sharedproperty", "Role without External Property"},
+        {"CEO", "CEO", "CEO", ceoRole.getSecurityMemberId(), "CEO", null, null, null},
+        {"Employee", "Employee", "Employee", employeeRole.getSecurityMemberId(), "Employee", "Test", "Shared", null},
+        {"Everybody", "Everybody", "Top level role", everybodyRole.getSecurityMemberId(), "", null, "Shared", "no external"},
+        {"Manager", "Manager", "Manager", managerRole.getSecurityMemberId(), "Manager", null, null, null},
     };
     ExcelAssertions.assertThat(rolesSheet).contains(rolesData);
   }
@@ -127,12 +127,12 @@ class TestSecurityExport {
   @Test
   void exportUserRoles() {
     var userRolesSheet = excel.getSheet("User roles");
-    String[][] userRolesData = new String[][] {
-      {"Name", ceoRole.getName(), employeeRole.getName(),
-        everybodyRole.getName(), managerRole.getName()},
-      {userCedric.getName(), null, "X", "X", null},
-      {userReto.getName(), null, "x", "X", "X"},
-      {userRolf.getName(), "X", "x", "X", null}
+    String[][] userRolesData = {
+        {"Name", ceoRole.getName(), employeeRole.getName(),
+            everybodyRole.getName(), managerRole.getName()},
+        {userCedric.getName(), null, "X", "X", null},
+        {userReto.getName(), null, "x", "X", "X"},
+        {userRolf.getName(), "X", "x", "X", null}
     };
     ExcelAssertions.assertThat(userRolesSheet).contains(userRolesData);
 
@@ -141,12 +141,12 @@ class TestSecurityExport {
   @Test
   void exportRoleMembers() {
     var roleMembersSheet = excel.getSheet("Role members");
-    String[][] roleMembersData = new String[][] {
-      {"Role name", "CEO", "Employee", "Everybody", "Manager"},
-      {"CEO", null, null, "P", null},
-      {"Employee", null, null, "P/M", "M"},
-      {"Everybody", null, null, null, null},
-      {"Manager", null, null, "P", null}
+    String[][] roleMembersData = {
+        {"Role name", "CEO", "Employee", "Everybody", "Manager"},
+        {"CEO", null, null, "P", null},
+        {"Employee", null, null, "P/M", "M"},
+        {"Everybody", null, null, null, null},
+        {"Manager", null, null, "P", null}
     };
     ExcelAssertions.assertThat(roleMembersSheet).contains(roleMembersData);
   }
@@ -170,33 +170,28 @@ class TestSecurityExport {
   private String[][] addSecurityMemberPermissions(String[][] permissionsData, ISecurityMember member, int memberCount) {
     var securityContext = Ivy.wf().getSecurityContext();
     var counter = 1;
-    for(var permission : permissions) {
+    for (var permission : permissions) {
       permissionsData[0][counter] = permission.getName();
       var permissionCheck = securityContext.securityDescriptor().getPermissionAccess(permission, member);
-      if(permissionCheck.isGranted()) {
-        if(permissionCheck.isExplicit()) {
+      if (permissionCheck.isGranted()) {
+        if (permissionCheck.isExplicit()) {
           permissionsData[memberCount][counter] = "G";
-        }
-        else {
+        } else {
           permissionsData[memberCount][counter] = "g";
         }
-      }
-      else if(permissionCheck.isDenied()) {
-        if(permissionCheck.isExplicit()) {
+      } else if (permissionCheck.isDenied()) {
+        if (permissionCheck.isExplicit()) {
           permissionsData[memberCount][counter] = "D";
-        }
-        else {
+        } else {
           permissionsData[memberCount][counter] = "d";
         }
-      }
-      else {
+      } else {
         permissionsData[memberCount][counter] = "";
       }
       counter++;
     }
     return permissionsData;
   }
-
 
   @Test
   void rolePermissionsMembers() {
@@ -215,34 +210,33 @@ class TestSecurityExport {
     ExcelAssertions.assertThat(rolePermissionsSheet).contains(rolePermissionsData);
   }
 
-
   @Test
   void exportOverview() {
     var overviewSheet = excel.getSheet("Overview");
-    String[][] overviewData = new String[][] {
-      {"Axon Ivy Security Report ", null, null},
-      {null, null, null},
-      {"Security System Name", "default", null},
-      {"Applications", "test", null},
-      {"Date", overviewSheet.getData()[4][1], null},
-      {"Axon Ivy Version", Advisor.getAdvisor().getVersion().toString(), null},
-      {"Current User", "Unknown User (Session 1)", null},
-      {"Hostname", "test.axonivy.com", null},
-      {"Number of Users", "3", null},
-      {"Number of Roles", "4", null},
-      {"File number", "1 of 1", null},
-      {"First and Last User", "Cedric Weiss - Rolf Stephan", null},
-      {"Legend", null, null},
-      {"User roles", "X", "User owns role directly"},
-      {"", "x", "User owns role indirectly"},
-      {null, null, null},
-      {"Role members", "M", "Role is a role member"},
-      {"", "P", "Role is the parent role of a role"},
-      {null, null, null},
-      {"User permissions / Role permissions", "G", "Permission was granted directly"},
-      {"", "g", "Permission was granted indirectly"},
-      {"", "D", "Permission was denied directly"},
-      {"", "d", "Permission was denied indirectly"}
+    String[][] overviewData = {
+        {"Axon Ivy Security Report ", null, null},
+        {null, null, null},
+        {"Security System Name", "default", null},
+        {"Applications", "test", null},
+        {"Date", overviewSheet.getData()[4][1], null},
+        {"Axon Ivy Version", Advisor.getAdvisor().getVersion().toString(), null},
+        {"Current User", "Unknown User (Session 1)", null},
+        {"Hostname", "test.axonivy.com", null},
+        {"Number of Users", "3", null},
+        {"Number of Roles", "4", null},
+        {"File number", "1 of 1", null},
+        {"First and Last User", "Cedric Weiss - Rolf Stephan", null},
+        {"Legend", null, null},
+        {"User roles", "X", "User owns role directly"},
+        {"", "x", "User owns role indirectly"},
+        {null, null, null},
+        {"Role members", "M", "Role is a role member"},
+        {"", "P", "Role is the parent role of a role"},
+        {null, null, null},
+        {"User permissions / Role permissions", "G", "Permission was granted directly"},
+        {"", "g", "Permission was granted indirectly"},
+        {"", "D", "Permission was denied directly"},
+        {"", "d", "Permission was denied indirectly"}
     };
 
     ExcelAssertions.assertThat(overviewSheet).contains(overviewData);

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/security/export/TestSecurityExportWithGeneratedUsers.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/security/export/TestSecurityExportWithGeneratedUsers.java
@@ -61,7 +61,7 @@ class TestSecurityExportWithGeneratedUsers {
   @Test
   void checkFileNames() {
     var start = 0;
-    for(var file : files) {
+    for (var file : files) {
       Assertions.assertThat(file.getName()).isEqualTo("AxonIvySecurityReport" + start + ".xlsx");
       start++;
     }
@@ -79,10 +79,9 @@ class TestSecurityExportWithGeneratedUsers {
       var firstRow = sheet.getRow(1).getCell(0).getStringCellValue();
       var lastRow = sheet.getLastRow().getCell(0).getStringCellValue();
       Assertions.assertThat(firstRow).isEqualTo("testUser-%04d".formatted((start)));
-      if(start + 999 > userCount) {
+      if (start + 999 > userCount) {
         Assertions.assertThat(lastRow).isEqualTo("testUser-%04d".formatted(userCount));
-      }
-      else {
+      } else {
         Assertions.assertThat(lastRow).isEqualTo("testUser-%04d".formatted(start + 999));
       }
       start += 1000;

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/services/rest/TestUiStateClient.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/services/rest/TestUiStateClient.java
@@ -85,21 +85,21 @@ class TestUiStateClient {
     assertThat(getPropertyValue(uiStateClient, "password")).isEqualTo("password");
     assertThat(uiStateClient.uri()).isEqualTo("https://url.com");
   }
-  
+
   private String getPropertyValueTime(RestClient client, String key) {
     return client.properties().stream()
-            .filter(p -> p.key().equals(key))
-            .filter(p -> p.value().equals("2000"))
-            .findAny()
-            .get()
-            .value();
+        .filter(p -> p.key().equals(key))
+        .filter(p -> "2000".equals(p.value()))
+        .findAny()
+        .get()
+        .value();
   }
-  
+
   private String getPropertyValue(RestClient client, String key) {
     return client.properties().stream()
-            .filter(p -> p.key().equals(key))
-            .findAny()
-            .get()
-            .value();
+        .filter(p -> p.key().equals(key))
+        .findAny()
+        .get()
+        .value();
   }
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/system/ssl/TestSslClientBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/system/ssl/TestSslClientBean.java
@@ -37,13 +37,13 @@ class TestSslClientBean {
   void extractSubject() {
     TlsTesterBean bean = new TlsTesterBean();
     assertThat(bean.getSubject("Cert alias found: CN=DigiCert Assured ID Root CA,OU=www.digicert.com,O=DigiCert Inc,C=US alg=RSA, length=2048"))
-      .isEqualTo("CN=DigiCert Assured ID Root CA,OU=www.digicert.com,O=DigiCert Inc,C=US");
+        .isEqualTo("CN=DigiCert Assured ID Root CA,OU=www.digicert.com,O=DigiCert Inc,C=US");
     assertThat(bean.getSubject("CN=AffirmTrust Commercial,O=AffirmTrust,C=US"))
-      .isEqualTo("CN=AffirmTrust Commercial,O=AffirmTrust,C=US");
+        .isEqualTo("CN=AffirmTrust Commercial,O=AffirmTrust,C=US");
     assertThat(bean.getSubject("CN=QuoVadis Root CA 2,O=QuoVadis Limited,C=BM alg=RSA"))
-      .isEqualTo("CN=QuoVadis Root CA 2,O=QuoVadis Limited,C=BM");
+        .isEqualTo("CN=QuoVadis Root CA 2,O=QuoVadis Limited,C=BM");
     assertThat(bean.getSubject("OU=certSIGN ROOT CA G2,O=CERTSIGN SA,C=RO alg=RSA, length=4096"))
-      .isEqualTo("OU=certSIGN ROOT CA G2,O=CERTSIGN SA,C=RO");
+        .isEqualTo("OU=certSIGN ROOT CA G2,O=CERTSIGN SA,C=RO");
   }
 
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/util/TestDurationFormat.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/util/TestDurationFormat.java
@@ -2,10 +2,13 @@
 package ch.ivyteam.enginecockpit.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Duration;
 import java.time.Instant;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import ch.ivyteam.util.date.Now;
 
 class TestDurationFormat {
@@ -17,7 +20,7 @@ class TestDurationFormat {
 
   @BeforeEach
   void beforeEach() {
-    Now.set((str) -> NOW);
+    Now.set(str -> NOW);
   }
 
   @Test
@@ -65,14 +68,14 @@ class TestDurationFormat {
   @Test
   void not_available_3_hours() {
     assertThat(DurationFormat.NOT_AVAILABLE.milliSeconds(THREE_HOURS.toMillis())).isEqualTo("3 h");
-    assertThat(DurationFormat.NOT_AVAILABLE.microSeconds(THREE_HOURS.toMillis()*1000L)).isEqualTo("3 h");
+    assertThat(DurationFormat.NOT_AVAILABLE.microSeconds(THREE_HOURS.toMillis() * 1000L)).isEqualTo("3 h");
     assertThat(DurationFormat.NOT_AVAILABLE.fromNowTo(NOW.plus(THREE_HOURS))).isEqualTo("3 h");
   }
 
   @Test
   void blank_soon_3_hours() {
     assertThat(DurationFormat.BLANK_SOON.milliSeconds(THREE_HOURS.toMillis())).isEqualTo("3 h");
-    assertThat(DurationFormat.BLANK_SOON.microSeconds(THREE_HOURS.toMillis()*1000L)).isEqualTo("3 h");
+    assertThat(DurationFormat.BLANK_SOON.microSeconds(THREE_HOURS.toMillis() * 1000L)).isEqualTo("3 h");
     assertThat(DurationFormat.BLANK_SOON.fromNowTo(NOW.plus(THREE_HOURS))).isEqualTo("3 h");
   }
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/util/TestUrlUtil.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/util/TestUrlUtil.java
@@ -14,24 +14,25 @@ class TestUrlUtil {
   @BeforeEach
   void beforeEach() {
     var v = Advisor.instance().getVersion();
-    version = v.getMajorVersion() + "." + v.getMinorVersion(); 
+    version = v.getMajorVersion() + "." + v.getMinorVersion();
   }
 
   @Test
   void docBaseUrls() {
     assertThat(UrlUtil.getEngineGuideBaseUrl())
-            .isEqualTo("https://developer.axonivy.com/doc/"+version+"/engine-guide");
+        .isEqualTo("https://developer.axonivy.com/doc/" + version + "/engine-guide");
     assertThat(UrlUtil.getCockpitEngineGuideUrl())
-            .isEqualTo("https://developer.axonivy.com/doc/"+version+"/engine-guide/reference/engine-cockpit/");
+        .isEqualTo("https://developer.axonivy.com/doc/" + version + "/engine-guide/reference/engine-cockpit/");
     assertThat(UrlUtil.getDesignerGuideBaseUrl())
-            .isEqualTo("https://developer.axonivy.com/doc/"+version+"/designer-guide");
+        .isEqualTo("https://developer.axonivy.com/doc/" + version + "/designer-guide");
   }
 
   @Test
   void replaceEngineGuide() {
     var plainText = "@engine.guide.url@/configuration/advanced-configuration.html#overriding-configuration";
     var outputText = "\n" +
-            "<a href='https://developer.axonivy.com/doc/"+version+"/engine-guide/configuration/advanced-configuration.html#overriding-configuration' target='_blank'>https://developer.axonivy.com/doc/"+version+"/engine-guide/configuration/advanced-configuration.html#overriding-configuration</a>";
+        "<a href='https://developer.axonivy.com/doc/" + version + "/engine-guide/configuration/advanced-configuration.html#overriding-configuration' target='_blank'>https://developer.axonivy.com/doc/" + version
+        + "/engine-guide/configuration/advanced-configuration.html#overriding-configuration</a>";
     assertThat(UrlUtil.replaceLinks(plainText)).isEqualTo(outputText);
   }
 
@@ -39,16 +40,16 @@ class TestUrlUtil {
   void replaceDesignerGuide() {
     var plainText = "@designer.guide.url@/user-interface/standard-processes";
     var outputText = "\n" +
-            "<a href='https://developer.axonivy.com/doc/"+version+"/designer-guide/user-interface/standard-processes' target='_blank'>https://developer.axonivy.com/doc/"+version+"/designer-guide/user-interface/standard-processes</a>";
+        "<a href='https://developer.axonivy.com/doc/" + version + "/designer-guide/user-interface/standard-processes' target='_blank'>https://developer.axonivy.com/doc/" + version + "/designer-guide/user-interface/standard-processes</a>";
     assertThat(UrlUtil.replaceLinks(plainText)).isEqualTo(outputText);
   }
 
   @Test
   void replaceHtmlLinks() {
     var plainText = "To install your own Elasticsearch server follow these steps\n" +
-            "https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html";
+        "https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html";
     var outputText = "To install your own Elasticsearch server follow these steps\n" +
-            "<a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html' target='_blank'>https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html</a>";
+        "<a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html' target='_blank'>https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html</a>";
     assertThat(UrlUtil.replaceLinks(plainText)).isEqualTo(outputText);
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/ApplicationBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/ApplicationBean.java
@@ -31,10 +31,10 @@ public class ApplicationBean extends TreeView<AbstractActivity> {
 
   private AbstractActivity selectedActivity;
 
-  private Application newApp;
+  private final Application newApp;
   private boolean activateNewApp;
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public ApplicationBean() {
     managerBean = ManagerBean.instance();
@@ -81,7 +81,7 @@ public class ApplicationBean extends TreeView<AbstractActivity> {
   protected void filterNode(TreeNode<AbstractActivity> node) {
     var activity = node.getData();
     if (StringUtils.containsIgnoreCase(activity.getName(), filter)) {
-      new DefaultTreeNode<AbstractActivity>(activity, filteredTreeNode);
+      new DefaultTreeNode<>(activity, filteredTreeNode);
     }
   }
 
@@ -94,7 +94,7 @@ public class ApplicationBean extends TreeView<AbstractActivity> {
     for (var node : nodes) {
       var activity = node.getData();
       activity.updateStats();
-      if (processing == false) {
+      if (!processing) {
         processing = activity.getState().isProcessing();
       }
       reloadNodeState(node.getChildren());
@@ -126,14 +126,14 @@ public class ApplicationBean extends TreeView<AbstractActivity> {
     try {
       var securityContext = ISecurityManager.instance().securityContexts().get(newApp.getSecSystem());
       var appToCreate = NewApplication.create(newApp.getName())
-              .active(activateNewApp)
-              .toNewApplication();
+          .active(activateNewApp)
+          .toNewApplication();
       IApplicationRepository.of(securityContext).create(appToCreate);
       reloadTree();
       managerBean.reloadApplications();
     } catch (RuntimeException ex) {
       FacesContext.getCurrentInstance().addMessage("applicationMessage",
-              new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", ex.getMessage()));
+          new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", ex.getMessage()));
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/ApplicationDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/ApplicationDetailBean.java
@@ -37,7 +37,7 @@ public class ApplicationDetailBean {
 
   private ConfigViewImpl configView;
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public ApplicationDetailBean() {
     managerBean = ManagerBean.instance();
@@ -54,24 +54,24 @@ public class ApplicationDetailBean {
   public void onload() {
     managerBean.reloadApplications();
     app = managerBean.getApplications().stream()
-            .filter(a -> a.getName().equals(appName))
-            .findAny()
-            .orElse(null);
+        .filter(a -> a.getName().equals(appName))
+        .findAny()
+        .orElse(null);
     if (app == null) {
       ResponseHelper.notFound("Application '" + appName + "' not found");
       return;
     }
 
     configView = new ConfigViewImpl(((IApplicationInternal) getIApplication()).getConfiguration(),
-            this::enrichPmvProperties, List.of(ConfigViewImpl.defaultFilter(),
-                    new ContentFilter<>("Variables", "Show Variables",
-                            p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "Variables."), true),
-                    new ContentFilter<>("Databases", "Show Databases",
-                            p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "Databases."), true),
-                    new ContentFilter<>("RestClients", "Show Rest Clients",
-                            p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "RestClients."), true),
-                    new ContentFilter<>("WebServiceClients", "Show Web Service Clients",
-                            p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "WebServiceClients."), true)));
+        this::enrichPmvProperties, List.of(ConfigViewImpl.defaultFilter(),
+            new ContentFilter<>("Variables", "Show Variables",
+                p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "Variables."), true),
+            new ContentFilter<>("Databases", "Show Databases",
+                p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "Databases."), true),
+            new ContentFilter<>("RestClients", "Show Rest Clients",
+                p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "RestClients."), true),
+            new ContentFilter<>("WebServiceClients", "Show Web Service Clients",
+                p -> !StringUtils.startsWithIgnoreCase(p.getKey(), "WebServiceClients."), true)));
   }
 
   public Application getApplication() {
@@ -102,7 +102,7 @@ public class ApplicationDetailBean {
 
   public String getPmCount() {
     return managerBean.formatNumber(getIApplication().getProcessModels().stream()
-            .mapToInt(pm -> pm.getProcessModelVersions().size()).sum());
+        .mapToInt(pm -> pm.getProcessModelVersions().size()).sum());
   }
 
   private IApplication getIApplication() {
@@ -133,7 +133,7 @@ public class ApplicationDetailBean {
     libraries.add(StandardProcessStartFinder.AUTO);
     libraries.add(config.getValue());
     Arrays.stream(StandardProcessType.values())
-            .forEach(type -> libraries.addAll(configurator.findLibraries(type)));
+        .forEach(type -> libraries.addAll(configurator.findLibraries(type)));
     return List.copyOf(libraries);
   }
 
@@ -141,12 +141,12 @@ public class ApplicationDetailBean {
     List<String> libs = new LinkedList<>();
     libs.add("");
     var available = app.getProcessModels().stream()
-      .flatMap(pm -> pm.getProcessModelVersions().stream())
-      .map(IProcessModelVersion::getLibrary)
-      .filter(Objects::nonNull)
-      .map(ILibrary::getId)
-      .distinct()
-      .collect(Collectors.toList());
+        .flatMap(pm -> pm.getProcessModelVersions().stream())
+        .map(IProcessModelVersion::getLibrary)
+        .filter(Objects::nonNull)
+        .map(ILibrary::getId)
+        .distinct()
+        .collect(Collectors.toList());
     libs.addAll(available);
     return libs;
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/MoveApplicationBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/MoveApplicationBean.java
@@ -96,9 +96,9 @@ public class MoveApplicationBean {
 
   public List<String> getSecuritySystems() {
     return ISecurityManager.instance().securityContexts().all().stream()
-            .filter(s -> app != null && !s.equals(app.getSecurityContext()))
-            .map(ISecurityContext::getName)
-            .collect(Collectors.toList());
+        .filter(s -> app != null && !s.equals(app.getSecurityContext()))
+        .map(ISecurityContext::getName)
+        .collect(Collectors.toList());
   }
 
   public void setTargetSecuritySystem(String targetSecuritySystem) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/PmvDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/PmvDetailBean.java
@@ -23,7 +23,7 @@ public class PmvDetailBean {
   private String appName;
   private String pmName;
   private String pmvVersion;
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
   private ProcessModelVersion pmv;
   private String deployedProject;
   private List<ProcessModelVersion> dependendPmvs;
@@ -78,25 +78,25 @@ public class PmvDetailBean {
     if (iPmv == null) {
       LOGGER.warn("Can not refresh PMV details for " + appName + "/" + pmName + "/" + pmvVersion);
       ResponseHelper.notFound("Process Model Version '" + pmName + "' for version '" + pmvVersion
-              + "' in app '" + appName + "' not found");
+          + "' in app '" + appName + "' not found");
       return;
     }
 
     pmv = new ProcessModelVersion(iPmv);
     dependendPmvs = iPmv.getAllRelatedProcessModelVersions(ProcessModelVersionRelation.DEPENDENT).stream()
-            .map(ProcessModelVersion::new)
-            .collect(Collectors.toList());
+        .map(ProcessModelVersion::new)
+        .collect(Collectors.toList());
     requriedPmvs = iPmv.getAllRelatedProcessModelVersions(ProcessModelVersionRelation.REQUIRED).stream()
-            .map(ProcessModelVersion::new)
-            .collect(Collectors.toList());
+        .map(ProcessModelVersion::new)
+        .collect(Collectors.toList());
     var library = iPmv.getLibrary();
     if (library == null) {
       return;
     }
     deployedProject = library.getId();
     requiredSpecifications = library.getRequiredLibrarySpecifications().stream()
-            .map(spec -> new LibSpecification(spec))
-            .collect(Collectors.toList());
+        .map(LibSpecification::new)
+        .collect(Collectors.toList());
   }
 
   public ProcessModelVersion getPmv() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/AbstractActivity.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/AbstractActivity.java
@@ -97,8 +97,7 @@ public abstract class AbstractActivity {
     return true;
   }
 
-  public void convert() {
-  }
+  public void convert() {}
 
   public boolean canConvert() {
     return false;
@@ -135,11 +134,11 @@ public abstract class AbstractActivity {
   public abstract void delete();
 
   public void forceDelete() {}
-  
+
   public boolean hasReleasedProcessModelVersion() {
     return true;
   }
-  
+
   public String getWarningMessageForNoReleasedPmv() {
     return "";
   }
@@ -149,17 +148,17 @@ public abstract class AbstractActivity {
       executor.run();
       reloadBean(reloadOnlyStats);
       Message.info()
-              .clientId("applicationMessage")
-              .summary("Successfully " + action + " module")
-              .detail(getActivityType() + " " + getName())
-              .show();
+          .clientId("applicationMessage")
+          .summary("Successfully " + action + " module")
+          .detail(getActivityType() + " " + getName())
+          .show();
     } catch (IllegalStateException ex) {
       Message.error()
-              .clientId("applicationMessage")
-              .summary("Could not " + action + " module")
-              .detail(ex.getMessage())
-              .exception(ex)
-              .show();
+          .clientId("applicationMessage")
+          .summary("Could not " + action + " module")
+          .detail(ex.getMessage())
+          .exception(ex)
+          .show();
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/Application.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/Application.java
@@ -179,12 +179,12 @@ public class Application extends AbstractActivity {
   public List<WebServiceProcess> getWebServiceProcesses() {
     if (webServiceProcesses == null) {
       webServiceProcesses = app.getProcessModels().stream()
-              .map(IProcessModel::getReleasedProcessModelVersion)
-              .map(IWorkflowProcessModelVersion::of)
-              .filter(Objects::nonNull)
-              .flatMap(pmv -> pmv.getWebServiceProcesses().stream())
-              .map(WebServiceProcess::new)
-              .collect(Collectors.toList());
+          .map(IProcessModel::getReleasedProcessModelVersion)
+          .map(IWorkflowProcessModelVersion::of)
+          .filter(Objects::nonNull)
+          .flatMap(pmv -> pmv.getWebServiceProcesses().stream())
+          .map(WebServiceProcess::new)
+          .collect(Collectors.toList());
     }
     return webServiceProcesses;
   }
@@ -193,9 +193,9 @@ public class Application extends AbstractActivity {
   @SuppressWarnings("restriction")
   public boolean hasReleasedProcessModelVersion() {
     return app.getProcessModels()
-              .stream()
-              .map(ch.ivyteam.ivy.application.internal.ProcessModel.class::cast)
-              .allMatch(ch.ivyteam.ivy.application.internal.ProcessModel::hasReleasedProcessModelVersion);
+        .stream()
+        .map(ch.ivyteam.ivy.application.internal.ProcessModel.class::cast)
+        .allMatch(ch.ivyteam.ivy.application.internal.ProcessModel::hasReleasedProcessModelVersion);
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/LibSpecification.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/LibSpecification.java
@@ -5,9 +5,9 @@ import ch.ivyteam.ivy.application.value.VersionRange;
 
 public class LibSpecification {
 
-  private String id;
-  private boolean resolved;
-  private String version;
+  private final String id;
+  private final boolean resolved;
+  private final String version;
   private ProcessModelVersion resolvedPmv;
   private String resolvedPmvName;
 
@@ -19,7 +19,7 @@ public class LibSpecification {
     if (resolvedLib != null) {
       resolvedPmv = new ProcessModelVersion(resolvedLib.getProcessModelVersion());
       resolvedPmvName = resolvedPmv.getName() + " (" + resolvedPmv.getQualifiedVersion() + " / " +
-              resolvedPmv.getState().getOperation() + " / " + resolvedPmv.getState().getReleaseState() + ")";
+          resolvedPmv.getState().getOperation() + " / " + resolvedPmv.getState().getReleaseState() + ")";
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModel.java
@@ -11,7 +11,7 @@ import ch.ivyteam.ivy.application.IProcessModelVersion;
 import ch.ivyteam.ivy.workflow.IWorkflowContext;
 
 public class ProcessModel extends AbstractActivity {
-  private IProcessModel pm;
+  private final IProcessModel pm;
   private Boolean isOverrideProject;
   private long runningCasesCount = -1;
 
@@ -69,7 +69,7 @@ public class ProcessModel extends AbstractActivity {
   @Override
   @SuppressWarnings("restriction")
   public boolean hasReleasedProcessModelVersion() {
-    var processModel = (ch.ivyteam.ivy.application.internal.ProcessModel)pm;
+    var processModel = (ch.ivyteam.ivy.application.internal.ProcessModel) pm;
     return processModel.hasReleasedProcessModelVersion();
   }
 
@@ -83,12 +83,12 @@ public class ProcessModel extends AbstractActivity {
     if (isOverrideProject == null) {
       var overrideProject = ((IApplicationInternal) pm.getApplication()).getConfiguration().getOrDefault("OverrideProject");
       var projectId = pm.getProcessModelVersions().stream()
-              .map(IProcessModelVersion::getLibrary)
-              .filter(Objects::nonNull)
-              .map(ILibrary::getId)
-              .distinct()
-              .findFirst()
-              .orElse(null);
+          .map(IProcessModelVersion::getLibrary)
+          .filter(Objects::nonNull)
+          .map(ILibrary::getId)
+          .distinct()
+          .findFirst()
+          .orElse(null);
       isOverrideProject = projectId != null && projectId.equals(overrideProject);
     }
     return isOverrideProject;
@@ -98,9 +98,8 @@ public class ProcessModel extends AbstractActivity {
     if (pm != null && runningCasesCount < 0) {
       var wf = IWorkflowContext.current();
       runningCasesCount = pm.getProcessModelVersions().parallelStream()
-              .mapToLong(pmv -> wf.getRunningCasesCount(pmv)).sum();
+          .mapToLong(pmv -> wf.getRunningCasesCount(pmv)).sum();
     }
   }
-
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModelVersion.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModelVersion.java
@@ -12,9 +12,9 @@ import ch.ivyteam.ivy.workflow.IWorkflowContext;
 
 public class ProcessModelVersion extends AbstractActivity {
 
-  private IProcessModelVersionInternal pmv;
-  private String lastChangeDate;
-  private Library lib;
+  private final IProcessModelVersionInternal pmv;
+  private final String lastChangeDate;
+  private final Library lib;
   private int runningCasesCount = -1;
 
   public ProcessModelVersion(IProcessModelVersion pmv) {
@@ -32,7 +32,7 @@ public class ProcessModelVersion extends AbstractActivity {
   @Override
   public String getDetailView() {
     return "pmv-detail.xhtml?appName=" + pmv.getApplication().getName() + "&pmName="
-            + pmv.getProcessModel().getName() + "&pmvVersion=" + pmv.getVersionNumber();
+        + pmv.getProcessModel().getName() + "&pmvVersion=" + pmv.getVersionNumber();
   }
 
   @Override
@@ -130,7 +130,7 @@ public class ProcessModelVersion extends AbstractActivity {
 
   public String getLibraryResolvedTooltip() {
     return (isLibraryResolved() ? "All" : "Not all")
-            + " direct and indirect required libraries are available in the system.";
+        + " direct and indirect required libraries are available in the system.";
   }
 
   private void countRunningCases() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/StateOfActivity.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/StateOfActivity.java
@@ -147,17 +147,17 @@ public class StateOfActivity {
 
   public boolean is(ActivityState... states) {
     return Arrays.asList(states).stream()
-            .anyMatch(s -> s.name().equals(activityState));
+        .anyMatch(s -> s.name().equals(activityState));
   }
 
   public boolean is(ReleaseState... states) {
     return Arrays.asList(states).stream()
-            .anyMatch(s -> s.name().equals(releaseState));
+        .anyMatch(s -> s.name().equals(releaseState));
   }
 
   public static boolean is(String operation, ActivityOperationState... states) {
     return Arrays.asList(states).stream()
-            .anyMatch(s -> s.name().equals(operation));
+        .anyMatch(s -> s.name().equals(operation));
   }
 
   public void updateChildProblems(AbstractActivity activity) {
@@ -173,7 +173,7 @@ public class StateOfActivity {
     var problems = new ArrayList<String>();
     for (var child : activity.children) {
       if (is(child.getState().operation, ActivityOperationState.INACTIVE, ActivityOperationState.ERROR)
-              && isNotArchived(child)) {
+          && isNotArchived(child)) {
         problems.add(child.getName() + ": " + child.getState().operation);
       }
       problems.addAll(checkChildrenForProblemStates(child));

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/WebServiceProcess.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/WebServiceProcess.java
@@ -32,8 +32,8 @@ public class WebServiceProcess {
   private static String toProcessName(IWebServiceProcess ws) {
     String processIdentifier = ws.getProcessIdentifier();
     return ws.getWebServiceProcessStartElements().stream().findFirst()
-            .map(start -> toProcessName(start, processIdentifier))
-            .orElse(processIdentifier);
+        .map(start -> toProcessName(start, processIdentifier))
+        .orElse(processIdentifier);
   }
 
   private static String toProcessName(IWebServiceProcessStartElement start, String processIdentifier) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/commons/Feature.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/commons/Feature.java
@@ -11,7 +11,7 @@ public class Feature {
   public Feature(String clazz) {
     this(clazz, false);
   }
-  
+
   public Feature(String clazz, boolean isDefault) {
     this.clazz = clazz;
     this.isDefault = isDefault;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/commons/Property.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/commons/Property.java
@@ -18,7 +18,7 @@ public class Property {
   public Property(String name, String value) {
     this(name, value, null, false);
   }
-  
+
   public Property(String name, String value, boolean isDefault) {
     this.name = name;
     this.value = value;
@@ -31,7 +31,6 @@ public class Property {
     this.isDefault = isDefault;
     this.sensitive = meta != null ? meta.format() == ConfigValueFormat.PASSWORD : false;
   }
-
 
   public String getName() {
     return name;
@@ -56,7 +55,7 @@ public class Property {
   public void setSensitive(boolean sensitive) {
     this.sensitive = sensitive;
   }
-  
+
   public boolean isDefault() {
     return isDefault;
   }
@@ -71,18 +70,18 @@ public class Property {
     }
     Property other = (Property) obj;
     return new EqualsBuilder()
-            .append(name, other.getName())
-            .append(value, other.getValue())
-            .append(sensitive, other.isSensitive())
-            .isEquals();
+        .append(name, other.getName())
+        .append(value, other.getValue())
+        .append(sensitive, other.isSensitive())
+        .isEquals();
   }
 
   @Override
   public int hashCode() {
     return new HashCodeBuilder()
-            .append(name)
-            .append(value)
-            .append(sensitive)
-            .toHashCode();
+        .append(name)
+        .append(value)
+        .append(sensitive)
+        .toHashCode();
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/commons/TreeView.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/commons/TreeView.java
@@ -18,7 +18,7 @@ public abstract class TreeView<T> {
 
   public void reloadTree() {
     filter = "";
-    rootTreeNode = new DefaultTreeNode<T>("Tree", null, null);
+    rootTreeNode = new DefaultTreeNode<>("Tree", null, null);
     buildTree();
     applyToAllNodes(this::applyExpanded);
   }
@@ -38,7 +38,7 @@ public abstract class TreeView<T> {
 
   public void setFilter(String filter) {
     this.filter = filter;
-    filteredTreeNode = new DefaultTreeNode<T>("Filtered tree", null, null);
+    filteredTreeNode = new DefaultTreeNode<>("Filtered tree", null, null);
     filterTree(rootTreeNode.getChildren());
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/BrandingBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/BrandingBean.java
@@ -39,13 +39,13 @@ import ch.ivyteam.ivy.config.IFileAccess;
 public class BrandingBean implements AllResourcesDownload {
 
   private static final Map<String, String> RESOURCE_NAMES = Map.of("logo", "The main logo image",
-          "logo_light", "Same as the main logo, but e.g. in our case with white writing",
-          "logo_small", "The logo in small (square format recommended), used by e.g. error, login pages",
-          "logo_mail", "The logo with is taken by the default Axon Ivy Engine email notifications",
-          "favicon", "The logo fot the browser tab (square format recommended)");
+      "logo_light", "Same as the main logo, but e.g. in our case with white writing",
+      "logo_small", "The logo in small (square format recommended), used by e.g. error, login pages",
+      "logo_mail", "The logo with is taken by the default Axon Ivy Engine email notifications",
+      "favicon", "The logo fot the browser tab (square format recommended)");
   private static final Set<String> ALLOWED_EXTENSIONS = Set.of("png", "jpg", "jpeg", "svg", "webp", "gif");
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
   private BrandingIO brandingIO;
 
   private List<BrandingResource> resources;
@@ -86,17 +86,17 @@ public class BrandingBean implements AllResourcesDownload {
   public void reloadResources() {
     brandingIO = new BrandingIO(managerBean.getSelectedIApplication());
     resources = brandingIO.findResources(List.copyOf(RESOURCE_NAMES.keySet())).entrySet().stream()
-            .map(this::toBrandingResource)
-            .sorted(Comparator.comparing(BrandingResource::getLabel))
-            .collect(Collectors.toList());
+        .map(this::toBrandingResource)
+        .sorted(Comparator.comparing(BrandingResource::getLabel))
+        .collect(Collectors.toList());
     reloadCustomCssContent();
   }
 
   private void reloadCustomCssContent() {
     customCssContent = brandingIO.readCustomCss();
     cssColors = brandingIO.cssColors().stream()
-            .map(CssColorDTO::new)
-            .collect(Collectors.toList());
+        .map(CssColorDTO::new)
+        .collect(Collectors.toList());
   }
 
   public List<BrandingResource> getResources() {
@@ -121,8 +121,8 @@ public class BrandingBean implements AllResourcesDownload {
 
   public void setSelectedCssColor(String selectedCssColor) {
     this.selectedCssColor = cssColors.stream()
-            .filter(c -> c.getColor().equals(selectedCssColor))
-            .findFirst().orElse(new CssColorDTO("unknown color", "", ""));
+        .filter(c -> c.getColor().equals(selectedCssColor))
+        .findFirst().orElse(new CssColorDTO("unknown color", "", ""));
   }
 
   public CssColorDTO getSelectedCssColor() {
@@ -201,11 +201,11 @@ public class BrandingBean implements AllResourcesDownload {
     try (var out = new ByteArrayOutputStream()) {
       DownloadUtil.zipDir(appBrandingDir(appName), out);
       return DefaultStreamedContent
-              .builder()
-              .stream(() -> new ByteArrayInputStream(out.toByteArray()))
-              .contentType("application/zip")
-              .name("branding-" + appName + ".zip")
-              .build();
+          .builder()
+          .stream(() -> new ByteArrayInputStream(out.toByteArray()))
+          .contentType("application/zip")
+          .name("branding-" + appName + ".zip")
+          .build();
     } catch (IOException ex) {
       var message = new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", ex.getMessage());
       FacesContext.getCurrentInstance().addMessage("msgs", message);
@@ -240,8 +240,8 @@ public class BrandingBean implements AllResourcesDownload {
 
   public String getAllowedExtensionsString() {
     return ALLOWED_EXTENSIONS.stream()
-            .map(Object::toString)
-            .collect(Collectors.joining(", "));
+        .map(Object::toString)
+        .collect(Collectors.joining(", "));
   }
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/BusinessCalendarBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/BusinessCalendarBean.java
@@ -17,7 +17,7 @@ import ch.ivyteam.ivy.scripting.objects.Tree;
 @ViewScoped
 public class BusinessCalendarBean extends TreeView<BusinessCalendar> {
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
   private BusinessCalendar activeCalendar;
   private String calendarSelection;
 
@@ -29,7 +29,7 @@ public class BusinessCalendarBean extends TreeView<BusinessCalendar> {
   @Override
   protected void buildTree() {
     var rootTree = managerBean.getSelectedIApplication().getBusinessCalendarSettings()
-            .getAllBusinessCalendarConfigurations();
+        .getAllBusinessCalendarConfigurations();
     var node = new DefaultTreeNode<>(findCalendar(rootTree.getInfo()), rootTreeNode);
     node.setExpanded(true);
     buildCalendarTree(rootTree, node);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/SystemConfigBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/SystemConfigBean.java
@@ -14,13 +14,13 @@ import ch.ivyteam.enginecockpit.configuration.model.ConfigViewImpl;
 @ManagedBean
 @ViewScoped
 public class SystemConfigBean {
-  private ConfigViewImpl configView;
+  private final ConfigViewImpl configView;
 
   public SystemConfigBean() {
     configView = new ConfigViewImpl(List.of(
-            ConfigViewImpl.defaultFilter(),
-            new ContentFilter<ConfigProperty>("Security Systems", "Show Security Systems",
-                    p -> !StringUtils.startsWith(p.getKey(), "SecuritySystems."), true)));
+        ConfigViewImpl.defaultFilter(),
+        new ContentFilter<ConfigProperty>("Security Systems", "Show Security Systems",
+            p -> !StringUtils.startsWith(p.getKey(), "SecuritySystems."), true)));
   }
 
   public ConfigViewImpl getConfigView() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/VariableBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/VariableBean.java
@@ -20,7 +20,7 @@ import ch.ivyteam.ivy.vars.Variables;
 @ManagedBean
 @ViewScoped
 public class VariableBean implements ConfigView {
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
   private List<ConfigProperty> variables;
   private List<ConfigProperty> filteredVariables;
   private String filter;
@@ -37,9 +37,9 @@ public class VariableBean implements ConfigView {
     if (managerBean.getApplications().size() != 0) {
       app = managerBean.getSelectedIApplication();
       variables = variables().all().stream()
-              .filter(Objects::nonNull)
-              .map(ConfigProperty::new)
-              .collect(Collectors.toList());
+          .filter(Objects::nonNull)
+          .map(ConfigProperty::new)
+          .collect(Collectors.toList());
     }
     filteredVariables = null;
   }
@@ -100,7 +100,7 @@ public class VariableBean implements ConfigView {
 
   private void reloadAndUiMessage(String message) {
     FacesContext.getCurrentInstance().addMessage("msgs",
-            new FacesMessage("'" + activeVariable.getKey() + "' " + message));
+        new FacesMessage("'" + activeVariable.getKey() + "' " + message));
     reloadVariables();
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/BusinessCalendar.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/BusinessCalendar.java
@@ -16,11 +16,11 @@ import ch.ivyteam.ivy.application.calendar.WorkingTime;
 import ch.ivyteam.util.date.Weekday;
 
 public class BusinessCalendar {
-  private String name;
-  private Weekday firstDayOfWeek;
-  private List<TimeDayConfig> workingTimes;
-  private List<String> freeDaysOfWeek;
-  private List<TimeDayConfig> freeDays;
+  private final String name;
+  private final Weekday firstDayOfWeek;
+  private final List<TimeDayConfig> workingTimes;
+  private final List<String> freeDaysOfWeek;
+  private final List<TimeDayConfig> freeDays;
 
   public BusinessCalendar(IBusinessCalendarConfiguration calendarConfig) {
     this.name = calendarConfig.getName();
@@ -41,16 +41,16 @@ public class BusinessCalendar {
     }
 
     freeDays.addAll(calendarConfig.getFreeDaysOfYear().stream()
-            .map(day -> new TimeDayConfig(day, calendarName)).collect(Collectors.toList()));
+        .map(day -> new TimeDayConfig(day, calendarName)).collect(Collectors.toList()));
     freeDays.addAll(calendarConfig.getFreeEasterRelativeDays().stream()
-            .map(day -> new TimeDayConfig(day, calendarName)).collect(Collectors.toList()));
+        .map(day -> new TimeDayConfig(day, calendarName)).collect(Collectors.toList()));
     freeDays.addAll(calendarConfig.getFreeDates().stream().map(day -> new TimeDayConfig(day, calendarName))
-            .collect(Collectors.toList()));
+        .collect(Collectors.toList()));
 
     workingTimes.addAll(calendarConfig.getWorkingTimes().stream()
-            .map(time -> new TimeDayConfig(time, calendarName)).collect(Collectors.toList()));
+        .map(time -> new TimeDayConfig(time, calendarName)).collect(Collectors.toList()));
     freeDaysOfWeek.addAll(calendarConfig.getFreeDaysOfWeek().stream().map(day -> day.getDayOfWeek().getName())
-            .collect(Collectors.toList()));
+        .collect(Collectors.toList()));
   }
 
   public String getName() {
@@ -75,8 +75,8 @@ public class BusinessCalendar {
   }
 
   public final class WeekDay {
-    private String dayName;
-    private boolean free;
+    private final String dayName;
+    private final boolean free;
 
     public WeekDay(DayOfWeek day) {
       this.dayName = StringUtils.capitalize(day.name().toLowerCase());
@@ -93,8 +93,8 @@ public class BusinessCalendar {
   }
 
   public final class TimeDayConfig {
-    private String desc;
-    private String value;
+    private final String desc;
+    private final String value;
     private String calendarName;
     private String icon;
     private String tooltip;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
@@ -131,7 +131,7 @@ public class ConfigProperty {
 
   public String getShortSource() {
     return StringUtils.substring(source, StringUtils.lastIndexOf(source, '/') + 1,
-            getIndexOfSourceSuffix(source));
+        getIndexOfSourceSuffix(source));
   }
 
   public boolean isPassword() {
@@ -225,7 +225,7 @@ public class ConfigProperty {
           .build();
     } catch (IOException e) {
       FacesContext.getCurrentInstance().addMessage("msgs",
-              new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "Failed to load file: " + source));
+          new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "Failed to load file: " + source));
       return null;
     }
   }
@@ -248,10 +248,10 @@ public class ConfigProperty {
 
   private void correctValuesIfDaytimeFormat() {
     if (Objects.equals(configValueFormat, ConfigValueFormat.DAYTIME)) {
-      if (defaultValue.equals("0")) {
+      if ("0".equals(defaultValue)) {
         this.defaultValue = "00:00";
       }
-      if (value.equals("0")) {
+      if ("0".equals(value)) {
         this.value = "00:00";
       }
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigViewImpl.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigViewImpl.java
@@ -23,18 +23,18 @@ public class ConfigViewImpl implements TableFilter, ConfigView {
   private List<ConfigProperty> filteredConfigs;
   private String filter;
   private ConfigProperty activeConfig;
-  private IConfiguration configuration;
+  private final IConfiguration configuration;
   private List<String> selectedContentFilters;
-  private Function<ConfigProperty, ConfigProperty> propertyEnricher;
-  private List<ContentFilter<ConfigProperty>> contentFilters;
+  private final Function<ConfigProperty, ConfigProperty> propertyEnricher;
+  private final List<ContentFilter<ConfigProperty>> contentFilters;
 
   public ConfigViewImpl(List<ContentFilter<ConfigProperty>> contentFilters) {
     this(IConfiguration.instance(), c -> c, contentFilters);
   }
 
   public ConfigViewImpl(IConfiguration configuration,
-          Function<ConfigProperty, ConfigProperty> propertyEnricher,
-          List<ContentFilter<ConfigProperty>> contentFilters) {
+      Function<ConfigProperty, ConfigProperty> propertyEnricher,
+      List<ContentFilter<ConfigProperty>> contentFilters) {
     this.configuration = configuration;
     this.propertyEnricher = propertyEnricher;
     this.contentFilters = contentFilters;
@@ -45,10 +45,10 @@ public class ConfigViewImpl implements TableFilter, ConfigView {
   private void reloadConfigs() {
     ((Configuration) configuration).blockUntilReloaded();
     configs = configuration.getProperties().stream()
-            .filter(property -> !property.key().equals("SecuritySystem"))
-            .map(property -> new ConfigProperty(property))
-            .map(propertyEnricher)
-            .collect(Collectors.toList());
+        .filter(property -> !"SecuritySystem".equals(property.key()))
+        .map(ConfigProperty::new)
+        .map(propertyEnricher)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -120,9 +120,9 @@ public class ConfigViewImpl implements TableFilter, ConfigView {
   @Override
   public String getContentFilterText() {
     var text = contentFilters.stream()
-            .filter(ContentFilter::enabled)
-            .map(ContentFilter::name)
-            .collect(Collectors.joining(", "));
+        .filter(ContentFilter::enabled)
+        .map(ContentFilter::name)
+        .collect(Collectors.joining(", "));
     if (StringUtils.isBlank(text)) {
       return "none";
     }
@@ -132,7 +132,7 @@ public class ConfigViewImpl implements TableFilter, ConfigView {
   @Override
   public void setActiveConfig(String configKey) {
     this.activeConfig = configs.stream().filter(c -> StringUtils.equals(c.getKey(), configKey)).findFirst()
-            .orElse(new ConfigProperty());
+        .orElse(new ConfigProperty());
   }
 
   @Override
@@ -158,11 +158,11 @@ public class ConfigViewImpl implements TableFilter, ConfigView {
   private void reloadAndUiMessage(String message) {
     reloadConfigs();
     FacesContext.getCurrentInstance().addMessage("msgs",
-            new FacesMessage("'" + activeConfig.getKey() + "' " + message));
+        new FacesMessage("'" + activeConfig.getKey() + "' " + message));
     triggerTableFilter();
   }
 
   public static ContentFilter<ConfigProperty> defaultFilter() {
-    return new ContentFilter<ConfigProperty>(DEFINED_FILTER, "Show only defined values", c -> !c.isDefault());
+    return new ContentFilter<>(DEFINED_FILTER, "Show only defined values", c -> !c.isDefault());
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/CssColorDTO.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/CssColorDTO.java
@@ -29,24 +29,31 @@ public class CssColorDTO implements Serializable {
   public String getColor() {
     return color;
   }
+
   public void setColor(String color) {
     this.color = color;
   }
+
   public String getValue() {
     return value;
   }
+
   public void setValue(String value) {
     this.value = value;
   }
+
   public String getDefaultValue() {
     return defaultValue;
   }
+
   public void setDefaultValue(String defaultValue) {
     this.defaultValue = defaultValue;
   }
+
   public boolean isDefault() {
     return isDefault;
   }
+
   public void setDefault(boolean isDefault) {
     this.isDefault = isDefault;
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/dynamic/config/ConfigProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/dynamic/config/ConfigProperty.java
@@ -56,7 +56,7 @@ public class ConfigProperty {
     if (isDropdown()) {
       return value;
     }
-    if (value.equals(getDefaultValue())){
+    if (value.equals(getDefaultValue())) {
       return null;
     }
     return value;
@@ -66,7 +66,7 @@ public class ConfigProperty {
     if (metadata.isPassword() && StringUtils.isEmpty(value)) {
       return;
     }
-    if (this.value.equals(getDefaultValue()) && StringUtils.isEmpty(value) && !value.equals(getDefaultValue())){
+    if (this.value.equals(getDefaultValue()) && StringUtils.isEmpty(value) && !value.equals(getDefaultValue())) {
       return;
     }
     this.value = value;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/dynamic/config/ConfigPropertyGroup.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/dynamic/config/ConfigPropertyGroup.java
@@ -47,9 +47,13 @@ public class ConfigPropertyGroup {
       }
       var name = toName(p);
       var group = groups.stream()
-              .filter(g -> g.getName().equals(name))
-              .findAny()
-              .orElseGet(() -> { var g = new ConfigPropertyGroup(name); groups.add(g); return g; });
+          .filter(g -> g.getName().equals(name))
+          .findAny()
+          .orElseGet(() -> {
+            var g = new ConfigPropertyGroup(name);
+            groups.add(g);
+            return g;
+          });
       group.add(p);
     }
     return groups;
@@ -57,17 +61,17 @@ public class ConfigPropertyGroup {
 
   private static boolean isParentKey(List<ConfigProperty> properties, String n) {
     return properties.stream()
-            .map(ConfigProperty::getName)
-            .anyMatch(na -> !n.equals(na) && na.startsWith(n));
+        .map(ConfigProperty::getName)
+        .anyMatch(na -> !n.equals(na) && na.startsWith(n));
   }
 
   private static String toName(ConfigProperty p) {
     var name = p.getName();
     if (p.isKeyValue()) {
       return Arrays.stream(StringUtils.splitByCharacterTypeCamelCase(name))
-              .map(part -> StringUtils.remove(part, "."))
-              .map(part -> part.trim())
-              .collect(Collectors.joining(" "));
+          .map(part -> StringUtils.remove(part, "."))
+          .map(String::trim)
+          .collect(Collectors.joining(" "));
     }
     if (name.contains(".")) {
       return StringUtils.substringBefore(name, ".");

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/dynamic/config/DynamicConfig.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/dynamic/config/DynamicConfig.java
@@ -18,8 +18,8 @@ import ch.ivyteam.ivy.configuration.restricted.ConfigKey;
 @SuppressWarnings("restriction")
 public class DynamicConfig {
 
-  private List<ConfigPropertyGroup> groups;
-  private BiConsumer<ConfigKey, String> setter;
+  private final List<ConfigPropertyGroup> groups;
+  private final BiConsumer<ConfigKey, String> setter;
 
   public DynamicConfig(List<ConfigPropertyGroup> groups, BiConsumer<ConfigKey, String> setter) {
     this.groups = groups;
@@ -41,7 +41,7 @@ public class DynamicConfig {
       int separator = shortKey.indexOf('.');
       if (separator != -1) {
         var before = shortKey.substring(0, separator);
-        var next = shortKey.substring(separator+1);
+        var next = shortKey.substring(separator + 1);
         pKey = gKey.append(before).append(next);
       }
       setter.accept(pKey, p.getValue());
@@ -51,9 +51,9 @@ public class DynamicConfig {
 
   public static void message() {
     Message.info()
-            .clientId("dynamicConfigFormSaveSuccess")
-            .summary("Successfully saved")
-            .show();
+        .clientId("dynamicConfigFormSaveSuccess")
+        .summary("Successfully saved")
+        .show();
   }
 
   public static Builder create() {
@@ -78,8 +78,8 @@ public class DynamicConfig {
 
     public DynamicConfig toDynamicConfig() {
       var properties = new ConfiguratorMetadataProvider(configurator).get().entrySet().stream()
-              .map(entry -> toConfigProperty(entry.getKey(), entry.getValue()))
-              .collect(Collectors.toList());
+          .map(entry -> toConfigProperty(entry.getKey(), entry.getValue()))
+          .collect(Collectors.toList());
       var propertyGroups = ConfigPropertyGroup.toGroups(properties);
       return new DynamicConfig(propertyGroups, config::setProperty);
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/fileupload/DeployOptionsBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/fileupload/DeployOptionsBean.java
@@ -29,8 +29,8 @@ public class DeployOptionsBean {
 
   private static List<String> listNames(Enum<?>[] vals) {
     return Arrays.stream(vals)
-            .map(val -> val.name())
-            .collect(Collectors.toList());
+        .map(Enum::name)
+        .collect(Collectors.toList());
   }
 
   public String getDeployTestUsers() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/fileupload/HttpFile.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/fileupload/HttpFile.java
@@ -11,7 +11,7 @@ public class HttpFile {
   private final InputStream stream;
 
   public HttpFile(String name, String submittedFileName, long size, Map<String, String> parameters,
-          InputStream stream) {
+      InputStream stream) {
     this.name = name;
     this.submittedFileName = submittedFileName;
     this.size = size;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/fileupload/UploadHelperBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/fileupload/UploadHelperBean.java
@@ -18,8 +18,8 @@ public class UploadHelperBean {
 
   public String getDeploymentPossibleReason() {
     return "The system configuration '" + REST_SERVLET_ENABLED + "' or '"
-            + REST_DEPLOYMENT_ENABLED + "' is disabled.<br/>"
-            + "Please enable them or use the file system for the deployment.";
+        + REST_DEPLOYMENT_ENABLED + "' is disabled.<br/>"
+        + "Please enable them or use the file system for the deployment.";
   }
 
   private static boolean isRestEnabled() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/info/Application.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/info/Application.java
@@ -13,7 +13,7 @@ public class Application {
   private final boolean devMode;
 
   public Application(IApplication app) {
-    this.app = (IApplicationInternal)app;
+    this.app = (IApplicationInternal) app;
     this.name = app.getName();
     this.devMode = app.getSecurityContext().isDevMode();
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/info/EngineInfo.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/info/EngineInfo.java
@@ -29,10 +29,10 @@ public class EngineInfo {
 
   public EngineInfo() {
     applications = IApplicationRepository.instance().all().stream()
-            .sorted(Comparator.comparing(IApplication::getName, String.CASE_INSENSITIVE_ORDER))
-            .map(Application::new)
-            .filter(this::isNotInDevMode)
-            .collect(Collectors.toList());
+        .sorted(Comparator.comparing(IApplication::getName, String.CASE_INSENSITIVE_ORDER))
+        .map(Application::new)
+        .filter(this::isNotInDevMode)
+        .collect(Collectors.toList());
   }
 
   public boolean canShutdown() {
@@ -79,8 +79,8 @@ public class EngineInfo {
   public List<Application> getApplications() {
     if (isDemo()) {
       return applications.stream()
-              .filter(app -> !app.getName().equals("demo-portal"))
-              .collect(Collectors.toList());
+          .filter(app -> !"demo-portal".equals(app.getName()))
+          .collect(Collectors.toList());
     }
     if (isMaintenance()) {
       return new ArrayList<>();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/CacheBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/CacheBean.java
@@ -33,11 +33,10 @@ public class CacheBean {
     var server = ManagementFactory.getPlatformMBeanServer();
     try {
       caches = server.queryNames(new ObjectName("ivy Engine:type=CacheClassPersistencyService,name=*"), null)
-              .stream()
-              .flatMap(Cache::toCaches)
-              .collect(Collectors.toList());
-    } catch (MalformedObjectNameException ex) {
-    }
+          .stream()
+          .flatMap(Cache::toCaches)
+          .collect(Collectors.toList());
+    } catch (MalformedObjectNameException ex) {}
   }
 
   public List<Cache> getCaches() {
@@ -61,8 +60,8 @@ public class CacheBean {
   }
 
   public static final class Cache {
-    private static final String[] SIGNATURE = new String[0];
-    private static final Object[] PARAMS = new Object[0];
+    private static final String[] SIGNATURE = {};
+    private static final Object[] PARAMS = {};
     private final ObjectName objectName;
     private final String name;
     private final ValueProvider count;
@@ -79,17 +78,17 @@ public class CacheBean {
         name = StringUtils.removeEnd(name, "Data");
 
         return Stream.of(
-                toEntityCache(name, objectName),
-                toAssociationCache(name, objectName),
-                toBinaryCache(name, objectName),
-                toCharacterCache(name, objectName));
+            toEntityCache(name, objectName),
+            toAssociationCache(name, objectName),
+            toBinaryCache(name, objectName),
+            toCharacterCache(name, objectName));
       } catch (MalformedObjectNameException ex) {
         return null;
       }
     }
 
     private static Cache toEntityCache(String name, ObjectName objectName)
-            throws MalformedObjectNameException {
+        throws MalformedObjectNameException {
       var advisorName = new ObjectName(objectName.toString() + ",strategy=CacheAllRemoveUnused");
       ValueProvider limit = null;
       ValueProvider info = null;
@@ -107,11 +106,11 @@ public class CacheBean {
       var readHits = ValueProvider.attribute(objectName, "objectReadHits", Unit.ONE);
       var readMisses = ValueProvider.attribute(objectName, "objectReadMisses", Unit.ONE);
       return new Cache(objectName, name + " Entities", count, limit, readHits, readMisses, writes, info,
-              true);
+          true);
     }
 
     private static Cache toAssociationCache(String name, ObjectName objectName)
-            throws MalformedObjectNameException {
+        throws MalformedObjectNameException {
       objectName = new ObjectName(objectName.toString() + ",cache=ObjectsAndAssociations");
 
       var count = ValueProvider.attribute(objectName, "cachedAssociations", Unit.ONE);
@@ -119,17 +118,17 @@ public class CacheBean {
       var readHits = ValueProvider.attribute(objectName, "assocationReadHits", Unit.ONE);
       var readMisses = ValueProvider.attribute(objectName, "associationReadMisses", Unit.ONE);
       return new Cache(objectName, name + " Associations", count, null, readHits, readMisses, writes, null,
-              false);
+          false);
     }
 
     private static Cache toBinaryCache(String name, ObjectName objectName)
-            throws MalformedObjectNameException {
+        throws MalformedObjectNameException {
       ValueProvider info = null;
       var advisorName = getAdvisorName(objectName);
       if (advisorName != null) {
         info = ValueProvider.format(
-                "max=%d",
-                ValueProvider.attribute(advisorName, "maxBytesToCache", Unit.BYTES));
+            "max=%d",
+            ValueProvider.attribute(advisorName, "maxBytesToCache", Unit.BYTES));
       }
       objectName = new ObjectName(objectName.toString() + ",cache=LongBinaries");
       var count = ValueProvider.attribute(objectName, "cachedLongValues", Unit.ONE);
@@ -137,17 +136,17 @@ public class CacheBean {
       var readHits = ValueProvider.attribute(objectName, "readHits", Unit.ONE);
       var readMisses = ValueProvider.attribute(objectName, "readMisses", Unit.ONE);
       return new Cache(objectName, name + " Long Binaries", count, null, readHits, readMisses, writes, info,
-              true);
+          true);
     }
 
     private static Cache toCharacterCache(String name, ObjectName objectName)
-            throws MalformedObjectNameException {
+        throws MalformedObjectNameException {
       ValueProvider info = null;
       var advisorName = getAdvisorName(objectName);
       if (advisorName != null) {
         info = ValueProvider.format(
-                "max=%d",
-                ValueProvider.attribute(advisorName, "maxCharactersToCache", Unit.ONE));
+            "max=%d",
+            ValueProvider.attribute(advisorName, "maxCharactersToCache", Unit.ONE));
       }
       objectName = new ObjectName(objectName.toString() + ",cache=LongCharacters");
       var count = ValueProvider.attribute(objectName, "cachedLongValues", Unit.ONE);
@@ -155,7 +154,7 @@ public class CacheBean {
       var readHits = ValueProvider.attribute(objectName, "readHits", Unit.ONE);
       var readMisses = ValueProvider.attribute(objectName, "readMisses", Unit.ONE);
       return new Cache(objectName, name + " Long Characaters", count, null, readHits, readMisses, writes,
-              info, true);
+          info, true);
     }
 
     private static ObjectName getAdvisorName(ObjectName objectName) throws MalformedObjectNameException {
@@ -171,8 +170,8 @@ public class CacheBean {
     }
 
     private Cache(ObjectName objectName, String name, ValueProvider count, ValueProvider limit,
-            ValueProvider readHits, ValueProvider readMisses, ValueProvider writes, ValueProvider info,
-            boolean clearable) {
+        ValueProvider readHits, ValueProvider readMisses, ValueProvider writes, ValueProvider info,
+        boolean clearable) {
       this.objectName = objectName;
       this.name = name;
       this.count = count;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/IntermediateEventBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/IntermediateEventBean.java
@@ -13,7 +13,6 @@ import ch.ivyteam.enginecockpit.monitor.events.intermediate.IntermediateEvent;
 import ch.ivyteam.enginecockpit.util.ErrorHandler;
 import ch.ivyteam.log.Logger;
 
-
 @ManagedBean
 @ViewScoped
 public class IntermediateEventBean {
@@ -29,12 +28,12 @@ public class IntermediateEventBean {
 
   public void refresh() {
     try {
-      // needs to be modifiable for sorting	
+      // needs to be modifiable for sorting
       beans = ManagementFactory.getPlatformMBeanServer()
-              .queryNames(new ObjectName("ivy Engine:type=Process Intermediate Event Bean,application=*,pm=*,pmv=*,name=*"), null)
-              .stream()
-              .map(IntermediateEvent::new)
-              .collect(Collectors.toList());
+          .queryNames(new ObjectName("ivy Engine:type=Process Intermediate Event Bean,application=*,pm=*,pmv=*,name=*"), null)
+          .stream()
+          .map(IntermediateEvent::new)
+          .collect(Collectors.toList());
     } catch (MalformedObjectNameException ex) {
       HANDLER.showError("Cannot read intermediate event bean", ex);
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/JobBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/JobBean.java
@@ -33,13 +33,13 @@ public class JobBean {
   public void refresh() {
     try {
       var cronJobs = ManagementFactory.getPlatformMBeanServer()
-              .queryNames(new ObjectName("ivy Engine:type=Cron Job,name=*"), null)
-              .stream()
-              .map(Job::new);
+          .queryNames(new ObjectName("ivy Engine:type=Cron Job,name=*"), null)
+          .stream()
+          .map(Job::new);
       var periodicalJobs = ManagementFactory.getPlatformMBeanServer()
-              .queryNames(new ObjectName("ivy Engine:type=Periodical Job,name=*"), null)
-              .stream()
-              .map(Job::new);
+          .queryNames(new ObjectName("ivy Engine:type=Periodical Job,name=*"), null)
+          .stream()
+          .map(Job::new);
 
       var allJobs = Streams
           .concat(cronJobs, periodicalJobs)
@@ -80,7 +80,7 @@ public class JobBean {
 
   public static final class Job {
 
-    private MBean bean;
+    private final MBean bean;
 
     private Job(ObjectName name) {
       this.bean = MBean.create(HANDLER, name);
@@ -108,7 +108,7 @@ public class JobBean {
 
     public String getConfiguration() {
       if ("Cron Job".equals(bean.getNameKeyProperty("type"))) {
-        return bean.readAttribute("expression").asString() + " (" + bean.readAttribute("humanReadableExpression").asString()+")";
+        return bean.readAttribute("expression").asString() + " (" + bean.readAttribute("humanReadableExpression").asString() + ")";
       }
       var atFixRate = bean.readAttribute("atFixedRate").asBoolean();
       var desc = atFixRate ? " (each)" : " (between)";

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/OsBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/OsBean.java
@@ -6,6 +6,8 @@ import static ch.ivyteam.enginecockpit.monitor.value.ValueProvider.format;
 import static ch.ivyteam.enginecockpit.monitor.value.ValueProvider.percentage;
 import static ch.ivyteam.enginecockpit.monitor.value.ValueProvider.value;
 
+import java.util.function.DoubleSupplier;
+
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -17,13 +19,13 @@ import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
 @ManagedBean
 @ViewScoped
 public class OsBean {
-  private Monitor memoryMonitor = Monitor.build().name("Memory").icon("analytics-board-graph-line")
-          .yAxisLabel("Memory").reverseColors().toMonitor();
-  private Monitor cpuMonitor = Monitor.build().name("CPU Load").icon("computer-chip").yAxisLabel("Load")
-          .toMonitor();
-  private Monitor networkMonitor = Monitor.build().name("Network").icon("network-signal")
-          .yAxisLabel("Send / Recv").toMonitor();
-  private Monitor ioMonitor = Monitor.build().name("IO").icon("cd").yAxisLabel("Read / Write").toMonitor();
+  private final Monitor memoryMonitor = Monitor.build().name("Memory").icon("analytics-board-graph-line")
+      .yAxisLabel("Memory").reverseColors().toMonitor();
+  private final Monitor cpuMonitor = Monitor.build().name("CPU Load").icon("computer-chip").yAxisLabel("Load")
+      .toMonitor();
+  private final Monitor networkMonitor = Monitor.build().name("Network").icon("network-signal")
+      .yAxisLabel("Send / Recv").toMonitor();
+  private final Monitor ioMonitor = Monitor.build().name("IO").icon("cd").yAxisLabel("Read / Write").toMonitor();
 
   private long[] oldTicks;
   private double cpuLoad;
@@ -82,7 +84,7 @@ public class OsBean {
   }
 
   private ValueProvider cpuLoad() {
-    return percentage(value(() -> processorLoad(), Unit.PERCENTAGE));
+    return percentage(value((DoubleSupplier) this::processorLoad, Unit.PERCENTAGE));
   }
 
   private double processorLoad() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/StartEventBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/StartEventBean.java
@@ -28,12 +28,12 @@ public class StartEventBean {
 
   public void refresh() {
     try {
-      // needs to be modifiable for sorting	
+      // needs to be modifiable for sorting
       beans = ManagementFactory.getPlatformMBeanServer()
-              .queryNames(new ObjectName("ivy Engine:type=Process Start Event Bean,application=*,pm=*,pmv=*,name=*"), null)
-              .stream()
-              .map(StartEvent::new)
-              .collect(Collectors.toList());
+          .queryNames(new ObjectName("ivy Engine:type=Process Start Event Bean,application=*,pm=*,pmv=*,name=*"), null)
+          .stream()
+          .map(StartEvent::new)
+          .collect(Collectors.toList());
     } catch (MalformedObjectNameException ex) {
       HANDLER.showError("Cannot read start event beans", ex);
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/SystemHardware.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/SystemHardware.java
@@ -7,7 +7,9 @@ import javax.faces.context.FacesContext;
 import oshi.SystemInfo;
 import oshi.hardware.CentralProcessor;
 import oshi.hardware.GlobalMemory;
+import oshi.hardware.HWDiskStore;
 import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.NetworkIF;
 
 @ManagedBean
 @RequestScoped
@@ -33,11 +35,11 @@ public class SystemHardware {
 
   public SystemHardware() {
     var diskStores = HARDWARE.getDiskStores();
-    ioWriteTotal = diskStores.stream().mapToLong(n -> n.getWriteBytes()).sum();
-    ioReadTotal = diskStores.stream().mapToLong(n -> n.getReadBytes()).sum();
+    ioWriteTotal = diskStores.stream().mapToLong(HWDiskStore::getWriteBytes).sum();
+    ioReadTotal = diskStores.stream().mapToLong(HWDiskStore::getReadBytes).sum();
     var networkIFs = HARDWARE.getNetworkIFs();
-    networkReceiveTotal = networkIFs.stream().mapToLong(n -> n.getBytesRecv()).sum();
-    networkSendTotal = networkIFs.stream().mapToLong(n -> n.getBytesSent()).sum();
+    networkReceiveTotal = networkIFs.stream().mapToLong(NetworkIF::getBytesRecv).sum();
+    networkSendTotal = networkIFs.stream().mapToLong(NetworkIF::getBytesSent).sum();
     memoryAvailable = MEMORY.getAvailable();
     memoryTotal = MEMORY.getTotal();
     processorLogicalCount = PROCESSOR.getLogicalProcessorCount();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/blob/BlobDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/blob/BlobDto.java
@@ -1,9 +1,11 @@
 package ch.ivyteam.enginecockpit.monitor.blob;
 
 import java.util.Date;
+
 import org.apache.commons.io.FileUtils;
 import org.primefaces.model.DefaultStreamedContent;
 import org.primefaces.model.StreamedContent;
+
 import ch.ivyteam.enginecockpit.security.model.User;
 import ch.ivyteam.ivy.blob.storage.core.Blob;
 import ch.ivyteam.ivy.blob.storage.core.BlobService;
@@ -86,9 +88,9 @@ public class BlobDto {
 
   public StreamedContent download() {
     return DefaultStreamedContent.builder()
-            .name(blob.fileName())
-            .contentType(getMimeType())
-            .stream(() -> BlobService.of(blob.app()).read(blob.uuid()))
-            .build();
+        .name(blob.fileName())
+        .contentType(getMimeType())
+        .stream(() -> BlobService.of(blob.app()).read(blob.uuid()))
+        .build();
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/blob/BlobsDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/blob/BlobsDataModel.java
@@ -17,7 +17,7 @@ import ch.ivyteam.ivy.jsf.primefaces.sort.SortMetaConverter;
 
 public class BlobsDataModel extends LazyDataModel<BlobDto> {
 
-  private SecuritySystem securitySystem;
+  private final SecuritySystem securitySystem;
   private String filter;
 
   public BlobsDataModel(SecuritySystem securitySystem) {
@@ -40,10 +40,10 @@ public class BlobsDataModel extends LazyDataModel<BlobDto> {
     applyOrdering(query, sortBy);
 
     var blobs = query
-            .executor()
-            .results(first, pageSize).stream()
-            .map(BlobDto::new)
-            .collect(Collectors.toList());
+        .executor()
+        .results(first, pageSize).stream()
+        .map(BlobDto::new)
+        .collect(Collectors.toList());
     setRowCount((int) query.executor().count());
     return blobs;
   }
@@ -52,9 +52,9 @@ public class BlobsDataModel extends LazyDataModel<BlobDto> {
     if (StringUtils.isNotEmpty(filter)) {
       var dbFilter = "%" + filter + "%";
       query.where().and(query().where()
-              .path().isLikeIgnoreCase(dbFilter))
-            .or()
-              .uUID().isEqual(dbFilter);
+          .path().isLikeIgnoreCase(dbFilter))
+          .or()
+          .uUID().isEqual(dbFilter);
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/Event.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/Event.java
@@ -42,7 +42,7 @@ public abstract class Event {
     if (StringUtils.isEmpty(elementName)) {
       return beanName;
     }
-    return elementName +" (" + beanName + ")";
+    return elementName + " (" + beanName + ")";
   }
 
   public String getBeanDescription() {
@@ -51,7 +51,7 @@ public abstract class Event {
     if (StringUtils.isEmpty(elementDescr)) {
       return beanDescr;
     }
-    return elementDescr +" (" + beanDescr + ")";
+    return elementDescr + " (" + beanDescr + ")";
   }
 
   public String getApplication() {
@@ -72,7 +72,7 @@ public abstract class Event {
 
   public String getBeanConfiguration() {
     var entries = bean.readAttribute("beanConfiguration")
-      .asList(item -> (String)item.get("key")+"="+item.get("value"));
+        .asList(item -> (String) item.get("key") + "=" + item.get("value"));
     return entries.stream().collect(Collectors.joining("\n"));
   }
 
@@ -155,7 +155,6 @@ public abstract class Event {
   public void stop() {
     bean.invokeMethod("stop");
   }
-
 
   public void refresh() {
     firings = bean.readAttribute("firingHistory").asList(Firing::new);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/EventBeanThread.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/EventBeanThread.java
@@ -5,16 +5,16 @@ import javax.management.openmbean.CompositeData;
 import ch.ivyteam.enginecockpit.util.ErrorValue;
 
 public class EventBeanThread {
-  
+
   private final String name;
   private final Long javaThreadId;
   private final String state;
   private final ErrorValue lastError;
 
   public EventBeanThread(CompositeData thread) {
-    this.name = (String)thread.get("name");
-    this.javaThreadId = (Long)thread.get("javaThreadId");
-    this.state = (String)thread.get("state");
+    this.name = (String) thread.get("name");
+    this.javaThreadId = (Long) thread.get("javaThreadId");
+    this.state = (String) thread.get("state");
     this.lastError = new ErrorValue((CompositeData) thread.get("lastError"));
   }
 
@@ -33,7 +33,7 @@ public class EventBeanThread {
   public ErrorValue getLastError() {
     return lastError;
   }
-  
+
   public boolean getIsRunning() {
     return "RUNNING".equals(state);
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/Firing.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/Firing.java
@@ -10,10 +10,10 @@ import ch.ivyteam.enginecockpit.util.ErrorValue;
 
 public final class Firing {
 
-  private Date timestamp;
-  private long duration;
-  private String reason;
-  private ErrorValue error;
+  private final Date timestamp;
+  private final long duration;
+  private final String reason;
+  private final ErrorValue error;
 
   public Firing(CompositeData firing) {
     this.timestamp = (Date) firing.get("firingTimestamp");

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/intermediate/IntermediateEvent.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/intermediate/IntermediateEvent.java
@@ -13,12 +13,12 @@ public final class IntermediateEvent extends Event {
   @Override
   public String getFullRequestPath() {
     return getApplication() +
-            "/" +
-            getPm() +
-            "$" +
-            getPmv() +
-            "/" +
-            getProcessElementId();
+        "/" +
+        getPm() +
+        "$" +
+        getPmv() +
+        "/" +
+        getProcessElementId();
   }
 
   public String getLastFiringTimestamp() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/start/StartEvent.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/events/start/StartEvent.java
@@ -13,12 +13,12 @@ public final class StartEvent extends Event {
   @Override
   public String getFullRequestPath() {
     return getApplication() +
-           "/"+
-           getPm() +
-           "$" +
-           getPmv() +
-           "/" +
-           getRequestPath();
+        "/" +
+        getPm() +
+        "$" +
+        getPmv() +
+        "/" +
+        getRequestPath();
   }
 
   public String getRequestPath() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
@@ -17,7 +17,7 @@ import ch.ivyteam.ivy.health.check.HealthSeverity;
 public class HealthBean {
 
   private final HealthChecker checker = HealthChecker.instance();
-  private List<Check> checks;
+  private final List<Check> checks;
   private List<Message> messages;
   private String check;
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/log/LogBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/log/LogBean.java
@@ -73,8 +73,8 @@ public class LogBean implements AllResourcesDownload {
     }
 
     logs = LogFileRepository.instance().byDate(date)
-            .map(LogView::new)
-            .collect(Collectors.toList());
+        .map(LogView::new)
+        .collect(Collectors.toList());
 
     if (logs.isEmpty()) {
       return;
@@ -85,9 +85,9 @@ public class LogBean implements AllResourcesDownload {
     }
 
     logView = logs.stream()
-            .filter(l -> l.getChannel().equals(channel))
-            .findAny()
-            .orElse(null);
+        .filter(l -> l.getChannel().equals(channel))
+        .findAny()
+        .orElse(null);
     if (logView == null) {
       ResponseHelper.notFound("Log for channel " + channel + " does not exist");
     }
@@ -126,11 +126,11 @@ public class LogBean implements AllResourcesDownload {
   public StreamedContent getAllResourcesDownload() {
     var zipFile = writeLogsToZip();
     return DefaultStreamedContent
-            .builder()
-            .stream(() -> DownloadUtil.getFileStream(zipFile))
-            .contentType("application/zip")
-            .name("logs.zip")
-            .build();
+        .builder()
+        .stream(() -> DownloadUtil.getFileStream(zipFile))
+        .contentType("application/zip")
+        .name("logs.zip")
+        .build();
   }
 
   private File writeLogsToZip() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/log/LogView.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/log/LogView.java
@@ -23,9 +23,9 @@ public class LogView {
 
   private static final int LINES = 100;
 
-  private LogFile logFile;
+  private final LogFile logFile;
   private final String content;
-  private String size;
+  private final String size;
 
   public LogView(LogFile log) {
     logFile = log;
@@ -72,8 +72,8 @@ public class LogView {
   private List<String> readFileLines() {
     var lines = new ArrayList<String>();
     var builder = ReversedLinesFileReader.builder()
-            .setPath(logFile.path())
-            .setCharset(StandardCharsets.UTF_8);
+        .setPath(logFile.path())
+        .setCharset(StandardCharsets.UTF_8);
 
     var endReached = true;
     try (var reader = builder.get()) {
@@ -111,10 +111,10 @@ public class LogView {
   public StreamedContent getFile() throws IOException {
     var newInputStream = Files.newInputStream(logFile.path());
     return DefaultStreamedContent.builder()
-            .stream(() -> newInputStream)
-            .contentType("text/plain")
-            .name(logFile.name())
-            .build();
+        .stream(() -> newInputStream)
+        .contentType("text/plain")
+        .name(logFile.name())
+        .build();
   }
 
   public static LogViewUriBuilder uri() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MAttribute.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MAttribute.java
@@ -14,8 +14,8 @@ import javax.management.openmbean.TabularData;
 import org.apache.commons.lang.ArrayUtils;
 
 public class MAttribute implements Comparable<MAttribute> {
-  private Attribute attribute;
-  private MBeanAttributeInfo info;
+  private final Attribute attribute;
+  private final MBeanAttributeInfo info;
 
   MAttribute(Attribute attribute, MBeanAttributeInfo info) {
     this.attribute = attribute;
@@ -38,22 +38,22 @@ public class MAttribute implements Comparable<MAttribute> {
   public boolean getIsTraceable() {
     String type = info.getType();
     return compositeWithNumbersOnly(type) ||
-            isNumber(type);
+        isNumber(type);
   }
 
   private boolean isNumber(String type) {
     return Byte.class.getName().equals(type) ||
-            Byte.TYPE.getName().equals(type) ||
-            Short.class.getName().equals(type) ||
-            Short.TYPE.getName().equals(type) ||
-            Integer.class.getName().equals(type) ||
-            Integer.TYPE.getName().equals(type) ||
-            Long.class.getName().equals(type) ||
-            Long.TYPE.getName().equals(type) ||
-            Float.class.getName().equals(type) ||
-            Float.TYPE.getName().equals(type) ||
-            Double.class.getName().equals(type) ||
-            Double.TYPE.getName().equals(type);
+        Byte.TYPE.getName().equals(type) ||
+        Short.class.getName().equals(type) ||
+        Short.TYPE.getName().equals(type) ||
+        Integer.class.getName().equals(type) ||
+        Integer.TYPE.getName().equals(type) ||
+        Long.class.getName().equals(type) ||
+        Long.TYPE.getName().equals(type) ||
+        Float.class.getName().equals(type) ||
+        Float.TYPE.getName().equals(type) ||
+        Double.class.getName().equals(type) ||
+        Double.TYPE.getName().equals(type);
   }
 
   private boolean compositeWithNumbersOnly(String type) {
@@ -64,11 +64,11 @@ public class MAttribute implements Comparable<MAttribute> {
       }
       CompositeType ctype = data.getCompositeType();
       return ctype
-              .keySet()
-              .stream()
-              .map(ctype::getType)
-              .map(OpenType::getTypeName)
-              .allMatch(this::isNumber);
+          .keySet()
+          .stream()
+          .map(ctype::getType)
+          .map(OpenType::getTypeName)
+          .allMatch(this::isNumber);
     }
     return false;
   }
@@ -109,8 +109,8 @@ public class MAttribute implements Comparable<MAttribute> {
     StringBuilder builder = new StringBuilder();
     builder.append("<table>");
     tab
-            .values()
-            .forEach(entry -> appendRow(entry, builder));
+        .values()
+        .forEach(entry -> appendRow(entry, builder));
     builder.append("</table>");
     return builder.toString();
   }
@@ -124,10 +124,10 @@ public class MAttribute implements Comparable<MAttribute> {
   private static String getCompositeValue(CompositeData value) {
     CompositeType type = value.getCompositeType();
     return type
-            .keySet()
-            .stream()
-            .map(key -> key.toString() + "=" + getValue(value.get(key)))
-            .collect(Collectors.joining(", "));
+        .keySet()
+        .stream()
+        .map(key -> key.toString() + "=" + getValue(value.get(key)))
+        .collect(Collectors.joining(", "));
   }
 
   private static String getArrayValue(Object array) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MBean.java
@@ -22,11 +22,11 @@ import ch.ivyteam.enginecockpit.util.ErrorValue;
 public class MBean {
 
   public static final String NOT_AVAILABLE = DurationFormat.NOT_AVAILABLE_STR;
-  private static final Object[] EMPTY_PARAMS = new Object[0];
-  private static final String[] EMPTY_TYPES = new String[0];
+  private static final Object[] EMPTY_PARAMS = {};
+  private static final String[] EMPTY_TYPES = {};
 
-  private ErrorHandler handler;
-  private ObjectName name;
+  private final ErrorHandler handler;
+  private final ObjectName name;
 
   private MBean(ErrorHandler handler, ObjectName name) {
     this.handler = handler;
@@ -41,7 +41,7 @@ public class MBean {
     try {
       return create(handler, new ObjectName(name));
     } catch (MalformedObjectNameException ex) {
-      handler.showError("Could not parse MBean name '"+name+"'", ex);
+      handler.showError("Could not parse MBean name '" + name + "'", ex);
       return null;
     }
   }
@@ -64,7 +64,7 @@ public class MBean {
 
   public final class Attribute {
 
-    private String attribute;
+    private final String attribute;
 
     public Attribute(String attribute) {
       this.attribute = attribute;
@@ -80,15 +80,15 @@ public class MBean {
     }
 
     public Long asNullableLong() {
-      return (Long)asObject();
+      return (Long) asObject();
     }
 
     public long asLong() {
-      return (long)asObject();
+      return (long) asObject();
     }
 
     public ErrorValue asError() {
-      return new ErrorValue((CompositeData)asObject());
+      return new ErrorValue((CompositeData) asObject());
     }
 
     public String asDateString() {
@@ -108,7 +108,7 @@ public class MBean {
     }
 
     public boolean asBoolean() {
-      return (boolean)asObject();
+      return (boolean) asObject();
     }
 
     public String asString() {
@@ -116,7 +116,7 @@ public class MBean {
     }
 
     public <T> List<T> asList(Function<CompositeData, T> mapper) {
-      var array = (CompositeData[])asObject();
+      var array = (CompositeData[]) asObject();
       return Stream.of(array).map(mapper).toList();
     }
 
@@ -125,11 +125,11 @@ public class MBean {
       if (executions == 0) {
         return NOT_AVAILABLE;
       }
-      return readAttribute(attribute+"MinExecutionTimeInMicroSeconds").asMicros();
+      return readAttribute(attribute + "MinExecutionTimeInMicroSeconds").asMicros();
     }
 
     public String asAvgExecutionTime() {
-      var total = readAttribute(attribute+"TotalExecutionTimeInMicroSeconds").asNullableLong();
+      var total = readAttribute(attribute + "TotalExecutionTimeInMicroSeconds").asNullableLong();
       if (total == null) {
         return DurationFormat.NOT_AVAILABLE.microSeconds(total);
       }
@@ -145,7 +145,7 @@ public class MBean {
       if (executions == 0) {
         return NOT_AVAILABLE;
       }
-      return readAttribute(attribute+"MaxExecutionTimeInMicroSeconds").asMicros();
+      return readAttribute(attribute + "MaxExecutionTimeInMicroSeconds").asMicros();
     }
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MBeanTreeNode.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MBeanTreeNode.java
@@ -9,10 +9,10 @@ public class MBeanTreeNode extends DefaultTreeNode<MName> implements Comparable<
   MBeanTreeNode(MName name, Set<MName> allNames) {
     setData(name);
     setChildren(name.getDirectChildren(allNames)
-            .stream()
-            .map(child -> new MBeanTreeNode(child, allNames))
-            .sorted()
-            .collect(Collectors.toList()));
+        .stream()
+        .map(child -> new MBeanTreeNode(child, allNames))
+        .sorted()
+        .collect(Collectors.toList()));
     setType(this.isLeaf() ? "bean" : "folder");
     setSelectable(this.isLeaf());
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MBeansBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MBeansBean.java
@@ -40,9 +40,9 @@ public class MBeansBean {
     MBeanServer server = ManagementFactory.getPlatformMBeanServer();
     Set<ObjectName> beanNames = server.queryNames(null, null);
     Set<MName> names = beanNames
-            .stream()
-            .map(beanName -> new MName(beanName))
-            .collect(Collectors.toSet());
+        .stream()
+        .map(MName::new)
+        .collect(Collectors.toSet());
     root = new MBeanTreeNode(MName.ROOT, names);
   }
 
@@ -83,15 +83,15 @@ public class MBeansBean {
         MBeanInfo info = server.getMBeanInfo(selected.getObjectName());
         MBeanAttributeInfo[] attributeInfos = info.getAttributes();
         String[] attributeNames = Arrays
-                .stream(attributeInfos)
-                .map(MBeanAttributeInfo::getName)
-                .toArray(String[]::new);
+            .stream(attributeInfos)
+            .map(MBeanAttributeInfo::getName)
+            .toArray(String[]::new);
         attributes = server.getAttributes(selected.getObjectName(), attributeNames)
-                .asList()
-                .stream()
-                .map(attr -> createAttribute(attr, attributeInfos))
-                .sorted()
-                .collect(Collectors.toList());
+            .asList()
+            .stream()
+            .map(attr -> createAttribute(attr, attributeInfos))
+            .sorted()
+            .collect(Collectors.toList());
       } catch (InstanceNotFoundException | ReflectionException | IntrospectionException ex) {
         LOGGER.error("Could not get attributes of MBean " + selected.getObjectName(), ex);
       }
@@ -101,11 +101,11 @@ public class MBeansBean {
 
   private MAttribute createAttribute(Attribute attribute, MBeanAttributeInfo[] infos) {
     MBeanAttributeInfo info = Arrays
-            .stream(infos)
-            .filter(inf -> Objects.equals(inf.getName(), attribute.getName()))
-            .findAny()
-            .orElseThrow(() -> new IllegalArgumentException(
-                    "Attribute info for attribute " + attribute.getName() + " not found"));
+        .stream(infos)
+        .filter(inf -> Objects.equals(inf.getName(), attribute.getName()))
+        .findAny()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Attribute info for attribute " + attribute.getName() + " not found"));
     return new MAttribute(attribute, info);
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MName.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MName.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.MalformedObjectNameException;
@@ -24,7 +25,7 @@ public class MName {
     try {
       return new MName(ObjectName.getInstance(nameStr));
     } catch (MalformedObjectNameException ex) {
-      throw new RuntimeException("Cannot parse MBean name '"+nameStr+"'", ex);
+      throw new RuntimeException("Cannot parse MBean name '" + nameStr + "'", ex);
     }
   }
 
@@ -41,8 +42,8 @@ public class MName {
   }
 
   private void ensureTypeIsFirst() {
-    Property type = properties.stream().filter(property -> property.key.equals("type")).findAny()
-            .orElse(null);
+    Property type = properties.stream().filter(property -> "type".equals(property.key)).findAny()
+        .orElse(null);
     if (type != null) {
       properties.remove(type);
       properties.add(0, type);
@@ -86,8 +87,8 @@ public class MName {
       return !child.domain.isEmpty();
     }
     return domain.equals(child.domain) &&
-            properties.size() < child.properties.size() &&
-            samePrefixProperties(child.properties);
+        properties.size() < child.properties.size() &&
+        samePrefixProperties(child.properties);
   }
 
   private MName getDirectChild(MName other) {
@@ -103,11 +104,9 @@ public class MName {
     builder.append(':');
     if (!properties.isEmpty()) {
       String props = properties
-              .stream()
-              .map(prop -> {
-                return prop.key + "=" + prop.value;
-              })
-              .collect(Collectors.joining(","));
+          .stream()
+          .map(prop -> (prop.key + "=" + prop.value))
+          .collect(Collectors.joining(","));
       builder.append(props);
     } else {
       builder.append("*");
@@ -122,12 +121,10 @@ public class MName {
     if (!properties.isEmpty()) {
       builder.append(':');
       builder.append(
-              properties
-                      .stream()
-                      .map(prop -> {
-                        return prop.key + "=" + prop.value;
-                      })
-                      .collect(Collectors.joining(",")));
+          properties
+              .stream()
+              .map(prop -> (prop.key + "=" + prop.value))
+              .collect(Collectors.joining(",")));
     }
     return builder.toString();
   }
@@ -144,10 +141,10 @@ public class MName {
 
   public Set<MName> getDirectChildren(Set<MName> allNames) {
     return allNames
-            .stream()
-            .filter(this::isChild)
-            .map(this::getDirectChild)
-            .collect(Collectors.toSet());
+        .stream()
+        .filter(this::isChild)
+        .map(this::getDirectChild)
+        .collect(Collectors.toSet());
   }
 
   @Override
@@ -186,7 +183,7 @@ public class MName {
       }
       Property other = (Property) obj;
       return Objects.equals(key, other.key) &&
-              Objects.equals(value, other.value);
+          Objects.equals(value, other.value);
     }
 
     @Override
@@ -201,7 +198,7 @@ public class MName {
 
     private static final class PositionComparator implements Comparator<Property> {
 
-      private String propertyList;
+      private final String propertyList;
 
       public PositionComparator(String propertyList) {
         this.propertyList = propertyList;
@@ -213,11 +210,11 @@ public class MName {
       }
 
       private int toPosition(Property property) {
-        int pos = propertyList.indexOf(property.key +"=" + property.value);
+        int pos = propertyList.indexOf(property.key + "=" + property.value);
         if (pos >= 0) {
           return pos;
         }
-        throw new IllegalArgumentException("Cannot found property " + property +" in property list '"+propertyList +"'");
+        throw new IllegalArgumentException("Cannot found property " + property + " in property list '" + propertyList + "'");
       }
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MTrace.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/MTrace.java
@@ -19,7 +19,7 @@ public class MTrace extends Series {
 
   public MTrace(MName name, MAttribute attribute, String compositeName) {
     super(build(createValueProvider(name, attribute, compositeName),
-            createLabel(name, attribute, compositeName)));
+        createLabel(name, attribute, compositeName)));
     this.name = name;
     this.attribute = attribute;
     this.compositeName = compositeName;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/AbstractDatabase.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/AbstractDatabase.java
@@ -20,7 +20,7 @@ abstract class AbstractDatabase {
   private final String application;
 
   AbstractDatabase(ObjectName extDatabase, String queries, Monitor connectionsMonitor, Monitor queriesMonitor,
-          Monitor executionTimeMonitor) {
+      Monitor executionTimeMonitor) {
     this.connectionsMonitor = connectionsMonitor;
     this.queriesMonitor = queriesMonitor;
     this.executionTimeMonitor = executionTimeMonitor;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/ClusterMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/ClusterMonitorBean.java
@@ -33,17 +33,17 @@ public class ClusterMonitorBean {
   public ClusterMonitorBean() {
     sendMessagesMonitor = Monitor.build().name("Sent Messages").icon("dns").toMonitor();
     sendProcessingTimeMonitor = Monitor.build().name("Send Processing Time").icon("timer").yAxisLabel("Time")
-            .toMonitor();
+        .toMonitor();
     receiveMessagesMonitor = Monitor.build().name("Received Messages").icon("dns").toMonitor();
     receiveProcessingTimeMonitor = Monitor.build().name("Receive Processing Time").icon("timer")
-            .yAxisLabel("Time").toMonitor();
+        .yAxisLabel("Time").toMonitor();
 
     if (ManagementFactory.getPlatformMBeanServer().queryNames(CLUSTER_CHANNEL, null).isEmpty()) {
       return;
     }
     var sendMessages = new ExecutionCounter(CLUSTER_CHANNEL.getCanonicalName(), "sendMessages", "sendErrors");
     var receivedMessages = new ExecutionCounter(CLUSTER_CHANNEL.getCanonicalName(), "receiveMessages",
-            "receiveErrors");
+        "receiveErrors");
 
     sendMessagesMonitor.addInfoValue(format("%5d", sendMessages.deltaExecutions()));
     sendMessagesMonitor.addInfoValue(format("Total %5d", sendMessages.executions()));
@@ -76,11 +76,11 @@ public class ClusterMonitorBean {
     receiveProcessingTimeMonitor.addInfoValue(format("Total %t", receivedMessages.executionTime()));
 
     receiveProcessingTimeMonitor
-            .addSeries(Series.build(receivedMessages.deltaMinExecutionTime(), "Min").toSeries());
+        .addSeries(Series.build(receivedMessages.deltaMinExecutionTime(), "Min").toSeries());
     receiveProcessingTimeMonitor
-            .addSeries(Series.build(receivedMessages.deltaAvgExecutionTime(), "Avg").toSeries());
+        .addSeries(Series.build(receivedMessages.deltaAvgExecutionTime(), "Avg").toSeries());
     receiveProcessingTimeMonitor
-            .addSeries(Series.build(receivedMessages.deltaMaxExecutionTime(), "Max").toSeries());
+        .addSeries(Series.build(receivedMessages.deltaMaxExecutionTime(), "Max").toSeries());
   }
 
   public Monitor getSendMessagesMonitor() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/Database.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/Database.java
@@ -9,12 +9,12 @@ final class Database extends AbstractDatabase {
 
   Database(ObjectName extDatabase) {
     super(
-            extDatabase,
-            "Queries",
-            Monitor.build().title("Database Connections").name("Connections").icon("insert_link").toMonitor(),
-            Monitor.build().title("Database Queries").name("Queries").icon("dns").toMonitor(),
-            Monitor.build().title("Database Query Execution Time").name("Execution Time").icon("timer")
-                    .yAxisLabel("Execution Time [us]").toMonitor());
+        extDatabase,
+        "Queries",
+        Monitor.build().title("Database Connections").name("Connections").icon("insert_link").toMonitor(),
+        Monitor.build().title("Database Queries").name("Queries").icon("dns").toMonitor(),
+        Monitor.build().title("Database Query Execution Time").name("Execution Time").icon("timer")
+            .yAxisLabel("Execution Time [us]").toMonitor());
   }
 
   private Database() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/DatabaseMonitor.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/DatabaseMonitor.java
@@ -14,8 +14,8 @@ import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
 @ViewScoped
 public class DatabaseMonitor {
   private AbstractDatabase database;
-  private String applicationName;
-  private String databaseName;
+  private final String applicationName;
+  private final String databaseName;
 
   public DatabaseMonitor() {
     this("", "");
@@ -27,9 +27,9 @@ public class DatabaseMonitor {
     try {
       var databases = searchJmx(appName, databaseName);
       database = databases.stream()
-              .map(client -> new Database(client))
-              .filter(this::isDatabase)
-              .findFirst().orElse(Database.NO_DATA);
+          .map(Database::new)
+          .filter(this::isDatabase)
+          .findFirst().orElse(Database.NO_DATA);
     } catch (MalformedObjectNameException ex) {
       database = Database.NO_DATA;
     }
@@ -53,13 +53,13 @@ public class DatabaseMonitor {
 
   private boolean isDatabase(AbstractDatabase db) {
     return db.application().equals(applicationName) &&
-            db.name().equals(databaseName);
+        db.name().equals(databaseName);
   }
 
   private static Set<ObjectName> searchJmx(String appName, String databaseName)
-          throws MalformedObjectNameException {
+      throws MalformedObjectNameException {
     return ManagementFactory.getPlatformMBeanServer().queryNames(
-            new ObjectName("ivy Engine:type=External Database,application=" + appName + ",name=" + databaseName),
-            null);
+        new ObjectName("ivy Engine:type=External Database,application=" + appName + ",name=" + databaseName),
+        null);
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/ExecutionCounter.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/ExecutionCounter.java
@@ -34,12 +34,12 @@ class ExecutionCounter {
     deltaErrors = cache(1, delta(errors));
 
     executionTime = attribute(objectName, executionsName + "TotalExecutionTimeInMicroSeconds",
-            Unit.MICRO_SECONDS);
+        Unit.MICRO_SECONDS);
     deltaMinExecutionTime = cache(1, attribute(objectName,
-            executionsName + "MinExecutionTimeDeltaInMicroSeconds", Unit.MICRO_SECONDS));
+        executionsName + "MinExecutionTimeDeltaInMicroSeconds", Unit.MICRO_SECONDS));
     deltaAvgExecutionTime = cache(1, derivation(executionTime, executions));
     deltaMaxExecutionTime = cache(1, attribute(objectName,
-            executionsName + "MaxExecutionTimeDeltaInMicroSeconds", Unit.MICRO_SECONDS));
+        executionsName + "MaxExecutionTimeDeltaInMicroSeconds", Unit.MICRO_SECONDS));
   }
 
   ValueProvider executions() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/MailClientMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/MailClientMonitorBean.java
@@ -17,7 +17,7 @@ public class MailClientMonitorBean {
 
   private final Monitor sentMonitor = Monitor.build().name("Mails Sent").icon("email").toMonitor();
   private final Monitor executionTimeMonitor = Monitor.build().name("Execution Time")
-          .title("Mail Sending Execution Time").icon("timer").yAxisLabel("Execution Time").toMonitor();
+      .title("Mail Sending Execution Time").icon("timer").yAxisLabel("Execution Time").toMonitor();
 
   public MailClientMonitorBean() {
     setupSentMonitor();
@@ -26,18 +26,18 @@ public class MailClientMonitorBean {
 
   private void setupSentMonitor() {
     sentMonitor.addInfoValue(format("Count %5d/%5d Errors %5d/%5d",
-            SENT_MAILS.deltaExecutions(), SENT_MAILS.executions(),
-            SENT_MAILS.deltaErrors(), SENT_MAILS.errors()));
+        SENT_MAILS.deltaExecutions(), SENT_MAILS.executions(),
+        SENT_MAILS.deltaErrors(), SENT_MAILS.errors()));
     sentMonitor.addSeries(Series.build(SENT_MAILS.deltaExecutions(), "Mails").toSeries());
     sentMonitor.addSeries(Series.build(SENT_MAILS.deltaErrors(), "Errors").toSeries());
   }
 
   private void setupExecutionTimeMonitor() {
     executionTimeMonitor.addInfoValue(format("Min %t Avg %t Max %t Total %t",
-            SENT_MAILS.deltaMinExecutionTime(),
-            SENT_MAILS.deltaAvgExecutionTime(),
-            SENT_MAILS.deltaMaxExecutionTime(),
-            SENT_MAILS.executionTime()));
+        SENT_MAILS.deltaMinExecutionTime(),
+        SENT_MAILS.deltaAvgExecutionTime(),
+        SENT_MAILS.deltaMaxExecutionTime(),
+        SENT_MAILS.executionTime()));
     executionTimeMonitor.addSeries(Series.build(SENT_MAILS.deltaMinExecutionTime(), "Min").toSeries());
     executionTimeMonitor.addSeries(Series.build(SENT_MAILS.deltaAvgExecutionTime(), "Avg").toSeries());
     executionTimeMonitor.addSeries(Series.build(SENT_MAILS.deltaMaxExecutionTime(), "Max").toSeries());

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/NotificationChannel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/NotificationChannel.java
@@ -1,12 +1,15 @@
 package ch.ivyteam.enginecockpit.monitor.mbeans.ivy;
 
 import static ch.ivyteam.enginecockpit.monitor.value.ValueProvider.format;
+
 import java.lang.management.ManagementFactory;
 import java.util.stream.Stream;
+
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+
 import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
 import ch.ivyteam.enginecockpit.monitor.monitor.Series;
 
@@ -14,22 +17,22 @@ final class NotificationChannel {
   public static final NotificationChannel NO_DATA = new NotificationChannel(null, null);
 
   private final Monitor deliveriesMonitor = Monitor.build()
-          .name("Deliveries")
-          .title("Channel Deliveries")
-          .icon("insert_link")
-          .toMonitor();
+      .name("Deliveries")
+      .title("Channel Deliveries")
+      .icon("insert_link")
+      .toMonitor();
 
   private final Monitor pushesTimeMonitor = Monitor.build()
-          .name("Pushes")
-          .title("Channel Pushes Time")
-          .icon("timer")
-          .toMonitor();
+      .name("Pushes")
+      .title("Channel Pushes Time")
+      .icon("timer")
+      .toMonitor();
 
   private final Monitor locksMonitor = Monitor.build()
-          .name("Locks")
-          .title("Channel Locks")
-          .icon("timer")
-          .toMonitor();
+      .name("Locks")
+      .title("Channel Locks")
+      .icon("timer")
+      .toMonitor();
 
   private String label;
 
@@ -74,7 +77,7 @@ final class NotificationChannel {
     try {
       return Stream
           .of(ManagementFactory.getPlatformMBeanServer().getMBeanInfo(channel).getAttributes())
-          .anyMatch(attr -> attr.getName().equals("errors"));
+          .anyMatch(attr -> "errors".equals(attr.getName()));
     } catch (IntrospectionException | InstanceNotFoundException | ReflectionException ex) {
       return false;
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/NotificationChannelMonitor.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/NotificationChannelMonitor.java
@@ -2,8 +2,10 @@ package ch.ivyteam.enginecockpit.monitor.mbeans.ivy;
 
 import java.lang.management.ManagementFactory;
 import java.util.Set;
+
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+
 import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
 import ch.ivyteam.ivy.security.ISecurityContext;
 
@@ -17,19 +19,19 @@ public class NotificationChannelMonitor {
       this.securityContext = securityContext;
       var channels = searchJmx(channelId);
       channel = channels.stream()
-              .map(name -> new NotificationChannel(name, channelName))
-              .findFirst()
-              .orElse(NotificationChannel.NO_DATA);
+          .map(name -> new NotificationChannel(name, channelName))
+          .findFirst()
+          .orElse(NotificationChannel.NO_DATA);
     } catch (MalformedObjectNameException ex) {
       channel = NotificationChannel.NO_DATA;
     }
   }
 
   private Set<ObjectName> searchJmx(String channelId)
-          throws MalformedObjectNameException {
+      throws MalformedObjectNameException {
     return ManagementFactory.getPlatformMBeanServer().queryNames(
-            new ObjectName("ivy Engine:type=Notification Channel,securityContext="+securityContext.getName()+",id=" + channelId),
-            null);
+        new ObjectName("ivy Engine:type=Notification Channel,securityContext=" + securityContext.getName() + ",id=" + channelId),
+        null);
   }
 
   public String getChannel() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/RestClient.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/RestClient.java
@@ -16,11 +16,11 @@ class RestClient {
   public static final RestClient NO_DATA = new RestClient();
 
   private final Monitor connectionsMonitor = Monitor.build().name("Connections")
-          .title("REST Client Connections").icon("insert_link").toMonitor();
+      .title("REST Client Connections").icon("insert_link").toMonitor();
   private final Monitor callsMonitor = Monitor.build().name("Calls").title("REST Client Calls")
-          .icon("settings_ethernet").toMonitor();
+      .icon("settings_ethernet").toMonitor();
   private final Monitor executionTimeMonitor = Monitor.build().name("Execution Time")
-          .title("REST Client Execution Time").icon("timer").yAxisLabel("Execution Time").toMonitor();
+      .title("REST Client Execution Time").icon("timer").yAxisLabel("Execution Time").toMonitor();
 
   private final String label;
   private final String id;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/RestClientMonitor.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/RestClientMonitor.java
@@ -10,8 +10,8 @@ import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
 
 public class RestClientMonitor {
   private RestClient restClient;
-  private String applicationName;
-  private String restClientUUID;
+  private final String applicationName;
+  private final String restClientUUID;
 
   public RestClientMonitor() {
     this("", "");
@@ -23,9 +23,9 @@ public class RestClientMonitor {
     try {
       var clients = searchJmx(appName, restClientUUID);
       restClient = clients.stream()
-              .map(client -> new RestClient(client))
-              .filter(this::isRestClient)
-              .findFirst().orElse(RestClient.NO_DATA);
+          .map(RestClient::new)
+          .filter(this::isRestClient)
+          .findFirst().orElse(RestClient.NO_DATA);
     } catch (MalformedObjectNameException ex) {
       restClient = RestClient.NO_DATA;
     }
@@ -49,14 +49,14 @@ public class RestClientMonitor {
 
   private boolean isRestClient(RestClient client) {
     return client.application().equals(applicationName) &&
-            client.id().equals(restClientUUID);
+        client.id().equals(restClientUUID);
   }
 
   private static Set<ObjectName> searchJmx(String appName, String restClientName)
-          throws MalformedObjectNameException {
+      throws MalformedObjectNameException {
     return ManagementFactory.getPlatformMBeanServer().queryNames(
-            new ObjectName("ivy Engine:type=External REST Web Service,application=" + appName + ",name=\"*(" + restClientName + ")\""),
-            null);
+        new ObjectName("ivy Engine:type=External REST Web Service,application=" + appName + ",name=\"*(" + restClientName + ")\""),
+        null);
   }
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/SystemDatabase.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/SystemDatabase.java
@@ -18,10 +18,10 @@ public final class SystemDatabase extends AbstractDatabase {
 
   SystemDatabase() {
     super(
-            DATABASE_PERSISTENCY_SERVICE,
-            "Transactions",
-            Monitor.build().name("Connections").icon("insert_link").toMonitor(),
-            Monitor.build().name("Transactions").icon("dns").toMonitor(),
-            Monitor.build().name("Processing Time").icon("timer").yAxisLabel("Time").toMonitor());
+        DATABASE_PERSISTENCY_SERVICE,
+        "Transactions",
+        Monitor.build().name("Connections").icon("insert_link").toMonitor(),
+        Monitor.build().name("Transactions").icon("dns").toMonitor(),
+        Monitor.build().name("Processing Time").icon("timer").yAxisLabel("Time").toMonitor());
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/WebService.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/WebService.java
@@ -13,9 +13,9 @@ class WebService {
   public static final WebService NO_DATA = new WebService();
 
   private final Monitor callsMonitor = Monitor.build().name("Calls").title("Web Service Calls")
-          .icon("language").toMonitor();
+      .icon("language").toMonitor();
   private final Monitor executionTimeMonitor = Monitor.build().name("Execution Time")
-          .title("Web Service Execution Time").icon("timer").yAxisLabel("Execution Time").toMonitor();
+      .title("Web Service Execution Time").icon("timer").yAxisLabel("Execution Time").toMonitor();
 
   private final String label;
   private final String id;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/WebServiceMonitor.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/WebServiceMonitor.java
@@ -10,8 +10,8 @@ import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
 
 public class WebServiceMonitor {
   private WebService webService;
-  private String applicationName;
-  private String webServiceId;
+  private final String applicationName;
+  private final String webServiceId;
 
   public WebServiceMonitor() {
     this("", "");
@@ -23,9 +23,9 @@ public class WebServiceMonitor {
     try {
       var services = searchJmx(appName, webServiceId);
       webService = services.stream()
-              .map(service -> new WebService(service))
-              .filter(this::isWebService)
-              .findFirst().orElse(WebService.NO_DATA);
+          .map(WebService::new)
+          .filter(this::isWebService)
+          .findFirst().orElse(WebService.NO_DATA);
     } catch (MalformedObjectNameException ex) {
       webService = WebService.NO_DATA;
     }
@@ -45,13 +45,13 @@ public class WebServiceMonitor {
 
   private boolean isWebService(WebService service) {
     return service.application().equals(applicationName) &&
-            service.id().equals(webServiceId);
+        service.id().equals(webServiceId);
   }
 
   private static Set<ObjectName> searchJmx(String appName, String webServiceId)
-          throws MalformedObjectNameException {
+      throws MalformedObjectNameException {
     return ManagementFactory.getPlatformMBeanServer().queryNames(
-            new ObjectName("ivy Engine:type=External Web Service,application=" + appName + ",name=\"*(" + webServiceId + ")\""),
-            null);
+        new ObjectName("ivy Engine:type=External Web Service,application=" + appName + ",name=\"*(" + webServiceId + ")\""),
+        null);
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/JvmMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/JvmMonitorBean.java
@@ -18,7 +18,7 @@ import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
 @ViewScoped
 public class JvmMonitorBean {
   private final Monitor cpuMonitor = Monitor.build().name("CPU Load").icon("computer-chip").yAxisLabel("Load")
-          .toMonitor();
+      .toMonitor();
   private final Monitor classesMonitor = Monitor.build().name("Classes").icon("coffee-cup").toMonitor();
   private final Monitor threadsMonitor = Monitor.build().name("Threads").icon("analytics-graph").toMonitor();
 
@@ -66,12 +66,12 @@ public class JvmMonitorBean {
 
   private ValueProvider processCpuLoad() {
     return percentage(
-            attribute(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, "ProcessCpuLoad", Unit.PERCENTAGE));
+        attribute(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, "ProcessCpuLoad", Unit.PERCENTAGE));
   }
 
   private ValueProvider systemCpuLoad() {
     return percentage(
-            attribute(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, "SystemCpuLoad", Unit.PERCENTAGE));
+        attribute(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME, "SystemCpuLoad", Unit.PERCENTAGE));
   }
 
   private ValueProvider classesLoaded() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/MemoryMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/MemoryMonitorBean.java
@@ -21,11 +21,11 @@ import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
 @ViewScoped
 public class MemoryMonitorBean {
   private final Monitor heapMemoryMonitor = Monitor.build().name("Heap Memory")
-          .icon("analytics-board-graph-line").yAxisLabel("Memory").toMonitor();
+      .icon("analytics-board-graph-line").yAxisLabel("Memory").toMonitor();
   private final Monitor nonHeapMemoryMonitor = Monitor.build().name("Non Heap Memory")
-          .icon("analytics-board-graph-line").yAxisLabel("Memory").toMonitor();
+      .icon("analytics-board-graph-line").yAxisLabel("Memory").toMonitor();
   private final Monitor gcMonitor = Monitor.build().name("Garbage Collection").icon("recycling-trash-bin-2")
-          .yAxisLabel("Time").toMonitor();
+      .yAxisLabel("Time").toMonitor();
 
   public MemoryMonitorBean() {
     setupHeapMemoryMonitor();
@@ -52,11 +52,11 @@ public class MemoryMonitorBean {
   private void setupGcMonitors() {
     try {
       var garbageCollectors = ManagementFactory.getPlatformMBeanServer()
-              .queryNames(new ObjectName("java.lang:type=GarbageCollector,name=*"), null);
+          .queryNames(new ObjectName("java.lang:type=GarbageCollector,name=*"), null);
       for (ObjectName garbageCollector : garbageCollectors) {
         String label = garbageCollector.getKeyProperty("name");
         gcMonitor.addInfoValue(format(label + " %t/%t Count %5d", deltaGcCollectionTime(garbageCollector),
-                gcCollectionTime(garbageCollector), gcCollections(garbageCollector)));
+            gcCollectionTime(garbageCollector), gcCollections(garbageCollector)));
         gcMonitor.addSeries(Series.build(deltaGcCollectionTime(garbageCollector), label).toSeries());
       }
     } catch (MalformedObjectNameException ex) {
@@ -78,32 +78,32 @@ public class MemoryMonitorBean {
 
   private ValueProvider heapMemoryMax() {
     return composite(attribute(ManagementFactory.MEMORY_MXBEAN_NAME, "HeapMemoryUsage", Unit.ONE), "max",
-            Unit.BYTES);
+        Unit.BYTES);
   }
 
   private ValueProvider heapMemoryInit() {
     return composite(attribute(ManagementFactory.MEMORY_MXBEAN_NAME, "HeapMemoryUsage", Unit.ONE), "init",
-            Unit.BYTES);
+        Unit.BYTES);
   }
 
   private ValueProvider heapMemoryUsed() {
     return composite(attribute(ManagementFactory.MEMORY_MXBEAN_NAME, "HeapMemoryUsage", Unit.ONE), "used",
-            Unit.BYTES);
+        Unit.BYTES);
   }
 
   private ValueProvider heapMemoryCommitted() {
     return composite(attribute(ManagementFactory.MEMORY_MXBEAN_NAME, "HeapMemoryUsage", Unit.ONE),
-            "committed", Unit.BYTES);
+        "committed", Unit.BYTES);
   }
 
   private ValueProvider nonHeapMemoryCommitted() {
     return composite(attribute(ManagementFactory.MEMORY_MXBEAN_NAME, "NonHeapMemoryUsage", Unit.ONE),
-            "committed", Unit.BYTES);
+        "committed", Unit.BYTES);
   }
 
   private ValueProvider nonHeapMemoryUsed() {
     return composite(attribute(ManagementFactory.MEMORY_MXBEAN_NAME, "NonHeapMemoryUsage", Unit.ONE), "used",
-            Unit.BYTES);
+        Unit.BYTES);
   }
 
   private ValueProvider deltaGcCollectionTime(ObjectName garbabeCollector) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/RequestMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/RequestMonitorBean.java
@@ -25,23 +25,23 @@ import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
 public class RequestMonitorBean {
   private final Monitor requestsMonitor = Monitor.build().name("Requests").icon("network-signal").toMonitor();
   private final Monitor errorsMonitor = Monitor.build().name("Errors").icon("global-warming-globe-fire")
-          .toMonitor();
+      .toMonitor();
   private final Monitor bytesMonitor = Monitor.build().name("Bytes").icon("cd").yAxisLabel("Bytes")
-          .toMonitor();
+      .toMonitor();
   private final Monitor processingTimeMonitor = Monitor.build().name("Processing Time")
-          .icon("optimization-timer").yAxisLabel("Time").toMonitor();
+      .icon("optimization-timer").yAxisLabel("Time").toMonitor();
   private final Monitor connectionsMonitor = Monitor.build().name("Connections").icon("insert_link-timer")
-          .yAxisLabel("Connections").toMonitor();
+      .yAxisLabel("Connections").toMonitor();
 
   public RequestMonitorBean() {
     try {
       Set<ObjectName> requestProcessors = ManagementFactory.getPlatformMBeanServer()
-              .queryNames(new ObjectName("ivy:type=GlobalRequestProcessor,name=*"), null);
+          .queryNames(new ObjectName("ivy:type=GlobalRequestProcessor,name=*"), null);
       for (ObjectName requestProcessor : requestProcessors) {
         setupRequestProcessingMonitors(requestProcessor);
       }
       Set<ObjectName> protocolHandlers = ManagementFactory.getPlatformMBeanServer()
-              .queryNames(new ObjectName("ivy:type=ProtocolHandler,port=*"), null);
+          .queryNames(new ObjectName("ivy:type=ProtocolHandler,port=*"), null);
       for (ObjectName protocolHandler : protocolHandlers) {
         setupProtocolHandlerMonitors(protocolHandler);
       }
@@ -84,13 +84,13 @@ public class RequestMonitorBean {
 
   private void setupBytesMonitor(ObjectName requestProcessor, String label) {
     bytesMonitor.addInfoValue(
-            format(label + " Sent %5d/%5d", deltaBytesSent(requestProcessor), bytesSent(requestProcessor)));
+        format(label + " Sent %5d/%5d", deltaBytesSent(requestProcessor), bytesSent(requestProcessor)));
     bytesMonitor.addInfoValue(format(label + " Received %5d/%5d", deltaBytesReceived(requestProcessor),
-            bytesReceived(requestProcessor)));
+        bytesReceived(requestProcessor)));
 
     bytesMonitor.addSeries(Series.build(deltaBytesSent(requestProcessor), label + " Sent").toSeries());
     bytesMonitor
-            .addSeries(Series.build(deltaBytesReceived(requestProcessor), label + " Received").toSeries());
+        .addSeries(Series.build(deltaBytesReceived(requestProcessor), label + " Received").toSeries());
   }
 
   private void setupProcessTimeMonitor(ObjectName requestProcessor, String label) {
@@ -127,8 +127,8 @@ public class RequestMonitorBean {
 
   private ValueProvider deltaProcessingTime(ObjectName requestProcessor) {
     return derivation(
-            processingTime(requestProcessor),
-            attribute(requestProcessor, "requestCount", Unit.ONE));
+        processingTime(requestProcessor),
+        attribute(requestProcessor, "requestCount", Unit.ONE));
   }
 
   private ValueProvider processingTime(ObjectName requestProcessor) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/memory/histogram/ClassHisto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/memory/histogram/ClassHisto.java
@@ -3,6 +3,7 @@ package ch.ivyteam.enginecockpit.monitor.memory.histogram;
 import static java.lang.Long.parseLong;
 
 import java.util.Map;
+import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -21,8 +22,8 @@ public class ClassHisto {
 
   public ClassHisto(ClassHistogramBean classHistogram, String name, String module, long instances, long bytes) {
     this.classHistogram = classHistogram;
-    this.name=name;
-    this.module=module;
+    this.name = name;
+    this.module = module;
     this.instances = instances;
     this.maxInstances = instances;
     this.minInstances = instances;
@@ -33,7 +34,7 @@ public class ClassHisto {
     if (module.isBlank()) {
       return name;
     }
-    return name + " "+ module;
+    return name + " " + module;
   }
 
   public String getName() {
@@ -93,11 +94,11 @@ public class ClassHisto {
 
   static Map<String, ClassHisto> parse(ClassHistogramBean classHistogram, String dump) {
     return dump
-            .lines()
-            .dropWhile(line -> line.startsWith(" num") || line.startsWith("---"))
-            .takeWhile(line -> line.contains(":"))
-            .map(line -> toClassInfo(classHistogram, line))
-            .collect(Collectors.<ClassHisto, String, ClassHisto>toMap(ClassHisto::getId, info -> info, (info1, info2) -> info1.merge(info2)));
+        .lines()
+        .dropWhile(line -> line.startsWith(" num") || line.startsWith("---"))
+        .takeWhile(line -> line.contains(":"))
+        .map(line -> toClassInfo(classHistogram, line))
+        .collect(Collectors.<ClassHisto, String, ClassHisto> toMap(ClassHisto::getId, info -> info, (BinaryOperator<ClassHisto>) ClassHisto::merge));
   }
 
   private static ClassHisto toClassInfo(ClassHistogramBean classHistogram, String line) {
@@ -113,11 +114,11 @@ public class ClassHisto {
   private static String toUserFriendlyName(String name) {
     if (name.startsWith("[")) {
       if (name.startsWith("[L")) {
-        return toUserFriendlyName(name.substring(2, name.length()-1)) + "[]";
+        return toUserFriendlyName(name.substring(2, name.length() - 1)) + "[]";
       }
       return toUserFriendlyName(name.substring(1)) + "[]";
     } else if (name.length() == 1) {
-      return switch(name) {
+      return switch (name) {
         case "B" -> "byte";
         case "C" -> "char";
         case "S" -> "short";
@@ -134,8 +135,7 @@ public class ClassHisto {
 
   private static String toUserFriendlyModule(String module) {
     module = StringUtils.removeEnd(module, ")");
-    module = StringUtils.removeStart(module, "(");
-    return module;
+    return StringUtils.removeStart(module, "(");
   }
 
   private ClassHisto merge(ClassHisto other) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/memory/histogram/ClassHistogramBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/memory/histogram/ClassHistogramBean.java
@@ -33,7 +33,7 @@ import ch.ivyteam.log.Logger;
 public class ClassHistogramBean {
 
   static final ObjectName DIAGNOSTIC_COMMAND = createDiagnosticCommand();
-  static final ObjectName  HOT_SPOT_DIAGNOSTIC = createHotSpotDiagnostic();
+  static final ObjectName HOT_SPOT_DIAGNOSTIC = createHotSpotDiagnostic();
   private static final Logger LOGGER = Logger.getPackageLogger(ClassHistogramBean.class);
   private static final ErrorHandler HANDLER = new ErrorHandler("msgs", LOGGER);
   private Map<String, ClassHisto> history = new HashMap<>();
@@ -49,7 +49,7 @@ public class ClassHistogramBean {
   public void refresh() {
     try {
       var dump = (String) ManagementFactory.getPlatformMBeanServer().invoke(DIAGNOSTIC_COMMAND,
-              "gcClassHistogram", new Object[] {new String[] {}}, new String[] {"[Ljava.lang.String;"});
+          "gcClassHistogram", new Object[] {new String[] {}}, new String[] {"[Ljava.lang.String;"});
       var newClasses = ClassHisto.parse(this, dump);
       history = merge(history, newClasses);
       classes = new ArrayList<>(history.values());
@@ -73,10 +73,10 @@ public class ClassHistogramBean {
   public StreamedContent dumpMemory() throws InstanceNotFoundException, ReflectionException, MBeanException, IOException {
     var dumpDir = Files.createTempDirectory("memoryDump");
     var dumpName = Advisor.getAdvisor().getApplicationName() + " Memory Dump";
-    var dumpFile = dumpDir.resolve(dumpName+".hprof");
+    var dumpFile = dumpDir.resolve(dumpName + ".hprof");
     ManagementFactory.getPlatformMBeanServer().invoke(HOT_SPOT_DIAGNOSTIC,
-            "dumpHeap", new Object[] {dumpFile.toAbsolutePath().toString(), true}, new String[] {String.class.getName(), boolean.class.getName()});
-    var zipFile = dumpDir.resolve(dumpName+".zip");
+        "dumpHeap", new Object[] {dumpFile.toAbsolutePath().toString(), true}, new String[] {String.class.getName(), boolean.class.getName()});
+    var zipFile = dumpDir.resolve(dumpName + ".zip");
     zip(dumpFile, zipFile);
     Files.delete(dumpFile);
 
@@ -180,8 +180,8 @@ public class ClassHistogramBean {
 
   private static class TempFileInputStream extends InputStream {
 
-    private InputStream is;
-    private Path dumpFile;
+    private final InputStream is;
+    private final Path dumpFile;
     public TempFileInputStream(Path dumpFile) throws IOException {
       this.dumpFile = dumpFile;
       is = Files.newInputStream(dumpFile);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/monitor/Monitor.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/monitor/Monitor.java
@@ -46,8 +46,8 @@ public class Monitor {
 
   private final List<Series> series = new ArrayList<>();
   private final List<ValueProvider> infoValues = new ArrayList<>();
-  private final List<String> labels = new ArrayList<String>();
-  private final String[] fillColors = new String[]{"#607D8B", "#FFC107", "#FF5722"};
+  private final List<String> labels = new ArrayList<>();
+  private final String[] fillColors = {"#607D8B", "#FFC107", "#FF5722"};
 
   protected Monitor(MonitorInfo info) {
     this.info = info;
@@ -119,11 +119,11 @@ public class Monitor {
     if (!infoValues.isEmpty()) {
       builder.append(": ");
       builder.append(infoValues
-              .stream()
-              .map(ValueProvider::nextValue)
-              .map(v -> v.value())
-              .map(Object::toString)
-              .collect(Collectors.joining(", ")));
+          .stream()
+          .map(ValueProvider::nextValue)
+          .map(Value::value)
+          .map(Object::toString)
+          .collect(Collectors.joining(", ")));
     }
     return builder.toString();
   }
@@ -187,16 +187,16 @@ public class Monitor {
   }
 
   private void calcNewValues(long time) {
-    series.forEach(serie -> serie.calcNewValue());
+    series.forEach(Series::calcNewValue);
     ZonedDateTime stamp = ZonedDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneId.systemDefault());
     labels.add(stamp.format(DateTimeFormatter.ofPattern("HH:mm:ss")));
     series.forEach(serie -> cleanUpOldData(serie.getData()));
     Optional<Value> maxValue = series
-            .stream()
-            .map(Series::maxValue)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .max(Comparator.naturalOrder());
+        .stream()
+        .map(Series::maxValue)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .max(Comparator.naturalOrder());
     Unit scaleToUnit = scaleUnit(maxValue);
     setYAxisMaxValue(maxValue, scaleToUnit);
     setYAxisUnit(scaleToUnit);
@@ -261,7 +261,7 @@ public class Monitor {
   }
 
   public static final class Builder {
-    private MonitorInfo.Builder builder = MonitorInfo.build();
+    private final MonitorInfo.Builder builder = MonitorInfo.build();
 
     public Builder title(String t) {
       builder.title(t);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/monitor/Series.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/monitor/Series.java
@@ -59,7 +59,7 @@ public class Series {
   }
 
   public void scale(Unit scaleToUnit) {
-    List<Object> scaledNumbers = new ArrayList<Object>(data.size());
+    List<Object> scaledNumbers = new ArrayList<>(data.size());
     data.forEach(datapoint -> {
       scaledNumbers.add(scaleTo(datapoint, scaleToUnit));
     });

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/Max.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/Max.java
@@ -3,7 +3,7 @@ package ch.ivyteam.enginecockpit.monitor.performance;
 import static ch.ivyteam.enginecockpit.monitor.performance.ProcessElementStatistic.A_MILLION;
 
 final class Max {
-  private final double totalExecutionTime ;
+  private final double totalExecutionTime;
 
   private final long internalExecutions;
   private final double totalInternalExecutionTime;
@@ -17,9 +17,9 @@ final class Max {
   private final double avgExternalExecutionTime;
   private final double maxExternalExecutionTime;
 
-  Max (long totalExecutionTime,
-       long internalExecutions, long totalInternalExecutionTime, long minInternalExecutionTime, long avgInternalExecutionTime, long maxInternalExecutionTime,
-       long externalExecutions, long totalExternalExecutionTime, long minExternalExecutionTime, long avgExternalExecutionTime, long maxExternalExecutionTime) {
+  Max(long totalExecutionTime,
+      long internalExecutions, long totalInternalExecutionTime, long minInternalExecutionTime, long avgInternalExecutionTime, long maxInternalExecutionTime,
+      long externalExecutions, long totalExternalExecutionTime, long minExternalExecutionTime, long avgExternalExecutionTime, long maxExternalExecutionTime) {
 
     this.totalExecutionTime = totalExecutionTime / A_MILLION;
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ProcessElementStatistic.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ProcessElementStatistic.java
@@ -1,6 +1,5 @@
 package ch.ivyteam.enginecockpit.monitor.performance;
 
-
 import ch.ivyteam.enginecockpit.monitor.trace.BackgroundMeterUtil;
 import ch.ivyteam.ivy.bpm.engine.restricted.model.IProcessElement;
 import ch.ivyteam.ivy.bpm.engine.restricted.statistic.IProcessElementExecutionStatistic;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ProcessExecutionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ProcessExecutionBean.java
@@ -39,9 +39,9 @@ public final class ProcessExecutionBean {
     Stream.of(stats).forEach(builder::add);
     var max = builder.toMax();
     return Stream
-            .of(stats)
-            .map(stat -> new ProcessElementStatistic(stat, max))
-            .collect(Collectors.toList());
+        .of(stats)
+        .map(stat -> new ProcessElementStatistic(stat, max))
+        .collect(Collectors.toList());
   }
 
   public List<ProcessElementStatistic> getProcessElements() {
@@ -108,7 +108,7 @@ public final class ProcessExecutionBean {
       return "1 second";
     }
     if (seconds < 60) {
-      return seconds +" seconds";
+      return seconds + " seconds";
     }
     Instant now = Instant.now();
     var then = now.plus(Duration.ofSeconds(seconds));

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ThreadBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ThreadBean.java
@@ -66,7 +66,7 @@ public class ThreadBean {
     ThreadInfo[] infos = threadMxBean().dumpAllThreads(true, true);
     maxCpuTime = Stream.of(infos).map(this::toCpuTime).max(Long::compareTo).orElse(-1L);
     maxUserTime = Stream.of(infos).map(this::toUserTime).max(Long::compareTo).orElse(-1L);
-    threads = Stream.of(infos).map(info -> infoFor(info)).collect(Collectors.toList());
+    threads = Stream.of(infos).map(this::infoFor).collect(Collectors.toList());
     filteredThreads = threads;
   }
 
@@ -76,14 +76,14 @@ public class ThreadBean {
       return null;
     }
     return DefaultStreamedContent.builder().name("ThreadDump.txt").contentType("text/text")
-            .stream(() -> new ByteArrayInputStream(dump.getBytes(StandardCharsets.UTF_8))).build();
+        .stream(() -> new ByteArrayInputStream(dump.getBytes(StandardCharsets.UTF_8))).build();
   }
 
   private String dumpToString() {
     try {
       return (String) ManagementFactory.getPlatformMBeanServer().invoke(
-              new ObjectName("com.sun.management", "type", "DiagnosticCommand"), "threadPrint",
-              new Object[] {new String[0]}, new String[] {String[].class.getName()});
+          new ObjectName("com.sun.management", "type", "DiagnosticCommand"), "threadPrint",
+          new Object[] {new String[0]}, new String[] {String[].class.getName()});
     } catch (Exception ex) {
       var message = new FacesMessage(FacesMessage.SEVERITY_ERROR, ex.getClass().getSimpleName(), ex.getMessage());
       FacesContext.getCurrentInstance().addMessage("msgs", message);
@@ -109,16 +109,14 @@ public class ThreadBean {
       try {
         var id = Long.valueOf(filter.toString());
         return info.getId() == id;
-      }
-      catch (NumberFormatException ex) {
-      }
+      } catch (NumberFormatException ex) {}
       String name = info.getName();
       if (name != null && StringUtils.containsIgnoreCase(name, filter.toString())) {
         return true;
       }
-     }
+    }
     return false;
-   }
+  }
 
   public Info getSelected() {
     return this.selected;
@@ -157,7 +155,6 @@ public class ThreadBean {
     private final ThreadInfo info;
 
     private Info(ThreadInfo info, long cpuTime, long userTime) {
-      super();
       this.id = info.getThreadId();
       this.name = info.getThreadName();
       this.state = info.getThreadState();
@@ -193,12 +190,12 @@ public class ThreadBean {
     public String getStateTitle() {
       if (isDeadLocked()) {
         return "This thread is deadlocked! It is waiting to lock " + getLockName()
-                + " which is owned by thread " + getLockOwner() + ".";
+            + " which is owned by thread " + getLockOwner() + ".";
       }
       return switch (state) {
         case RUNNABLE -> "Thread is runnable.";
         case BLOCKED -> "Thread is blocked. It waits to lock " + getLockName() + " which is owned by thread "
-                + getLockOwner() + ".";
+            + getLockOwner() + ".";
         case WAITING -> "Thread is waiting on lock " + getLockName() + ".";
         case TIMED_WAITING -> "Thread is waiting with a timeout on lock " + getLockName() + ".";
         case NEW -> "Thread is new and not yet started";
@@ -253,7 +250,7 @@ public class ThreadBean {
     private String toMonitorString(MonitorInfo monitor) {
       var frame = monitor.getLockedStackFrame();
       return monitor.toString() + " - " + frame.getClassName() + "." + frame.getMethodName() + "("
-              + frame.getFileName() + ":" + frame.getLineNumber() + ")";
+          + frame.getFileName() + ":" + frame.getLineNumber() + ")";
     }
 
     public String getLockName() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Configuration.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Configuration.java
@@ -10,16 +10,16 @@ import org.primefaces.model.file.UploadedFile;
 import ch.ivyteam.ivy.scripting.objects.Xml;
 
 public record Configuration(String name, String label, String description, String provider, String contents) {
-  
+
   static Configuration from(CompositeData data) {
     return new Configuration(
-        (String)data.get("name"), 
-        (String)data.get("label"), 
-        (String)data.get("description"), 
-        (String)data.get("provider"),
+        (String) data.get("name"),
+        (String) data.get("label"),
+        (String) data.get("description"),
+        (String) data.get("provider"),
         null);
   }
-  
+
   static Configuration from(UploadedFile file) throws Exception {
     try (var is = file.getInputStream()) {
       var contents = IOUtils.toString(is, StandardCharsets.UTF_8);
@@ -32,11 +32,11 @@ public record Configuration(String name, String label, String description, Strin
           contents);
     }
   }
-  
+
   public String getName() {
     return name();
   }
-  
+
   public String getLabel() {
     return label();
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrBean.java
@@ -39,14 +39,13 @@ public class JfrBean {
   private static final Logger LOGGER = Logger.getPackageLogger(JfrBean.class);
   private static final ErrorHandler HANDLER = new ErrorHandler("msgs", LOGGER);
 
-
   private List<Recording> recordings;
-  private List<Configuration> configurations;
+  private final List<Configuration> configurations;
 
   private String configuration;
 
   private String name = Advisor.instance().getApplicationName();
-  private List<Option> options = Option.createAll();
+  private final List<Option> options = Option.createAll();
 
   public JfrBean() {
     refresh();
@@ -117,7 +116,7 @@ public class JfrBean {
       var id = ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "newRecording", null, null);
       configureRecording(id);
       configureOptions(id);
-      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "startRecording", new Object[]{id}, new String[]{long.class.getName()});
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "startRecording", new Object[] {id}, new String[] {long.class.getName()});
       refresh();
     } catch (InstanceNotFoundException | ReflectionException | MBeanException | OpenDataException ex) {
       HANDLER.showError("Cannot start recording '" + name + "'", ex);
@@ -125,8 +124,7 @@ public class JfrBean {
   }
 
   private void configureRecording(Object id)
-          throws ReflectionException, MBeanException, InstanceNotFoundException
-  {
+      throws ReflectionException, MBeanException, InstanceNotFoundException {
     var config = configuration();
     if (config.contents() != null) {
       ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "setConfiguration", new Object[] {id, config.contents()}, new String[] {long.class.getName(), String.class.getName()});
@@ -136,8 +134,8 @@ public class JfrBean {
   }
 
   private void configureOptions(Object id)
-          throws ReflectionException, MBeanException, InstanceNotFoundException, OpenDataException {
-    var originalOptions = (TabularData)ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "getRecordingOptions", new Object[] {id}, new String[] {long.class.getName()});
+      throws ReflectionException, MBeanException, InstanceNotFoundException, OpenDataException {
+    var originalOptions = (TabularData) ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "getRecordingOptions", new Object[] {id}, new String[] {long.class.getName()});
     var opts = new TabularDataSupport(originalOptions.getTabularType());
     var originalNameOption = originalOptions.get(new Object[] {"name"});
     var nameOption = new CompositeDataSupport(originalNameOption.getCompositeType(), Map.of("key", "name", "value", name));
@@ -157,32 +155,32 @@ public class JfrBean {
 
   public void stopRecording(Recording recording) {
     try {
-      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "stopRecording", new Object[]{recording.id()}, new String[]{long.class.getName()});
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "stopRecording", new Object[] {recording.id()}, new String[] {long.class.getName()});
       refresh();
     } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
-      HANDLER.showError("Cannot stop recording '"+recording.name()+"'", ex);
+      HANDLER.showError("Cannot stop recording '" + recording.name() + "'", ex);
     }
   }
 
   public void closeRecording(Recording recording) {
     try {
-      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "closeRecording", new Object[]{recording.id()}, new String[]{long.class.getName()});
+      ManagementFactory.getPlatformMBeanServer().invoke(FLIGHT_RECORDER, "closeRecording", new Object[] {recording.id()}, new String[] {long.class.getName()});
       refresh();
     } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
-      HANDLER.showError("Cannot close recording '"+recording.name()+"'", ex);
+      HANDLER.showError("Cannot close recording '" + recording.name() + "'", ex);
     }
   }
 
   public StreamedContent downloadRecording(Recording recording) {
     return DefaultStreamedContent.builder()
-        .name(recording.name()+".jfr")
+        .name(recording.name() + ".jfr")
         .stream(() -> new JfrStream(recording))
         .build();
   }
 
   public static List<Recording> queryRecordings() {
     try {
-      var recordings = (CompositeData[])ManagementFactory.getPlatformMBeanServer().getAttribute(FLIGHT_RECORDER, "Recordings");
+      var recordings = (CompositeData[]) ManagementFactory.getPlatformMBeanServer().getAttribute(FLIGHT_RECORDER, "Recordings");
       return Stream.of(recordings)
           .map(Recording::from)
           .collect(Collectors.toList());
@@ -194,7 +192,7 @@ public class JfrBean {
 
   private static List<Configuration> queryConfigurations() {
     try {
-      var configurations = (CompositeData[])ManagementFactory.getPlatformMBeanServer().getAttribute(FLIGHT_RECORDER, "Configurations");
+      var configurations = (CompositeData[]) ManagementFactory.getPlatformMBeanServer().getAttribute(FLIGHT_RECORDER, "Configurations");
       return new ArrayList<>(Stream.of(configurations)
           .map(Configuration::from)
           .toList());

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrStream.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/JfrStream.java
@@ -21,7 +21,7 @@ class JfrStream extends InputStream {
 
   private long open(Recording recording) {
     try {
-      return (long)ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "openStream", new Object[]{recording.id(), null}, new String[]{long.class.getName(), TabularData.class.getName()});
+      return (long) ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "openStream", new Object[] {recording.id(), null}, new String[] {long.class.getName(), TabularData.class.getName()});
     } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
       this.error = new IOException("Cannot open JFR stream for recording '" + recording.id() + "'", ex);
       return -1;
@@ -38,7 +38,7 @@ class JfrStream extends InputStream {
     }
     if (buffer == null || nextIndexToRead >= buffer.length) {
       try {
-        buffer = (byte[])ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "readStream", new Object[]{streamId}, new String[]{long.class.getName()});
+        buffer = (byte[]) ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "readStream", new Object[] {streamId}, new String[] {long.class.getName()});
       } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
         throw new IOException("Cannot read JFR stream", ex);
       }
@@ -50,16 +50,16 @@ class JfrStream extends InputStream {
     }
     return Byte.toUnsignedInt(buffer[nextIndexToRead++]);
   }
-  
+
   @Override
   public void close() throws IOException {
     if (error != null) {
       throw error;
     }
     try {
-      ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "closeStream", new Object[]{streamId}, new String[]{long.class.getName()});
+      ManagementFactory.getPlatformMBeanServer().invoke(JfrBean.FLIGHT_RECORDER, "closeStream", new Object[] {streamId}, new String[] {long.class.getName()});
     } catch (InstanceNotFoundException | ReflectionException | MBeanException ex) {
-      throw new IOException("Cannot close JFR stream", ex); 
+      throw new IOException("Cannot close JFR stream", ex);
     }
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Option.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Option.java
@@ -16,14 +16,15 @@ public final class Option {
     this.value = value;
     this.defaultValue = value;
   }
+
   public String getName() {
     return name;
   }
-  
+
   public String getLabel() {
     return label;
   }
-  
+
   public String getDescription() {
     return description;
   }
@@ -31,86 +32,85 @@ public final class Option {
   public String getValue() {
     return value;
   }
-  
+
   public void setValue(String value) {
     this.value = value;
-  }    
-  
+  }
+
   public boolean isDefaultValue() {
     return defaultValue.equals(value);
   }
-  
-  public static List<Option> createAll()
-  {
+
+  public static List<Option> createAll() {
     return List.of(
-            new Option("duration", "Duration", """
-              Sets how long the recording should be running.
-              
-              "0" if no limit should be imposed, otherwise a string representation of a positive Long 
-              followed by an empty space and one of the following units:
+        new Option("duration", "Duration", """
+          Sets how long the recording should be running.
 
-              "ns" (nanoseconds)
-              "us" (microseconds)
-              "ms" (milliseconds)
-              "s" (seconds)
-              "m" (minutes)
-              "h" (hours)
-              "d" (days)
-              
-              Examples:
-              "60 s",
-              "10 m",
-              "4 h",
-              "0"
-              """, "0"),
-            new Option("maxAge", "Max age", """
-              Specify the length of time that the data is kept in the disk repository until the oldest
-              data may be deleted. Only works if disk=true, otherwise this parameter is ignored.
-              
-              "0" if no limit is imposed, otherwise a string representation of a positive Long value 
-              followed by an empty space and one of the following units,
+          "0" if no limit should be imposed, otherwise a string representation of a positive Long
+          followed by an empty space and one of the following units:
 
-              "ns" (nanoseconds)
-              "us" (microseconds)
-              "ms" (milliseconds)
-              "s" (seconds)
-              "m" (minutes)
-              "h" (hours)
-              "d" (days)
-              
-              Examples:
-              "2 h"
-              "24 h"
-              "2 d"
-              "0"                                                                           
-              """, "0"), 
-            new Option("maxSize", "Max size", """
-              Specifies the size, measured in bytes, at which data is kept in disk repository. 
-              Only works if disk=true, otherwise this parameter is ignored.
-              
-              String representation of a Long value, must be positive
-              
-              Examples:
-              "0"
-              "100000000"                              
-              """, "0"),
-            new Option("disk", "Disk", """
-              Stores recorded data as it is recorded.
-              
-              String representation of a Boolean value, "true" or "false"
-              
-              Examples:
-              "true"
-              "false"                              
-              """, "false"),
-            new Option("dumpOnExit", "Dump on exit", """
-              Dumps recording data to disk on Java Virtual Machine (JVM) exit.
-              
-              String representation of a Boolean value, "true" or "false"
-              
-              Examples:
-              "true"
-              "false"                              
-              """, "false")); 
+          "ns" (nanoseconds)
+          "us" (microseconds)
+          "ms" (milliseconds)
+          "s" (seconds)
+          "m" (minutes)
+          "h" (hours)
+          "d" (days)
+
+          Examples:
+          "60 s",
+          "10 m",
+          "4 h",
+          "0"
+          """, "0"),
+        new Option("maxAge", "Max age", """
+          Specify the length of time that the data is kept in the disk repository until the oldest
+          data may be deleted. Only works if disk=true, otherwise this parameter is ignored.
+
+          "0" if no limit is imposed, otherwise a string representation of a positive Long value
+          followed by an empty space and one of the following units,
+
+          "ns" (nanoseconds)
+          "us" (microseconds)
+          "ms" (milliseconds)
+          "s" (seconds)
+          "m" (minutes)
+          "h" (hours)
+          "d" (days)
+
+          Examples:
+          "2 h"
+          "24 h"
+          "2 d"
+          "0"
+          """, "0"),
+        new Option("maxSize", "Max size", """
+          Specifies the size, measured in bytes, at which data is kept in disk repository.
+          Only works if disk=true, otherwise this parameter is ignored.
+
+          String representation of a Long value, must be positive
+
+          Examples:
+          "0"
+          "100000000"
+          """, "0"),
+        new Option("disk", "Disk", """
+          Stores recorded data as it is recorded.
+
+          String representation of a Boolean value, "true" or "false"
+
+          Examples:
+          "true"
+          "false"
+          """, "false"),
+        new Option("dumpOnExit", "Dump on exit", """
+          Dumps recording data to disk on Java Virtual Machine (JVM) exit.
+
+          String representation of a Boolean value, "true" or "false"
+
+          Examples:
+          "true"
+          "false"
+          """, "false"));
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Recording.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/jfr/Recording.java
@@ -16,46 +16,46 @@ public record Recording(long id, String name, String state, LocalDateTime startT
 
   static Recording from(CompositeData data) {
     return new Recording(
-        (Long)data.get("id"),
-        (String)data.get("name"),
-        (String)data.get("state"),
+        (Long) data.get("id"),
+        (String) data.get("name"),
+        (String) data.get("state"),
         toLocalDateTime(data.get("startTime")),
         toLocalDateTime(data.get("stopTime")),
-        (Long)data.get("size"),
-        (Long)data.get("duration"));
+        (Long) data.get("size"),
+        (Long) data.get("duration"));
   }
 
   private static LocalDateTime toLocalDateTime(Object msSinceEpoch) {
-    long ms = (Long)msSinceEpoch;
+    long ms = (Long) msSinceEpoch;
     if (ms == 0L) {
       return null;
     }
-    return LocalDateTime.ofInstant(Instant.ofEpochMilli((Long)msSinceEpoch), ZoneId.systemDefault());
+    return LocalDateTime.ofInstant(Instant.ofEpochMilli((Long) msSinceEpoch), ZoneId.systemDefault());
   }
-  
+
   public long getId() {
     return id();
   }
-  
+
   public String getName() {
     return name();
   }
-  
+
   public String getState() {
     return state();
   }
-  
+
   public String getSize() {
     var unit = Unit.BYTES;
     var value = size();
     var scaledValue = Unit.BYTES.convertTo(value, unit);
     while (scaledValue > 10000) {
-      unit= unit.scaleUp();
+      unit = unit.scaleUp();
       scaledValue = Unit.BYTES.convertTo(value, unit);
     }
-    return scaledValue+" "+ unit.symbol();
+    return scaledValue + " " + unit.symbol();
   }
-  
+
   public String getStartTime() {
     return format(startTime());
   }
@@ -63,14 +63,14 @@ public record Recording(long id, String name, String state, LocalDateTime startT
   public String getStopTime() {
     return format(stopTime());
   }
-  
+
   public String getDuration() {
     var unit = Unit.SECONDS;
     var value = duration();
     if (value == 0) {
       return "Unlimited";
     }
-    if (isRunning()) { 
+    if (isRunning()) {
       value = Duration.between(LocalDateTime.now(), startTime().plus(Duration.ofSeconds(value))).getSeconds();
       if (value <= 0) {
         return "Now";
@@ -78,32 +78,32 @@ public record Recording(long id, String name, String state, LocalDateTime startT
     }
     var scaledValue = Unit.SECONDS.convertTo(value, unit);
     while (scaledValue > 100) {
-      unit= unit.scaleUp();
+      unit = unit.scaleUp();
       scaledValue = Unit.SECONDS.convertTo(value, unit);
     }
-    return scaledValue+" "+ unit.symbol();
-    
+    return scaledValue + " " + unit.symbol();
+
   }
-  
+
   public boolean isCanStop() {
     return isRunning();
   }
-  
+
   public boolean isCanClose() {
     return true;
   }
 
   public boolean isCanDownload() {
-    return switch(state()) {
+    return switch (state()) {
       case "STOPPED" -> true;
       default -> false;
     };
   }
-  
+
   public boolean isRunning() {
     return "RUNNING".equals(state);
   }
-  
+
   public boolean isNotRunning() {
     return !isRunning();
   }
@@ -115,4 +115,3 @@ public record Recording(long id, String name, String state, LocalDateTime startT
     return time.format(DATE_TIME_FORMATTER);
   }
 }
-

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionBean.java
@@ -7,7 +7,7 @@ import javax.faces.bean.ViewScoped;
 @ViewScoped
 public class SessionBean {
 
-  private SessionDataModel dataModel = new SessionDataModel();
+  private final SessionDataModel dataModel = new SessionDataModel();
 
   public SessionDataModel getDataModel() {
     return dataModel;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionDataModel.java
@@ -18,28 +18,24 @@ import ch.ivyteam.ivy.security.ISessionInternal;
 
 public class SessionDataModel extends LazyDataModel<SessionDto> {
 
-  private static final List<Function<ISessionInternal, String>> GLOBAL_FILTERS =  List.of(
-          s -> s.getSessionUser() == null ? "" : s.getSessionUser().getName(),
-          ISessionInternal::creationReason,
-          ISessionInternal::getAuthenticationMode,
-          s -> Integer.toString(s.getIdentifier()),
-          s -> s.getSecurityContext().getName()
-  );
+  private static final List<Function<ISessionInternal, String>> GLOBAL_FILTERS = List.of(
+      s -> s.getSessionUser() == null ? "" : s.getSessionUser().getName(),
+      ISessionInternal::creationReason,
+      ISessionInternal::getAuthenticationMode,
+      s -> Integer.toString(s.getIdentifier()),
+      s -> s.getSecurityContext().getName());
 
-  private static final Map<String, Function<ISessionInternal, String>> SORTS_STRING =  Map.of(
-          "user", s -> s.getSessionUser() == null ? "" : s.getSessionUser().getName(),
-          "securitySystem", s -> s.getSecurityContext().getName(),
-          "cause", s -> StringUtils.defaultString(s.creationReason()),
-          "authMode", s -> StringUtils.defaultString(s.getAuthenticationMode())
-  );
-  private static final Map<String, Function<ISessionInternal, Instant>> SORTS_DATE =  Map.of(
-          "createdAt", ISessionInternal::createdAt,
-          "lastAccessedAt", ISessionInternal::lastAccessedAt
-  );
-  private static final Map<String, Function<ISessionInternal, Integer>> SORTS_NUMBER =  Map.of(
-          "httpSessionCount", s -> s.getHttpSessions().size(),
-          "id", ISessionInternal::getIdentifier
-  );
+  private static final Map<String, Function<ISessionInternal, String>> SORTS_STRING = Map.of(
+      "user", s -> s.getSessionUser() == null ? "" : s.getSessionUser().getName(),
+      "securitySystem", s -> s.getSecurityContext().getName(),
+      "cause", s -> StringUtils.defaultString(s.creationReason()),
+      "authMode", s -> StringUtils.defaultString(s.getAuthenticationMode()));
+  private static final Map<String, Function<ISessionInternal, Instant>> SORTS_DATE = Map.of(
+      "createdAt", ISessionInternal::createdAt,
+      "lastAccessedAt", ISessionInternal::lastAccessedAt);
+  private static final Map<String, Function<ISessionInternal, Integer>> SORTS_NUMBER = Map.of(
+      "httpSessionCount", s -> s.getHttpSessions().size(),
+      "id", ISessionInternal::getIdentifier);
 
   private boolean showUnauthenticatedSessions;
   private boolean showTemporarySessions;
@@ -82,8 +78,8 @@ public class SessionDataModel extends LazyDataModel<SessionDto> {
   @Override
   public int count(Map<String, FilterMeta> filterBy) {
     return (int) sessions()
-            .filter(this::filter)
-            .count();
+        .filter(this::filter)
+        .count();
   }
 
   @Override
@@ -94,10 +90,10 @@ public class SessionDataModel extends LazyDataModel<SessionDto> {
       stream = stream.sorted(comparator);
     }
     return stream
-            .skip(first)
-            .limit(pageSize)
-            .map(SessionDto::new)
-            .collect(Collectors.toList());
+        .skip(first)
+        .limit(pageSize)
+        .map(SessionDto::new)
+        .collect(Collectors.toList());
   }
 
   private Comparator<ISessionInternal> createComparator(Map<String, SortMeta> sortBy) {
@@ -143,11 +139,11 @@ public class SessionDataModel extends LazyDataModel<SessionDto> {
 
   private Stream<ISessionInternal> sessions() {
     return ISecurityContextRepository.instance().allWithSystem()
-            .stream()
-            .flatMap(s -> s.sessions().all().stream())
-            .filter(s -> !s.isSessionUserSystemUser())
-            .filter(s -> showUnauthenticatedSessions || (!showUnauthenticatedSessions && !s.isSessionUserUnknown()))
-            .filter(s -> showTemporarySessions || (!showTemporarySessions && !((ISessionInternal) s).isTemporary()))
-            .map(ISessionInternal.class::cast);
+        .stream()
+        .flatMap(s -> s.sessions().all().stream())
+        .filter(s -> !s.isSessionUserSystemUser())
+        .filter(s -> showUnauthenticatedSessions || (!showUnauthenticatedSessions && !s.isSessionUserUnknown()))
+        .filter(s -> showTemporarySessions || (!showTemporarySessions && !((ISessionInternal) s).isTemporary()))
+        .map(ISessionInternal.class::cast);
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/session/SessionDto.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+
 import ch.ivyteam.enginecockpit.security.model.SecuritySystem;
 import ch.ivyteam.enginecockpit.security.model.User;
 import ch.ivyteam.ivy.security.ISecurityContext;
@@ -38,8 +39,8 @@ public class SessionDto {
     this.link = SecuritySystem.link(session.getSecurityContext());
     this.authMode = StringUtils.trimToEmpty(session.getAuthenticationMode());
     this.httpSessions = session.getHttpSessions().stream()
-            .map(HttpSessionDto::new)
-            .collect(Collectors.toSet());
+        .map(HttpSessionDto::new)
+        .collect(Collectors.toSet());
     this.isTemporary = session.isTemporary();
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/system/overview/TrafficGraphBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/system/overview/TrafficGraphBean.java
@@ -22,7 +22,6 @@ import ch.ivyteam.ivy.trace.SystemOverview.CommunicationChannel;
 import ch.ivyteam.ivy.trace.SystemOverview.SystemLink;
 import ch.ivyteam.ivy.trace.Tracer;
 
-
 @ManagedBean
 @ViewScoped
 public class TrafficGraphBean {
@@ -42,7 +41,6 @@ public class TrafficGraphBean {
     model = new DefaultDiagramModel();
     model.setMaxConnections(-1);
     model.setContainment(false);
-
 
     var systemOverview = Tracer.instance().systemOverview();
     var inOutMax = Math.max(systemOverview.inbound().size(), systemOverview.outbound().size());
@@ -84,14 +82,14 @@ public class TrafficGraphBean {
     inbound.addEndPoint(out);
     var in = new BlankEndPoint(EndPointAnchor.LEFT);
     ivy.addEndPoint(in);
-    var strokeWidth = (int)Math.max(1, channel.statistics().requests() * 20 / requests);
+    var strokeWidth = (int) Math.max(1, channel.statistics().requests() * 20 / requests);
     var color = color(channel.statistics().average(), average);
     connect(in, out, channel, strokeWidth, color);
   }
 
   private void addOutbound(CommunicationChannel channel, Element ivy, long requests, long average) {
     var count = ivy.getEndPoints().stream().filter(ep -> ep.getAnchor() == EndPointAnchor.RIGHT).count();
-    var outbound = new Element(new System(channel.systemLink()), rightX(),  gridY(count));
+    var outbound = new Element(new System(channel.systemLink()), rightX(), gridY(count));
     setTitle(outbound, channel);
     setStyleClass(outbound, channel);
     model.addElement(outbound);
@@ -99,7 +97,7 @@ public class TrafficGraphBean {
     outbound.addEndPoint(in);
     var out = new BlankEndPoint(EndPointAnchor.RIGHT);
     ivy.addEndPoint(out);
-    var strokeWidth = (int)Math.max(1, channel.statistics().requests() * 20 / requests);
+    var strokeWidth = (int) Math.max(1, channel.statistics().requests() * 20 / requests);
     var color = color(channel.statistics().average(), average);
     connect(in, out, channel, strokeWidth, color);
   }
@@ -109,7 +107,7 @@ public class TrafficGraphBean {
   }
 
   private String rightX() {
-    return (width - ELEMENT_WIDTH - BORDER) +"px";
+    return (width - ELEMENT_WIDTH - BORDER) + "px";
   }
 
   private String gridY(long count) {
@@ -128,7 +126,7 @@ public class TrafficGraphBean {
   }
 
   private String middleX() {
-    return (width/2 - ELEMENT_WIDTH / 2)  + "px";
+    return (width / 2 - ELEMENT_WIDTH / 2) + "px";
   }
 
   private void setTitle(Element element, CommunicationChannel channel) {
@@ -167,20 +165,20 @@ public class TrafficGraphBean {
   private String color(long value, long max) {
     var percentage = value * 100.0f / max;
     var color = 120 - percentage * 120 / 100;
-    return "hsl("+color+", 100%, 70%)";
+    return "hsl(" + color + ", 100%, 70%)";
 
   }
 
   private void connect(EndPoint in, EndPoint out, CommunicationChannel channel, int strokeWidth, String color) {
-    var curviness = Math.max(1, 100+(width-1000)/2);
+    var curviness = Math.max(1, 100 + (width - 1000) / 2);
     var connector = new BezierConnector(curviness, -1);
-    connector.setPaintStyle("{stroke:'"+color+"', strokeWidth:"+strokeWidth+"}");
+    connector.setPaintStyle("{stroke:'" + color + "', strokeWidth:" + strokeWidth + "}");
     var connection = new Connection(out, in, connector);
 
     var avg = format(channel.statistics().average());
-    var label = new LabelOverlay(channel.statistics().requests() +" requests / " + channel.statistics().errors() +" errors / " + avg);
+    var label = new LabelOverlay(channel.statistics().requests() + " requests / " + channel.statistics().errors() + " errors / " + avg);
     connection.getOverlays().add(label);
-    var arrow = new ArrowOverlay(strokeWidth*2+20, strokeWidth+20, 1, 1);
+    var arrow = new ArrowOverlay(strokeWidth * 2 + 20, strokeWidth + 20, 1, 1);
     connection.getOverlays().add(arrow);
     model.connect(connection);
   }
@@ -189,10 +187,10 @@ public class TrafficGraphBean {
     var unit = Unit.NANO_SECONDS;
     var scaledValue = Unit.NANO_SECONDS.convertTo(value, unit);
     while (scaledValue > 10000) {
-      unit= unit.scaleUp();
+      unit = unit.scaleUp();
       scaledValue = Unit.NANO_SECONDS.convertTo(value, unit);
     }
-    return scaledValue+" "+ unit.symbol();
+    return scaledValue + " " + unit.symbol();
   }
 
   public DiagramModel getModel() {
@@ -260,7 +258,7 @@ public class TrafficGraphBean {
 
     @Override
     public String toString() {
-      return "System [name="+name+"]";
+      return "System [name=" + name + "]";
     }
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/BackgroundMeterUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/BackgroundMeterUtil.java
@@ -1,33 +1,28 @@
 package ch.ivyteam.enginecockpit.monitor.trace;
 
 public class BackgroundMeterUtil {
-  public static String background(double value, double max)
-  {
+  public static String background(double value, double max) {
     return background(percentage(value, max));
   }
 
-  public static String background(long value, long max)
-  {
+  public static String background(long value, long max) {
     return background(percentage(value, max));
   }
 
-  private static int percentage(long value, long max)
-  {
+  private static int percentage(long value, long max) {
     var percentage = value * 100.0f / max;
-    return (int)percentage;
+    return (int) percentage;
   }
 
-  private static int percentage(double value, double max)
-  {
+  private static int percentage(double value, double max) {
     var percentage = value * 100.0f / max;
-    return (int)percentage;
+    return (int) percentage;
   }
 
-  private static String background(int percentage)
-  {
+  private static String background(int percentage) {
     var maxPercentage = Math.min(percentage + 20, 100);
     var color = 120 - percentage * 120 / 100;
-    return "linear-gradient(90deg, hsl("+color+", 100%, 70%) " + percentage + "%, var(--surface-a, #FFFFFF) " + maxPercentage + "%)";
+    return "linear-gradient(90deg, hsl(" + color + ", 100%, 70%) " + percentage + "%, var(--surface-a, #FFFFFF) " + maxPercentage + "%)";
   }
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/Span.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/Span.java
@@ -84,26 +84,20 @@ public final class Span {
   }
 
   static String getStatusClass(TraceSpan span) {
-    switch(span.status()) {
-      case ERROR:
-        return "error";
-      case OK:
-        return "success";
-      case UNSET:
-      default:
-        return "";
-    }
+    return switch (span.status()) {
+      case ERROR -> "error";
+      case OK -> "success";
+      case UNSET -> "";
+      default -> "";
+    };
   }
 
   static String getStatusTooltip(TraceSpan span) {
-    switch(span.status()) {
-      case ERROR:
-        return "Error status. See attributes for error details.";
-      case OK:
-        return "OK status. There might be some result attributes available.";
-      case UNSET:
-      default:
-        return "Status not set. No result attributes available.";
-    }
+    return switch (span.status()) {
+      case ERROR -> "Error status. See attributes for error details.";
+      case OK -> "OK status. There might be some result attributes available.";
+      case UNSET -> "Status not set. No result attributes available.";
+      default -> "Status not set. No result attributes available.";
+    };
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/SpanAttribute.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/SpanAttribute.java
@@ -27,18 +27,21 @@ public final class SpanAttribute {
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj)
+    if (this == obj) {
       return true;
-    if (obj == null)
+    }
+    if (obj == null) {
       return false;
-    if (getClass() != obj.getClass())
+    }
+    if (getClass() != obj.getClass()) {
       return false;
+    }
     SpanAttribute other = (SpanAttribute) obj;
     return Objects.equals(attribute, other.attribute);
   }
 
   @Override
   public String toString() {
-    return "SpanAttribute [attribute="+attribute+"]";
+    return "SpanAttribute [attribute=" + attribute + "]";
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/SpanBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/SpanBean.java
@@ -52,8 +52,8 @@ public final class SpanBean extends TreeView<Span> {
 
   private void buildTreeNode(TraceSpan span, TreeNode<Span> parentNode, int depth) {
     var node = new DefaultTreeNode<>(
-            new Span(span, trace.get().rootSpan().times().executionTime().toNanos(), depth),
-            parentNode);
+        new Span(span, trace.get().rootSpan().times().executionTime().toNanos(), depth),
+        parentNode);
     int nextDepth = ++depth;
     span.children().forEach(child -> buildTreeNode(child, node, nextDepth));
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/TraceBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/trace/TraceBean.java
@@ -27,7 +27,7 @@ import ch.ivyteam.ivy.trace.Tracer;
 public class TraceBean {
 
   private static final double ONE_MILLION = 1_000_000d;
-  private Tracer tracer = Tracer.instance();
+  private final Tracer tracer = Tracer.instance();
   private List<Trc> traces = readData();
   private List<Trc> filteredTraces;
   private String filter;
@@ -73,7 +73,7 @@ public class TraceBean {
   }
 
   public boolean isNotStoppable() {
-    return !isRunning() || ! tracer.canBeStopped();
+    return !isRunning() || !tracer.canBeStopped();
   }
 
   private boolean isRunning() {
@@ -151,8 +151,8 @@ public class TraceBean {
 
     private String url(TraceSpan span) {
       return SpanUri.of(span.attributes())
-              .map(Trc::toRelativPath)
-              .orElse("");
+          .map(Trc::toRelativPath)
+          .orElse("");
     }
 
     private static String toRelativPath(URI uri) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/BaseUnit.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/BaseUnit.java
@@ -13,7 +13,7 @@ public class BaseUnit {
   static final BaseUnit ONE = new BaseUnit("", "", Scaling.METRIC);
   static final BaseUnit PERCENTAGE = new BaseUnit("%", "percentage", Scaling.NONE);
 
-  static final BaseUnit[] ALL = new BaseUnit[] {SECONDS, BYTES, DAY_TIME, PERCENTAGE, ONE};
+  static final BaseUnit[] ALL = {SECONDS, BYTES, DAY_TIME, PERCENTAGE, ONE};
 
   private BaseUnit(String symbol, String name, Scaling scaling) {
     this.symbol = symbol;
@@ -51,7 +51,7 @@ public class BaseUnit {
     }
     BaseUnit other = (BaseUnit) obj;
     return Objects.equals(name, other.name) && Objects.equals(symbol, other.symbol)
-            && Objects.equals(scaling, other.scaling);
+        && Objects.equals(scaling, other.scaling);
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/Scale.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/Scale.java
@@ -69,7 +69,7 @@ class Scale {
       return value * scaleDownFactor;
     }
     throw new IllegalArgumentException(
-            "The parameter toScale " + toScale + " does not belong to the current scaling " + this);
+        "The parameter toScale " + toScale + " does not belong to the current scaling " + this);
   }
 
   public double convertTo(double value, Scale toScale) {
@@ -86,7 +86,7 @@ class Scale {
       return value * scaleDownFactor;
     }
     throw new IllegalArgumentException(
-            "The parameter toScale " + toScale + " does not belong to the current scaling " + this);
+        "The parameter toScale " + toScale + " does not belong to the current scaling " + this);
   }
 
   private long getUpFactorTo(Scale toScale) {
@@ -135,10 +135,10 @@ class Scale {
     }
     Scale other = (Scale) obj;
     return Objects.equals(symbol, other.symbol) &&
-            Objects.equals(name, other.name) &&
-            downScaleFactor == other.downScaleFactor &&
-            upScaleFactor == other.upScaleFactor &&
-            useAsFullUnitSymbol == other.useAsFullUnitSymbol;
+        Objects.equals(name, other.name) &&
+        downScaleFactor == other.downScaleFactor &&
+        upScaleFactor == other.upScaleFactor &&
+        useAsFullUnitSymbol == other.useAsFullUnitSymbol;
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/Scaling.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/Scaling.java
@@ -1,7 +1,7 @@
 package ch.ivyteam.enginecockpit.monitor.unit;
 
 class Scaling {
-  private Scale normalScale;
+  private final Scale normalScale;
 
   private Scaling(Scale normalScale) {
     this.normalScale = normalScale;
@@ -12,50 +12,50 @@ class Scaling {
   }
 
   public static final Scaling NONE = Scaling
-          .startWithNormal("", "")
-          .toScaling();
+      .startWithNormal("", "")
+      .toScaling();
 
   static Scaling METRIC = Scaling
-          .startWith("a", "atto")
-          .upTo(1000, "n", "nano")
-          .upTo(1000, "f", "femto")
-          .upTo(1000, "p", "pico")
-          .upTo(1000, "n", "nano")
-          .upTo(1000, "u", "micro")
-          .upTo(1000, "m", "milli")
-          .upToNormal(1000, "", "")
-          .upTo(1000, "k", "kilo")
-          .upTo(1000, "M", "mega")
-          .upTo(1000, "G", "giga")
-          .upTo(1000, "T", "tera")
-          .upTo(1000, "P", "peta")
-          .upTo(1000, "E", "exa")
-          .toScaling();
+      .startWith("a", "atto")
+      .upTo(1000, "n", "nano")
+      .upTo(1000, "f", "femto")
+      .upTo(1000, "p", "pico")
+      .upTo(1000, "n", "nano")
+      .upTo(1000, "u", "micro")
+      .upTo(1000, "m", "milli")
+      .upToNormal(1000, "", "")
+      .upTo(1000, "k", "kilo")
+      .upTo(1000, "M", "mega")
+      .upTo(1000, "G", "giga")
+      .upTo(1000, "T", "tera")
+      .upTo(1000, "P", "peta")
+      .upTo(1000, "E", "exa")
+      .toScaling();
 
   static Scaling TIME = Scaling
-          .startWith("a", "atto")
-          .upTo(1000, "n", "nano")
-          .upTo(1000, "f", "femto")
-          .upTo(1000, "p", "pico")
-          .upTo(1000, "n", "nano")
-          .upTo(1000, "u", "micro")
-          .upTo(1000, "m", "milli")
-          .upToNormal(1000, "s", "seconds").useAsFullUnitSymbol()
-          .upTo(60, "m", "minutes").useAsFullUnitSymbol()
-          .upTo(60, "h", "hours").useAsFullUnitSymbol()
-          .upTo(24, "d", "days").useAsFullUnitSymbol()
-          .upTo(365, "y", "years").useAsFullUnitSymbol()
-          .toScaling();
+      .startWith("a", "atto")
+      .upTo(1000, "n", "nano")
+      .upTo(1000, "f", "femto")
+      .upTo(1000, "p", "pico")
+      .upTo(1000, "n", "nano")
+      .upTo(1000, "u", "micro")
+      .upTo(1000, "m", "milli")
+      .upToNormal(1000, "s", "seconds").useAsFullUnitSymbol()
+      .upTo(60, "m", "minutes").useAsFullUnitSymbol()
+      .upTo(60, "h", "hours").useAsFullUnitSymbol()
+      .upTo(24, "d", "days").useAsFullUnitSymbol()
+      .upTo(365, "y", "years").useAsFullUnitSymbol()
+      .toScaling();
 
   static Scaling MEMORY = Scaling
-          .startWithNormal("", "")
-          .upTo(1024, "Ki", "kilo")
-          .upTo(1024, "Mi", "mega")
-          .upTo(1024, "Gi", "giga")
-          .upTo(1024, "Ti", "tera")
-          .upTo(1024, "Pi", "peta")
-          .upTo(1024, "Ei", "exa")
-          .toScaling();
+      .startWithNormal("", "")
+      .upTo(1024, "Ki", "kilo")
+      .upTo(1024, "Mi", "mega")
+      .upTo(1024, "Gi", "giga")
+      .upTo(1024, "Ti", "tera")
+      .upTo(1024, "Pi", "peta")
+      .upTo(1024, "Ei", "exa")
+      .toScaling();
 
   static Scaling DAY_TIME = Scaling.startWithNormal("", "").toScaling();
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/Unit.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/unit/Unit.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 public class Unit {
-  private BaseUnit baseUnit;
-  private Scale scale;
+  private final BaseUnit baseUnit;
+  private final Scale scale;
 
   public static final Unit BYTES = new Unit(BaseUnit.BYTES);
   public static final Unit KILO_BYTES = BYTES.scaleUp();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/DifferenceValue.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/DifferenceValue.java
@@ -1,8 +1,8 @@
 package ch.ivyteam.enginecockpit.monitor.value;
 
 class DifferenceValue implements ValueProvider {
-  private ValueProvider minuend;
-  private ValueProvider subtrahend;
+  private final ValueProvider minuend;
+  private final ValueProvider subtrahend;
 
   public DifferenceValue(ValueProvider minuend, ValueProvider subtrahend) {
     this.minuend = minuend;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/FormattedValue.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/FormattedValue.java
@@ -83,13 +83,13 @@ class FormattedValue implements ValueProvider {
 
   private static final class IntegerPart implements Part {
     private final int valueIndex;
-    private LongValueFormatter longValueFormatter;
+    private final LongValueFormatter longValueFormatter;
 
     public IntegerPart(int valueIndex, String format) {
       this.valueIndex = valueIndex;
       int digits = 0;
       if (format.length() > 2) {
-        digits  = Integer.parseInt(format.substring(1, format.length() - 1));
+        digits = Integer.parseInt(format.substring(1, format.length() - 1));
       }
       longValueFormatter = new LongValueFormatter(digits);
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/LongValueFormatter.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/LongValueFormatter.java
@@ -4,7 +4,7 @@ import ch.ivyteam.enginecockpit.monitor.unit.Unit;
 
 public class LongValueFormatter {
 
-  private int digits;
+  private final int digits;
 
   public LongValueFormatter(int digits) {
     this.digits = digits;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/MAttributeReader.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/MAttributeReader.java
@@ -27,7 +27,7 @@ final class MAttributeReader implements ValueProvider {
     try {
       return new Value(server.getAttribute(mBeanName, attributeName), unit);
     } catch (InstanceNotFoundException | AttributeNotFoundException | ReflectionException
-            | MBeanException ex) {
+        | MBeanException ex) {
       throw new RuntimeException("Cannot read attribute " + attributeName + " of MBean " + mBeanName, ex);
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/MPatternAttributeReader.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/MPatternAttributeReader.java
@@ -33,7 +33,7 @@ final class MPatternAttributeReader implements ValueProvider {
       }
       return new Value(value, unit);
     } catch (InstanceNotFoundException | AttributeNotFoundException | ReflectionException
-            | MBeanException ex) {
+        | MBeanException ex) {
       throw new RuntimeException("Cannot read attribute " + attributeName + " of MBean " + mBeanName, ex);
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/Value.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/value/Value.java
@@ -34,7 +34,7 @@ public class Value implements Comparable<Value> {
 
   boolean isFloating() {
     return value instanceof Float ||
-            value instanceof Double;
+        value instanceof Double;
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/renewlicence/RenewLicenceBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/renewlicence/RenewLicenceBean.java
@@ -60,10 +60,10 @@ public class RenewLicenceBean {
       var licenceContent = signedLicence.save().toAsciiOnlyString();
       var multipart = createMultipart(licenceContent);
       return createClient().target(getUri()).request()
-              .header("X-Requested-By", "ivy")
-              .header("MIME-Version", "1.0")
-              .header("mailTo", mailAddress)
-              .put(Entity.entity(multipart, multipart.getMediaType()));
+          .header("X-Requested-By", "ivy")
+          .header("MIME-Version", "1.0")
+          .header("mailTo", mailAddress)
+          .put(Entity.entity(multipart, multipart.getMediaType()));
     } catch (Exception ex) {
       return Response.status(400).entity("There was problem with requesting response ").build();
     }
@@ -73,7 +73,7 @@ public class RenewLicenceBean {
     try (var formDataMultiPart = new FormDataMultiPart()) {
       var filePart = new FormDataBodyPart("oldLicense", licContent);
       var multipart = (FormDataMultiPart) formDataMultiPart.field("oldLicense", licContent,
-              MediaType.MULTIPART_FORM_DATA_TYPE).bodyPart(filePart);
+          MediaType.MULTIPART_FORM_DATA_TYPE).bodyPart(filePart);
       multipart.setMediaType(Boundary.addBoundary(MediaType.MULTIPART_FORM_DATA_TYPE));
       return multipart;
     }
@@ -110,6 +110,6 @@ public class RenewLicenceBean {
 
   private static String getUri() {
     return System.getProperty("licence.base.uri", "https://license-order.axonivy.io/ivy/api/LicenseOrder")
-            + "/renewLicense";
+        + "/renewLicense";
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/LanguageBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/LanguageBean.java
@@ -36,8 +36,8 @@ public class LanguageBean {
   private List<Locale> locales(ISecurityContext securityContext, Function<LanguageRepository, List<Locale>> supplier) {
     var languages = LanguageManager.instance().languages(securityContext);
     var locales = supplier.apply(languages).stream()
-            .sorted(Comparator.comparing(this::toDisplayName, String.CASE_INSENSITIVE_ORDER))
-            .collect(Collectors.toList());
+        .sorted(Comparator.comparing(this::toDisplayName, String.CASE_INSENSITIVE_ORDER))
+        .collect(Collectors.toList());
 
     var l = new ArrayList<Locale>();
     l.add(Locale.ROOT);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleBean.java
@@ -10,7 +10,7 @@ import ch.ivyteam.enginecockpit.system.ManagerBean;
 @ViewScoped
 public class RoleBean {
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
   private RoleDataModel roleDataModel;
 
   public RoleBean() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDetailBean.java
@@ -109,14 +109,14 @@ public class RoleDetailBean {
     }
     var taskQueryExecutor = IWorkflowContext.of(securityContext).getTaskQueryExecutor();
     runningTaskCount = TaskQuery.create(taskQueryExecutor).where().state().isEqual(TaskState.CREATED)
-            .or().state().isEqual(TaskState.RESUMED)
-            .or().state().isEqual(TaskState.PARKED)
-            .andOverall().activatorId().isEqual(iRole.getSecurityMemberId()).executor().count();
+        .or().state().isEqual(TaskState.RESUMED)
+        .or().state().isEqual(TaskState.PARKED)
+        .andOverall().activatorId().isEqual(iRole.getSecurityMemberId()).executor().count();
     directTaskCount = TaskQuery.create(taskQueryExecutor).where().state().isEqual(TaskState.CREATED)
-            .or().state().isEqual(TaskState.SUSPENDED)
-            .or().state().isEqual(TaskState.RESUMED)
-            .or().state().isEqual(TaskState.PARKED)
-            .andOverall().activatorId().isEqual(iRole.getSecurityMemberId()).executor().count();
+        .or().state().isEqual(TaskState.SUSPENDED)
+        .or().state().isEqual(TaskState.RESUMED)
+        .or().state().isEqual(TaskState.PARKED)
+        .andOverall().activatorId().isEqual(iRole.getSecurityMemberId()).executor().count();
     roleProperties.setMemberName(this.roleName);
     this.newRoleName = this.roleName;
     var parentRole = iRole.getParent();
@@ -174,7 +174,7 @@ public class RoleDetailBean {
     try {
       iRole.move(parentRole);
       role.setParentRoleName(newParentRoleName);
-    } catch(Exception ex) {
+    } catch (Exception ex) {
       var msg = new FacesMessage(FacesMessage.SEVERITY_ERROR, "Role Parent not saved", ex.getMessage());
       FacesContext.getCurrentInstance().addMessage("msgs", msg);
       return;
@@ -219,8 +219,8 @@ public class RoleDetailBean {
     faces.getExternalContext().getFlash().setKeepMessages(true);
     try {
       var newRole = NewRole.create(newChildRoleName)
-              .parentRole(getIRole())
-              .toNewRole();
+          .parentRole(getIRole())
+          .toNewRole();
       securityContext.roles().create(newRole);
       var msg = new FacesMessage("Role '" + newChildRoleName + "' created successfully", "");
       faces.addMessage("msgs", msg);
@@ -261,8 +261,8 @@ public class RoleDetailBean {
       return;
     }
     securityContext.users()
-            .findById(roleUser.getSecurityMemberId())
-            .addRole(getIRole());
+        .findById(roleUser.getSecurityMemberId())
+        .addRole(getIRole());
     roleUser = null;
   }
 
@@ -290,20 +290,20 @@ public class RoleDetailBean {
     var hasRole = UserQuery.create().where().hasRoleAssigned(getIRole());
     var dbQuery = "%" + query + "%";
     var searchFilter = UserQuery.create().where()
-            .name().isLikeIgnoreCase(dbQuery)
-            .or()
-            .fullName().isLikeIgnoreCase(dbQuery)
-            .or()
-            .eMailAddress().isLikeIgnoreCase(dbQuery);
+        .name().isLikeIgnoreCase(dbQuery)
+        .or()
+        .fullName().isLikeIgnoreCase(dbQuery)
+        .or()
+        .eMailAddress().isLikeIgnoreCase(dbQuery);
 
     return securityContext.users().query()
-            .where()
-            .not(hasRole)
-            .and(searchFilter)
-            .executor()
-            .resultsPaged(10)
-            .map(User::new)
-            .page(1);
+        .where()
+        .not(hasRole)
+        .and(searchFilter)
+        .executor()
+        .resultsPaged(10)
+        .map(User::new)
+        .page(1);
   }
 
   private IRole getIRole() {
@@ -316,8 +316,8 @@ public class RoleDetailBean {
 
   private void loadMembersOfRole() {
     membersOfRole = getIRole().getRoleMembers().stream()
-            .map(r -> new Role(r))
-            .collect(Collectors.toList());
+        .map(Role::new)
+        .collect(Collectors.toList());
   }
 
   public List<Role> getMembersOfRole() {
@@ -360,8 +360,8 @@ public class RoleDetailBean {
 
   public List<Role> searchMember(String query) {
     return roleDataModel.getList().stream()
-            .filter(m -> StringUtils.containsIgnoreCase(m.getName(), query) && !isRoleMemberOfRole(m.getName()))
-            .limit(10).collect(Collectors.toList());
+        .filter(m -> StringUtils.containsIgnoreCase(m.getName(), query) && !isRoleMemberOfRole(m.getName()))
+        .limit(10).collect(Collectors.toList());
   }
 
   public MemberProperty getMemberProperty() {
@@ -420,8 +420,8 @@ public class RoleDetailBean {
 
   public List<String> getRoles() {
     return securityContext.roles().all().stream()
-            .map(IRole::getName)
-            .filter(name -> !roleName.equals(name))
-            .collect(Collectors.toList());
+        .map(IRole::getName)
+        .filter(name -> !roleName.equals(name))
+        .collect(Collectors.toList());
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserBean.java
@@ -13,8 +13,8 @@ import ch.ivyteam.ivy.security.ISecurityContext;
 @ViewScoped
 public class UserBean {
 
-  private UserDataModel userDataModel;
-  private ManagerBean managerBean;
+  private final UserDataModel userDataModel;
+  private final ManagerBean managerBean;
   private NewUser newUser;
   private UserSynch userSynch;
 
@@ -50,7 +50,7 @@ public class UserBean {
 
   public static final class NewUser {
 
-    private ISecurityContext securityContext;
+    private final ISecurityContext securityContext;
     private String name;
     private String email;
     private String fullName;
@@ -94,11 +94,11 @@ public class UserBean {
 
     public String creatNewUser() {
       var newUser = ch.ivyteam.ivy.security.user.NewUser
-              .create(name)
-              .fullName(fullName)
-              .password(password)
-              .mailAddress(email)
-              .toNewUser();
+          .create(name)
+          .fullName(fullName)
+          .password(password)
+          .mailAddress(email)
+          .toNewUser();
       try {
         securityContext.users().create(newUser);
         var msg = new FacesMessage("User '" + newUser.getName() + "' created successfully", "");

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserDetailBean.java
@@ -82,17 +82,17 @@ public class UserDetailBean {
     roleDataModel = new RoleDataModel(new SecuritySystem(securityContext), false, 20);
     var caseQueryExecutor = IWorkflowContext.of(securityContext).getCaseQueryExecutor();
     startedCases = CaseQuery.create(caseQueryExecutor).where().isBusinessCase().and().creatorId()
-            .isEqual(iUser.getSecurityMemberId()).executor().count();
+        .isEqual(iUser.getSecurityMemberId()).executor().count();
     var taskQueryExecutor = IWorkflowContext.of(securityContext).getTaskQueryExecutor();
     workingOn = TaskQuery.create(taskQueryExecutor).where().state().isEqual(TaskState.CREATED)
-            .or().state().isEqual(TaskState.RESUMED)
-            .or().state().isEqual(TaskState.PARKED)
-            .andOverall().workerId().isEqual(iUser.getSecurityMemberId()).executor().count();
+        .or().state().isEqual(TaskState.RESUMED)
+        .or().state().isEqual(TaskState.PARKED)
+        .andOverall().workerId().isEqual(iUser.getSecurityMemberId()).executor().count();
     personalTasks = TaskQuery.create(taskQueryExecutor).where().state().isEqual(TaskState.CREATED)
-            .or().state().isEqual(TaskState.SUSPENDED)
-            .or().state().isEqual(TaskState.RESUMED)
-            .or().state().isEqual(TaskState.PARKED)
-            .andOverall().activatorId().isEqual(iUser.getSecurityMemberId()).executor().count();
+        .or().state().isEqual(TaskState.SUSPENDED)
+        .or().state().isEqual(TaskState.RESUMED)
+        .or().state().isEqual(TaskState.PARKED)
+        .andOverall().activatorId().isEqual(iUser.getSecurityMemberId()).executor().count();
     canWorkOn = TaskQuery.create(taskQueryExecutor).where().canWorkOn(iUser).executor().count();
 
     notificationChannelDataModel = NotificationChannelDataModel.instance(iUser, securityContext);
@@ -161,7 +161,7 @@ public class UserDetailBean {
       getIUser().addRole(securityContext.roles().find(roleName));
     } catch (Exception e) {
       FacesContext.getCurrentInstance().addMessage("roleMessage",
-              new FacesMessage("User already member of this role"));
+          new FacesMessage("User already member of this role"));
     }
   }
 
@@ -185,10 +185,10 @@ public class UserDetailBean {
     var message = "";
     if (personalTasks != 0) {
       message += "The user '" + userName + "' has " + getPersonalTasks() + " personal tasks. "
-              + "If you delete this user, no other user can work on these tasks. ";
+          + "If you delete this user, no other user can work on these tasks. ";
     }
     return message
-            + "You may want to disable this user instead of deleting it, you could lose part of the workflow history.";
+        + "You may want to disable this user instead of deleting it, you could lose part of the workflow history.";
   }
 
   public String getSecuritySystemName() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserSynch.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/UserSynch.java
@@ -6,9 +6,9 @@ import ch.ivyteam.ivy.security.ISecurityContext;
 
 public class UserSynch {
 
-  private ISecurityContext securityContext;
+  private final ISecurityContext securityContext;
   private String log;
-  private String preConfiguredUserName;
+  private final String preConfiguredUserName;
   private String userNameOnTheDialog;
 
   public UserSynch(ISecurityContext securityContext) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/directory/DirectoryBrowserBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/directory/DirectoryBrowserBean.java
@@ -28,7 +28,7 @@ public class DirectoryBrowserBean {
     this.directoryBrowser = browser;
     try {
       var directoryNodeToSelect = findDirectoryNode(browser, idToSelect);
-      this.root = new DefaultTreeNode<DirectoryNode>(null, null);
+      this.root = new DefaultTreeNode<>(null, null);
       browser.root().forEach(node -> addNewSubnode(root, node, directoryNodeToSelect));
     } catch (Exception ex) {
       errorMessage(ex);
@@ -43,7 +43,7 @@ public class DirectoryBrowserBean {
   }
 
   public String icon(DirectoryNode node) {
-    return switch(node.type()) {
+    return switch (node.type()) {
       case DEFAULT -> "folder-empty";
       case DOMAIN -> "buildings-1";
       case GROUP -> "multiple-neutral-1";
@@ -80,7 +80,7 @@ public class DirectoryBrowserBean {
   private void loadChildren(TreeNode<DirectoryNode> node, DirectoryNode initialValue) {
     try {
       directoryBrowser.children(node.getData())
-              .forEach(child -> addNewSubnode(node, child, initialValue));
+          .forEach(child -> addNewSubnode(node, child, initialValue));
     } catch (Exception ex) {
       errorMessage(ex);
     }
@@ -119,7 +119,7 @@ public class DirectoryBrowserBean {
   private void errorMessage(Exception ex) {
     LOGGER.error("Error in directory browser", ex);
     FacesContext.getCurrentInstance().addMessage("directoryBrowserMessage",
-      new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", getEndUserMessage(ex)));
+        new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", getEndUserMessage(ex)));
   }
 
   private static String getEndUserMessage(Exception ex) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/SecurityExportBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/SecurityExportBean.java
@@ -24,8 +24,7 @@ public class SecurityExportBean implements AllResourcesDownload {
   private Boolean disableGenerateButton = false;
   private String name;
 
-  public SecurityExportBean() {
-  }
+  public SecurityExportBean() {}
 
   public String getSecuritySystemName() {
     return name;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/SecurityExportJob.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/SecurityExportJob.java
@@ -11,14 +11,14 @@ import ch.ivyteam.ivy.security.ISession;
 @SuppressWarnings("restriction")
 public class SecurityExportJob implements IJob {
 
-  private SecurityExport securityExport;
+  private final SecurityExport securityExport;
 
   public SecurityExportJob(ISecurityContext securityContext, ISession session) {
     this.securityExport = new SecurityExport(securityContext, session);
   }
 
   @Override
-  public void execute(){
+  public void execute() {
     try {
       securityExport.export();
     } catch (IOException ex) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Cell.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Cell.java
@@ -22,7 +22,7 @@ public class Cell {
   }
 
   public void mergeTo(int height, int width) {
-    var range = new CellRangeAddress(row.num(), row.num()+height-1, num, num+width-1);
+    var range = new CellRangeAddress(row.num(), row.num() + height - 1, num, num + width - 1);
     row.sheet().sheet().addMergedRegion(range);
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Excel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Excel.java
@@ -13,7 +13,7 @@ import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbookType;
 
-public class Excel implements AutoCloseable{
+public class Excel implements AutoCloseable {
   private final XSSFWorkbook workbook;
   private final Map<Style, XSSFCellStyle> styles = new HashMap<>();
 
@@ -52,8 +52,7 @@ public class Excel implements AutoCloseable{
   }
 
   public Sheet getSheet(String sheetName) {
-    Sheet sheet = new Sheet(this, workbook.getSheet(sheetName));
-    return sheet;
+    return new Sheet(this, workbook.getSheet(sheetName));
   }
 
   XSSFCellStyle style(Style style) {
@@ -64,7 +63,7 @@ public class Excel implements AutoCloseable{
     var cellStyle = workbook.createCellStyle();
     var font = workbook.createFont();
     cellStyle.setFont(font);
-    switch(style) {
+    switch (style) {
       case TITLE -> {
         font.setFontHeight(16);
         cellStyle.setAlignment(HorizontalAlignment.CENTER);
@@ -74,7 +73,7 @@ public class Excel implements AutoCloseable{
       }
       case HEADER -> {
         font.setBold(true);
-        cellStyle.setRotation((short)45);
+        cellStyle.setRotation((short) 45);
       }
       case RESULT -> {
         cellStyle.setAlignment(HorizontalAlignment.LEFT);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Row.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Row.java
@@ -24,7 +24,7 @@ public class Row {
   public void createHeaderRotatedCell(int cellNum, String header, int width, int height) {
     var cell = createCell(cellNum);
     cell.style(Style.HEADER);
-    row.setHeight((short)height);
+    row.setHeight((short) height);
     cell.width(width);
     cell.value(header);
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Sheet.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Sheet.java
@@ -40,7 +40,6 @@ public class Sheet {
     }
   }
 
-
   XSSFSheet sheet() {
     return sheet;
   }
@@ -49,34 +48,34 @@ public class Sheet {
     return excel;
   }
 
-  public XSSFRow getRow(int rowNum){
-   return sheet.getRow(rowNum);
+  public XSSFRow getRow(int rowNum) {
+    return sheet.getRow(rowNum);
   }
 
-  public XSSFRow getLastRow(){
+  public XSSFRow getLastRow() {
     var lastRowNum = sheet.getLastRowNum();
-   return getRow(lastRowNum);
+    return getRow(lastRowNum);
   }
 
-  public String[][] getData(){
+  public String[][] getData() {
     var cellMax = 0;
     var rowNum = sheet.getLastRowNum();
-    for (var i=0; i<=rowNum; i++) {
+    for (var i = 0; i <= rowNum; i++) {
       var row = sheet.getRow(i);
-      if(row != null) {
-        if(row.getPhysicalNumberOfCells() > cellMax) {
+      if (row != null) {
+        if (row.getPhysicalNumberOfCells() > cellMax) {
           cellMax = row.getPhysicalNumberOfCells();
         }
       }
     }
 
     String[][] data = new String[sheet.getLastRowNum() + 1][cellMax];
-    for (var i=0; i<=sheet.getLastRowNum(); i++) {
+    for (var i = 0; i <= sheet.getLastRowNum(); i++) {
       var row = sheet.getRow(i);
-      if(row != null) {
-        for (var j=0;j<row.getLastCellNum();j++) {
+      if (row != null) {
+        for (var j = 0; j < row.getLastCellNum(); j++) {
           var cell = row.getCell(j);
-          if(cell != null) {
+          if (cell != null) {
             String cellval = cell.getStringCellValue();
             data[i][j] = cellval;
           }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Style.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/excel/Style.java
@@ -1,6 +1,5 @@
 package ch.ivyteam.enginecockpit.security.export.excel;
 
-
 public enum Style {
   TITLE,
   TITLE_NO_ALIGNMENT,

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/OverviewSheet.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/OverviewSheet.java
@@ -22,11 +22,11 @@ import ch.ivyteam.ivy.security.IUser;
 public class OverviewSheet {
 
   private final ISecurityContext securityContext;
-  private final static List<String> HEADERS = new ArrayList<String>(Arrays.asList("Security System Name", "Applications", "Date",
-          "Axon Ivy Version", "Current User", "Hostname", "Number of Users", "Number of Roles", "File number", "First and Last User"));
-  private Excel excel;
-  private List<IUser> users;
-  private ISession session;
+  private final static List<String> HEADERS = new ArrayList<>(Arrays.asList("Security System Name", "Applications", "Date",
+      "Axon Ivy Version", "Current User", "Hostname", "Number of Users", "Number of Roles", "File number", "First and Last User"));
+  private final Excel excel;
+  private final List<IUser> users;
+  private final ISession session;
 
   public OverviewSheet(Excel excel, ISecurityContext securityContext, List<IUser> users, ISession session) {
     this.excel = excel;
@@ -38,7 +38,7 @@ public class OverviewSheet {
   public void create(int userCount, int fileCount) {
     Sheet sheet = excel.createSheet("Overview");
     var fileNumber = userCount / 1000;
-    if(userCount < 1000) {
+    if (userCount < 1000) {
       fileNumber = 1;
     }
     var firstUser = users.getFirst();
@@ -47,9 +47,9 @@ public class OverviewSheet {
     var titleRow = sheet.createRow(rowNr++);
     titleRow.createTitleCell(0, "Axon Ivy Security Report ");
 
-    List<Row> rows = new ArrayList<Row>();
+    List<Row> rows = new ArrayList<>();
     rowNr++;
-    for(var header : HEADERS) {
+    for (var header : HEADERS) {
       var row = sheet.createRow(rowNr++);
       row.createHeaderCell(0, header, 33);
       rows.add(row);
@@ -96,13 +96,13 @@ public class OverviewSheet {
 
   private String getServerName() {
     var currentInstance = FacesContext.getCurrentInstance();
-    if(currentInstance != null) {
+    if (currentInstance != null) {
       return FacesContext.getCurrentInstance().getExternalContext().getRequestServerName();
     }
     return "test.axonivy.com";
   }
 
-  private void createLegendRow (Sheet sheet, int rowNr, String sheetName, String shortcut, String meaning) {
+  private void createLegendRow(Sheet sheet, int rowNr, String sheetName, String shortcut, String meaning) {
     var row = sheet.createRow(rowNr);
     row.createHeaderCell(0, sheetName, 33);
     row.createResultCellWidth(1, shortcut, 5);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/PermissionShortcut.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/PermissionShortcut.java
@@ -9,29 +9,26 @@ import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.security.ISecurityMember;
 
 public class PermissionShortcut {
-  private Map<IPermission, AccessState> accessStates = new HashMap<>();
+  private final Map<IPermission, AccessState> accessStates = new HashMap<>();
 
   public PermissionShortcut(ISecurityContext securityContext, ISecurityMember member) {
-    for(var checks : securityContext.securityDescriptor().getPermissionAccesses(member)) {
+    for (var checks : securityContext.securityDescriptor().getPermissionAccesses(member)) {
       accessStates.put(checks.getPermission(), checks.getAccessState());
     }
   }
 
   public String getPermissionShortcut(IPermission permission) {
     var accessState = accessStates.get(permission);
-    if(accessState.isGranted()) {
-      if(accessState.isExplicit()) {
+    if (accessState.isGranted()) {
+      if (accessState.isExplicit()) {
         return "G";
-      }
-      else {
+      } else {
         return "g";
       }
-    }
-    else if(accessState.isDenied()) {
-      if(accessState.isExplicit()) {
+    } else if (accessState.isDenied()) {
+      if (accessState.isExplicit()) {
         return "D";
-      }
-      else {
+      } else {
         return "d";
       }
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/RoleMembersSheet.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/RoleMembersSheet.java
@@ -9,9 +9,9 @@ import ch.ivyteam.enginecockpit.security.export.excel.Sheet;
 import ch.ivyteam.ivy.security.IRole;
 
 public class RoleMembersSheet {
-  private Iterable<IRole> roles;
-  private Excel excel;
-  private List<String> headers = new ArrayList<String>();
+  private final Iterable<IRole> roles;
+  private final Excel excel;
+  private final List<String> headers = new ArrayList<>();
   static final int ROTATED_HEADER_HEIGHT = 1500;
 
   public RoleMembersSheet(Excel excel, Iterable<IRole> roles) {
@@ -25,13 +25,13 @@ public class RoleMembersSheet {
     sheet.createHeader(0, Arrays.asList("Role name"), UsersSheet.HEADER_WITDH);
     addRoleNames();
 
-    for(var role : roles) {
+    for (var role : roles) {
       var row = sheet.createRow(rowNr++);
       var roleMembers = role.getRoleMembers();
       var parent = role.getParent();
       var cellNr = 0;
       row.createResultCell(cellNr++, role.getName());
-      for(var roleSecond : roles) {
+      for (var roleSecond : roles) {
         var index = headers.indexOf(roleSecond.getName()) + 1;
         String value = getMarker(roleMembers, parent, roleSecond);
         if (value != null) {
@@ -47,10 +47,10 @@ public class RoleMembersSheet {
 
   private String getMarker(List<IRole> roleMembers, IRole parent, IRole roleSecond) {
     String value = null;
-    if(parent != null && parent.equals(roleSecond)) {
+    if (parent != null && parent.equals(roleSecond)) {
       value = "P";
     }
-    if(roleMembers.contains(roleSecond)) {
+    if (roleMembers.contains(roleSecond)) {
       if (value != null) {
         value = value + "/M";
       } else {
@@ -61,7 +61,7 @@ public class RoleMembersSheet {
   }
 
   private void addRoleNames() {
-    for(var role : roles) {
+    for (var role : roles) {
       headers.add(role.getName());
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/RolesSheet.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/RolesSheet.java
@@ -14,9 +14,9 @@ public class RolesSheet {
   private static final List<String> HEADERS = Arrays.asList("Name", "Displayname", "Description", "Security Member Id", "External Name");
   private final Map<String, Integer> propertyColumns = new HashMap<>();
   private int propertyCellNr = 8;
-  private ArrayList<String> headers = new ArrayList<String>(HEADERS);
-  private Iterable<IRole> roles;
-  private Excel excel;
+  private final ArrayList<String> headers = new ArrayList<>(HEADERS);
+  private final Iterable<IRole> roles;
+  private final Excel excel;
 
   public RolesSheet(Excel excel, Iterable<IRole> roles) {
     this.excel = excel;
@@ -27,7 +27,7 @@ public class RolesSheet {
     int rowNr = 1;
     Sheet sheet = excel.createSheet("Roles");
 
-    for(var role : roles) {
+    for (var role : roles) {
       propertyCellNr = headers.size();
       var row = sheet.createRow(rowNr++);
       var cellNr = 0;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/SecurityMemberPermissionSheet.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/SecurityMemberPermissionSheet.java
@@ -11,44 +11,43 @@ import ch.ivyteam.ivy.security.IPermission;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.security.ISecurityMember;
 
-  public class SecurityMemberPermissionSheet {
-    private final ISecurityContext securityContext;
-    private Excel excel;
-    private Iterable<ISecurityMember> securityMembers;
-    static final int ROTATED_HEADER_HEIGHT = 3000;
-    private static final Comparator<IPermission> PERMISSION_NAME_COMPERATOR = Comparator.comparing(IPermission::getName);
+public class SecurityMemberPermissionSheet {
+  private final ISecurityContext securityContext;
+  private final Excel excel;
+  private final Iterable<ISecurityMember> securityMembers;
+  static final int ROTATED_HEADER_HEIGHT = 3000;
+  private static final Comparator<IPermission> PERMISSION_NAME_COMPERATOR = Comparator.comparing(IPermission::getName);
 
-    public SecurityMemberPermissionSheet(Excel excel, ISecurityContext securityContext, Iterable<ISecurityMember> securityMembers) {
-      this.excel = excel;
-      this.securityContext = securityContext;
-      this.securityMembers = securityMembers;
+  public SecurityMemberPermissionSheet(Excel excel, ISecurityContext securityContext, Iterable<ISecurityMember> securityMembers) {
+    this.excel = excel;
+    this.securityContext = securityContext;
+    this.securityMembers = securityMembers;
+  }
+
+  public void create(String sheetName) {
+    var rowNr = 1;
+    var headers = new ArrayList<String>();
+    Sheet sheet = excel.createSheet(sheetName + " permissions");
+    sheet.createHeader(0, Arrays.asList("Name"), UsersSheet.HEADER_WITDH);
+    var permissions = securityContext.securityDescriptor().getPermissions();
+    Collections.sort(permissions, PERMISSION_NAME_COMPERATOR);
+
+    for (var permission : permissions) {
+      headers.add(permission.getName());
     }
 
-    public void create(String sheetName) {
-      var rowNr = 1;
-      var headers = new ArrayList<String>();
-      Sheet sheet = excel.createSheet(sheetName + " permissions");
-      sheet.createHeader(0, Arrays.asList("Name"), UsersSheet.HEADER_WITDH);
-      var permissions = securityContext.securityDescriptor().getPermissions();
-      Collections.sort(permissions, PERMISSION_NAME_COMPERATOR);
+    for (var securityMember : securityMembers) {
+      PermissionShortcut shortcut = new PermissionShortcut(securityContext, securityMember);
+      var row = sheet.createRow(rowNr++);
+      var cellNr = 0;
 
-
-      for(var permission : permissions) {
-        headers.add(permission.getName());
+      row.createResultCell(cellNr++, securityMember.getName());
+      for (var permission : permissions) {
+        row.createResultCell(cellNr++, shortcut.getPermissionShortcut(permission));
       }
-
-      for (var securityMember : securityMembers) {
-        PermissionShortcut shortcut = new PermissionShortcut(securityContext, securityMember);
-        var row = sheet.createRow(rowNr++);
-        var cellNr = 0;
-
-        row.createResultCell(cellNr++, securityMember.getName());
-        for(var permission : permissions) {
-          row.createResultCell(cellNr++, shortcut.getPermissionShortcut(permission));
-        }
-      }
-
-      sheet.createHeaderRotated(0, UserRolesSheet.FIRST_CELL_NR, headers, UserRolesSheet.ROTATED_HEADER_WIDTH, ROTATED_HEADER_HEIGHT);
-      sheet.createFreezePane(1, 1);
     }
+
+    sheet.createHeaderRotated(0, UserRolesSheet.FIRST_CELL_NR, headers, UserRolesSheet.ROTATED_HEADER_WIDTH, ROTATED_HEADER_HEIGHT);
+    sheet.createFreezePane(1, 1);
+  }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/UserRolesSheet.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/UserRolesSheet.java
@@ -9,9 +9,9 @@ import ch.ivyteam.ivy.security.IRole;
 import ch.ivyteam.ivy.security.IUser;
 
 public class UserRolesSheet {
-  private Excel excel;
-  private Iterable<IUser> users;
-  private Iterable<IRole> roles;
+  private final Excel excel;
+  private final Iterable<IUser> users;
+  private final Iterable<IRole> roles;
   static final int ROTATED_HEADER_WIDTH = 3;
   static final int FIRST_CELL_NR = 1;
   static final int ROTATED_HEADER_HEIGHT = 1500;
@@ -29,17 +29,16 @@ public class UserRolesSheet {
     sheet.createHeader(0, List.of("Name"), UsersSheet.HEADER_WITDH);
     addRoleNames(headers);
 
-    for(var user : users) {
+    for (var user : users) {
       var row = sheet.createRow(rowNr++);
       var directUserRoles = user.getRoles();
       var allUserRoles = user.getAllRoles();
       var cellNr = 0;
       row.createResultCell(cellNr++, user.getName());
-      for(var role : roles) {
-        if(directUserRoles.contains(role)) {
+      for (var role : roles) {
+        if (directUserRoles.contains(role)) {
           row.createResultCell(cellNr, "X");
-        }
-        else if (allUserRoles.contains(role)) {
+        } else if (allUserRoles.contains(role)) {
           row.createResultCell(cellNr, "x");
         }
         cellNr++;
@@ -50,11 +49,9 @@ public class UserRolesSheet {
     sheet.createFreezePane(1, 1);
   }
 
-
   private void addRoleNames(List<String> headers) {
-    for(var role : roles) {
+    for (var role : roles) {
       headers.add(role.getName());
     }
   }
 }
-

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/UsersSheet.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/export/sheets/UsersSheet.java
@@ -14,16 +14,16 @@ import ch.ivyteam.ivy.security.IUser;
 public class UsersSheet {
   private static final List<String> HEADERS = Arrays.asList("Name", "Displayname", "Fullname", "Email", "SecurityId", "ExternalId", "External Name");
   static final WidthProvider HEADER_WITDH = header -> {
-    if(header.contains("Security") || header.contains("External")) {
+    if (header.contains("Security") || header.contains("External")) {
       return 45;
     }
     return 25;
   };
   private final Map<String, Integer> propertyColumns = new HashMap<>();
   private int propertyCellNr = 8;
-  private ArrayList<String> headers = new ArrayList<String>(HEADERS);
-  private Iterable<IUser> users;
-  private Excel excel;
+  private final ArrayList<String> headers = new ArrayList<>(HEADERS);
+  private final Iterable<IUser> users;
+  private final Excel excel;
 
   public UsersSheet(Excel excel, Iterable<IUser> users) {
     this.excel = excel;
@@ -33,7 +33,7 @@ public class UsersSheet {
   public void create() {
     int rowNr = 1;
     Sheet sheet = excel.createSheet("Users");
-    for(var user : users) {
+    for (var user : users) {
       propertyCellNr = headers.size();
       var row = sheet.createRow(rowNr++);
       var cellNr = 0;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/identity/IdentityProviderBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/identity/IdentityProviderBean.java
@@ -35,9 +35,9 @@ public class IdentityProviderBean {
     var configurator = identityProvider.configurator();
     var idp = ((SecurityContext) securityContext).config().identity();
     this.dynamicConfig = DynamicConfig.create()
-            .configurator(configurator)
-            .config(idp)
-            .toDynamicConfig();
+        .configurator(configurator)
+        .config(idp)
+        .toDynamicConfig();
     this.browserBean = new DirectoryBrowserBean();
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/MemberProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/MemberProperty.java
@@ -16,12 +16,12 @@ public class MemberProperty {
   private List<SecurityMemberProperty> filteredProperties;
   private SecurityMemberProperty property;
   private String filter;
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public MemberProperty() {
     var context = FacesContext.getCurrentInstance();
     managerBean = context.getApplication().evaluateExpressionGet(context, "#{managerBean}",
-            ManagerBean.class);
+        ManagerBean.class);
     property = new SecurityMemberProperty();
   }
 
@@ -66,12 +66,12 @@ public class MemberProperty {
 
   public void savePropertyMessage() {
     FacesContext.getCurrentInstance().addMessage("propertiesMessage",
-            new FacesMessage("Successfully updated property", ""));
+        new FacesMessage("Successfully updated property", ""));
   }
 
   public void removePropertyMessage() {
     FacesContext.getCurrentInstance().addMessage("propertiesMessage",
-            new FacesMessage("Successfully removed property", ""));
+        new FacesMessage("Successfully removed property", ""));
   }
 
   public class RoleProperty extends MemberProperty {
@@ -86,8 +86,8 @@ public class MemberProperty {
 
     private void reloadProperties() {
       super.properties = role.getAllPropertyNames().stream()
-              .map(key -> new SecurityMemberProperty(key, role.getProperty(key), false))
-              .collect(Collectors.toList());
+          .map(key -> new SecurityMemberProperty(key, role.getProperty(key), false))
+          .collect(Collectors.toList());
     }
 
     public void saveProperty() {
@@ -115,15 +115,15 @@ public class MemberProperty {
 
     private void reloadProperties() {
       super.properties = user.getAllPropertyNames().stream()
-              .map(key -> new SecurityMemberProperty(key, user.getProperty(key), user.isPropertyBacked(key)))
-              .collect(Collectors.toList());
+          .map(key -> new SecurityMemberProperty(key, user.getProperty(key), user.isPropertyBacked(key)))
+          .collect(Collectors.toList());
     }
 
     public void saveProperty() {
       if (user.isPropertyBacked(super.property.getKey())) {
         FacesContext.getCurrentInstance().addMessage("propertiesMessage",
-                new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "The property '"
-                        + super.property.getKey() + "' has already been imported from your Security System"));
+            new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "The property '"
+                + super.property.getKey() + "' has already been imported from your Security System"));
         return;
       }
       user.setProperty(super.property.getKey(), super.property.getValue());

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDataModel.java
@@ -37,7 +37,7 @@ public class NotificationChannelDataModel {
 
   private void resetChannel(NotificationChannelDto channel) {
     channel.getSubscriptions().forEach(
-            (event, subscription) -> subscription.setState(NotificationChannelSubscriptionDto.State.USE_DEFAULT));
+        (event, subscription) -> subscription.setState(NotificationChannelSubscriptionDto.State.USE_DEFAULT));
     saveChannel(channel);
   }
 
@@ -73,7 +73,7 @@ public class NotificationChannelDataModel {
 
   public static final class NotificationEventDto {
 
-    private Event event;
+    private final Event event;
 
     private NotificationEventDto(Event event) {
       this.event = event;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDto.java
@@ -17,27 +17,27 @@ public class NotificationChannelDto {
   private final Map<Event, NotificationChannelSubscriptionDto> subscriptions;
 
   private NotificationChannelDto(NotificationChannel channel,
-          Map<Event, NotificationChannelSubscriptionDto> subscriptions) {
+      Map<Event, NotificationChannelSubscriptionDto> subscriptions) {
     this.channel = channel;
     this.subscriptions = subscriptions;
   }
 
   public static List<NotificationChannelDto> all(ISecurityMember subscriber, ISecurityContext securityContext) {
     var channels = NotificationChannel.all(securityContext).stream()
-            .filter(channel -> channel.config().enabled())
-            .map(channel -> toChannel(subscriber, channel))
-            .toList();
+        .filter(channel -> channel.config().enabled())
+        .map(channel -> toChannel(subscriber, channel))
+        .toList();
     channels.forEach(channel -> Event.all().forEach(event -> channel.setSubscriptionIconAndTitle(NotificationEventDto.of(event))));
     return channels;
   }
 
   private static NotificationChannelDto toChannel(ISecurityMember subscriber, NotificationChannel channel) {
     var subscriptions = channel.configFor(subscriber).subscriptions().stream()
-            .collect(Collectors.toMap(
-                    NotificationSubscription::event,
-                    subscription -> new NotificationChannelSubscriptionDto(
-                            subscription.state(),
-                            subscription.isSubscribedByDefault())));
+        .collect(Collectors.toMap(
+            NotificationSubscription::event,
+            subscription -> new NotificationChannelSubscriptionDto(
+                subscription.state(),
+                subscription.isSubscribedByDefault())));
     return new NotificationChannelDto(channel, subscriptions);
   }
 
@@ -57,9 +57,9 @@ public class NotificationChannelDto {
     var subscription = subscriptions.get(event.getEvent());
     var state = subscription.getState();
 
-    boolean subscribedByUser = state.equals(NotificationChannelSubscriptionDto.State.SUBSCRIBED);
+    boolean subscribedByUser = NotificationChannelSubscriptionDto.State.SUBSCRIBED.equals(state);
 
-    boolean useDefault = state.equals(NotificationChannelSubscriptionDto.State.USE_DEFAULT);
+    boolean useDefault = NotificationChannelSubscriptionDto.State.USE_DEFAULT.equals(state);
 
     var icon = new StringBuilder();
     var iconTitle = new StringBuilder();
@@ -80,4 +80,4 @@ public class NotificationChannelDto {
     subscription.setIcon(icon.toString());
     subscription.setTitle(iconTitle.toString());
   }
- }
+}

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelSubscriptionDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelSubscriptionDto.java
@@ -10,7 +10,7 @@ public class NotificationChannelSubscriptionDto {
   private String title;
 
   public NotificationChannelSubscriptionDto(NotificationSubscription.State state,
-          boolean isSubscribedByDefault) {
+      boolean isSubscribedByDefault) {
     this.state = State.fromDbState(state);
     this.isSubscribedByDefault = isSubscribedByDefault;
   }
@@ -51,12 +51,12 @@ public class NotificationChannelSubscriptionDto {
     this.title = title;
   }
 
-  public static enum State {
+  public enum State {
     USE_DEFAULT("0"), SUBSCRIBED("1"), NOT_SUBSCRIBED("2");
 
-    private String value;
+    private final String value;
 
-    private State(String value) {
+    State(String value) {
       this.value = value;
     }
 
@@ -66,7 +66,7 @@ public class NotificationChannelSubscriptionDto {
     }
 
     public static State of(String value) {
-      for(State state: values()) {
+      for (State state : values()) {
         if (state.value.equals(value)) {
           return state;
         }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/Role.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/Role.java
@@ -1,11 +1,13 @@
 package ch.ivyteam.enginecockpit.security.model;
 
 import javax.ws.rs.core.UriBuilder;
+
 import org.apache.commons.lang3.StringUtils;
+
 import ch.ivyteam.ivy.security.IRole;
 import ch.ivyteam.ivy.security.ISecurityConstants;
 
-public class Role implements SecurityMember{
+public class Role implements SecurityMember {
 
   private String name;
   private String description;
@@ -14,7 +16,7 @@ public class Role implements SecurityMember{
   private boolean member;
   private boolean dynamic;
   private String parentRoleName;
-  private String securityContext;
+  private final String securityContext;
 
   public Role(String securityContext, String name) {
     this.securityContext = securityContext;
@@ -44,10 +46,10 @@ public class Role implements SecurityMember{
 
   public static String getViewUrl(String securityContext, String name) {
     return UriBuilder.fromPath("roledetail.xhtml")
-            .queryParam("system", securityContext)
-            .queryParam("name", name)
-            .build()
-            .toString();
+        .queryParam("system", securityContext)
+        .queryParam("name", name)
+        .build()
+        .toString();
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/RoleDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/RoleDataModel.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
+
 import ch.ivyteam.enginecockpit.commons.TreeView;
 import ch.ivyteam.ivy.security.IRole;
 import ch.ivyteam.ivy.security.ISecurityContext;
@@ -19,7 +21,7 @@ public class RoleDataModel extends TreeView<Role> {
   private final List<Role> roles;
 
   public RoleDataModel(SecuritySystem securitySystem, boolean showMember) {
-    this (securitySystem, showMember, ROLE_CHILDREN_LIMIT);
+    this(securitySystem, showMember, ROLE_CHILDREN_LIMIT);
   }
 
   public RoleDataModel(SecuritySystem securitySystem, boolean showMember, int showChildLimit) {
@@ -27,8 +29,8 @@ public class RoleDataModel extends TreeView<Role> {
     this.securityContext = securitySystem.getSecurityContext();
     this.showMember = showMember;
     this.roles = securityContext.roles().all().stream()
-            .map(role -> new Role(role))
-            .collect(Collectors.toList());
+        .map(Role::new)
+        .collect(Collectors.toList());
     this.filter = "";
     reloadTree();
   }
@@ -39,12 +41,12 @@ public class RoleDataModel extends TreeView<Role> {
     this.filter = filter;
     filteredTreeNode = new DefaultTreeNode<>("Filtered roles", null, null);
     roles.stream().filter(role -> StringUtils.containsIgnoreCase(role.getName(), filter))
-            .limit(showChildLimit)
-            .forEach(role -> new DefaultTreeNode<>("role", role, filteredTreeNode));
+        .limit(showChildLimit)
+        .forEach(role -> new DefaultTreeNode<>("role", role, filteredTreeNode));
     if (filteredTreeNode.getChildCount() >= showChildLimit) {
       new DefaultTreeNode<>("searchDummy",
-              new Role("", "The current search has more than " + showChildLimit + " results."),
-              filteredTreeNode);
+          new Role("", "The current search has more than " + showChildLimit + " results."),
+          filteredTreeNode);
     }
   }
 
@@ -54,7 +56,7 @@ public class RoleDataModel extends TreeView<Role> {
   }
 
   public void increaseShowChildLimitAndReloadTree(int increaseLimitBy) {
-    this.showChildLimit+=increaseLimitBy;
+    this.showChildLimit += increaseLimitBy;
     reloadTree();
   }
 
@@ -71,9 +73,9 @@ public class RoleDataModel extends TreeView<Role> {
   }
 
   public class LazyRoleTreeNode extends DefaultTreeNode<Role> {
-    private IRole role;
+    private final IRole role;
     private boolean childrenFetched;
-    private boolean member;
+    private final boolean member;
 
     public LazyRoleTreeNode(IRole role, boolean member, TreeNode<Role> node) {
       super(new Role(role, member), node);
@@ -129,10 +131,10 @@ public class RoleDataModel extends TreeView<Role> {
 
     private int addRolesToTree(List<IRole> rolesToAdd, boolean isMember) {
       super.getChildren().addAll(rolesToAdd.stream()
-              .sorted(Comparator.comparing(IRole::getName))
-              .limit(showChildLimit)
-              .map(child -> new LazyRoleTreeNode(child, isMember, this))
-              .collect(Collectors.toList()));
+          .sorted(Comparator.comparing(IRole::getName))
+          .limit(showChildLimit)
+          .map(child -> new LazyRoleTreeNode(child, isMember, this))
+          .collect(Collectors.toList()));
       return rolesToAdd.size() - showChildLimit;
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/SecurityMember.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/SecurityMember.java
@@ -11,9 +11,9 @@ public interface SecurityMember {
 
   static SecurityMember createFor(ISecurityMember securityMember) {
     if (securityMember.isUser()) {
-      return new User((IUser)securityMember);
+      return new User((IUser) securityMember);
     } else {
-      return new Role((IRole)securityMember);
+      return new Role((IRole) securityMember);
     }
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/SecurityMemberProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/SecurityMemberProperty.java
@@ -3,7 +3,7 @@ package ch.ivyteam.enginecockpit.security.model;
 public class SecurityMemberProperty {
   private String key;
   private String value;
-  private boolean managed;
+  private final boolean managed;
 
   public SecurityMemberProperty() {
     this("", "", false);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/SecuritySystem.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/SecuritySystem.java
@@ -63,8 +63,8 @@ public class SecuritySystem {
   public List<String> getAppNames() {
     if (appNames == null) {
       appNames = IApplicationRepository.of(securityContext).all().stream()
-              .map(IApplication::getName)
-              .collect(Collectors.toList());
+          .map(IApplication::getName)
+          .collect(Collectors.toList());
     }
     return appNames;
   }
@@ -114,7 +114,7 @@ public class SecuritySystem {
   public static boolean isJndiSecuritySystem(ISecurityContext securityContext) {
     var name = securityContext.getExternalSecuritySystemName();
     return MicrosoftActiveDirectoryIdentityProvider.ID.equals(name) ||
-           NovellEDirectoryIdentityProvider.ID.equals(name);
+        NovellEDirectoryIdentityProvider.ID.equals(name);
   }
 
   @SuppressWarnings("removal")

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
@@ -81,10 +81,10 @@ public class User implements SecurityMember {
 
   private static String getViewUrl(String securityContext, String name) {
     return UriBuilder.fromPath("userdetail.xhtml")
-            .queryParam("system", securityContext)
-            .queryParam("name", name)
-            .build()
-            .toString();
+        .queryParam("system", securityContext)
+        .queryParam("name", name)
+        .build()
+        .toString();
   }
 
   @Override
@@ -208,10 +208,10 @@ public class User implements SecurityMember {
 
   public Administrator getAdmin() {
     return new Administrator.Builder().username(getName())
-            .fullName(getFullName())
-            .email(getEmail())
-            .password(getRealPassword())
-            .toAdministrator();
+        .fullName(getFullName())
+        .email(getEmail())
+        .password(getRealPassword())
+        .toAdministrator();
   }
 
   public IUser getIUser() {
@@ -234,21 +234,21 @@ public class User implements SecurityMember {
   public List<Absence> getAbsences() {
     return absences;
   }
-  
+
   public boolean isIvySecuritySystem() {
     return isIvySecuritySystem;
   }
 
   private List<Substitute> substitutesOf(IUser user) {
     return user.getSubstitutes().stream()
-            .map(Substitute::of)
-            .collect(Collectors.toList());
+        .map(Substitute::of)
+        .collect(Collectors.toList());
   }
 
-  private List<Absence> absencesOf(IUser user){
+  private List<Absence> absencesOf(IUser user) {
     return user.getAbsences().stream()
-            .map(Absence::of)
-            .collect(Collectors.toList());
+        .map(Absence::of)
+        .collect(Collectors.toList());
   }
 
   public static class Substitute {
@@ -263,7 +263,7 @@ public class User implements SecurityMember {
     private final String securityContext;
 
     public Substitute(String name, String role, String memberIcon, String memberTitle, String typeIcon,
-            String typeTitle, String securityContext) {
+        String typeTitle, String securityContext) {
       this.name = name;
       this.role = role;
       this.memberIcon = memberIcon;
@@ -323,7 +323,7 @@ public class User implements SecurityMember {
         memberTitle = "Role";
       }
 
-      boolean onAbsence = substitute.getSubstitutionType().equals(SubstitutionType.ON_ABSENCE);
+      boolean onAbsence = SubstitutionType.ON_ABSENCE.equals(substitute.getSubstitutionType());
       String typeIcon = onAbsence ? "time-clock-circle" : "pin";
       String typeTitle = onAbsence ? "On absence" : "Permanent";
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/UserConverter.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/UserConverter.java
@@ -18,9 +18,9 @@ public class UserConverter implements Converter {
   public User getAsObject(FacesContext context, UIComponent component, String value) {
     if (StringUtils.isNotBlank(value)) {
       var managebean = context.getApplication().evaluateExpressionGet(context, "#{managerBean}",
-              ManagerBean.class);
+          ManagerBean.class);
       var user = managebean.getSelectedSecuritySystem().getSecurityContext().users().query().where()
-              .securityMemberId().isEqual(value).executor().firstResult();
+          .securityMemberId().isEqual(value).executor().firstResult();
       if (user != null) {
         return new User(user);
       }
@@ -30,8 +30,7 @@ public class UserConverter implements Converter {
 
   @Override
   public String getAsString(FacesContext context, UIComponent component, Object value) {
-    if (value instanceof User) {
-      var user = (User) value;
+    if (value instanceof User user) {
       return user.getSecurityMemberId();
     }
     return null;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/UserDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/UserDataModel.java
@@ -107,10 +107,10 @@ public class UserDataModel extends LazyDataModel<User> implements TableFilter {
     applyOrdering(userQuery, sortBy);
 
     var users = userQuery
-            .executor()
-            .results(first, pageSize).stream()
-            .map(User::new)
-            .collect(Collectors.toList());
+        .executor()
+        .results(first, pageSize).stream()
+        .map(User::new)
+        .collect(Collectors.toList());
     checkIfUserIsLoggedIn(securitySystem, users);
     setRowCount((int) userQuery.executor().count());
     return users;
@@ -126,11 +126,11 @@ public class UserDataModel extends LazyDataModel<User> implements TableFilter {
     if (StringUtils.isNotEmpty(filter)) {
       var dbFilter = "%" + filter + "%";
       query.where().and(userQuery().where()
-              .name().isLikeIgnoreCase(dbFilter)
-              .or()
-              .fullName().isLikeIgnoreCase(dbFilter)
-              .or()
-              .eMailAddress().isLikeIgnoreCase(dbFilter));
+          .name().isLikeIgnoreCase(dbFilter)
+          .or()
+          .fullName().isLikeIgnoreCase(dbFilter)
+          .or()
+          .eMailAddress().isLikeIgnoreCase(dbFilter));
     }
 
     query.where().and(userQuery().where().enabled().is(!showDisabledUsers));
@@ -176,9 +176,9 @@ public class UserDataModel extends LazyDataModel<User> implements TableFilter {
     for (var session : securitySystem.getSecurityContext().sessions().clusterSnapshot().getSessionInfos()) {
       var sessionUser = session.getSessionUserName();
       appUsers.stream()
-              .filter(u -> u.getName().equals(sessionUser))
-              .findAny()
-              .ifPresent(user -> user.setLoggedIn(true));
+          .filter(u -> u.getName().equals(sessionUser))
+          .findAny()
+          .ifPresent(user -> user.setLoggedIn(true));
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/AbstractPermission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/AbstractPermission.java
@@ -2,7 +2,7 @@ package ch.ivyteam.enginecockpit.security.permission;
 
 public abstract class AbstractPermission {
 
-  private String name;
+  private final String name;
   private boolean grant;
   private boolean deny;
   private boolean someGrant;
@@ -57,17 +57,17 @@ public abstract class AbstractPermission {
 
   public void defineState() {
     switch (state) {
-    case State.DEFAULT:
-      resetToInitialState();
-      break;
-    case State.GRANTED:
-      grant();
-      break;
-    case State.DENIED:
-      deny();
-      break;
-    default:
-      break;
+      case State.DEFAULT:
+        resetToInitialState();
+        break;
+      case State.GRANTED:
+        grant();
+        break;
+      case State.DENIED:
+        deny();
+        break;
+      default:
+        break;
     }
   }
 
@@ -76,24 +76,24 @@ public abstract class AbstractPermission {
       group();
     }
     switch (initialState) {
-    case State.GRANTED:
-      grant();
-      break;
-    case State.DENIED:
-      deny();
-      break;
-    case State.SOMEGRANTED:
-      someGrant();
-      break;
-    case State.SOMEDENIED:
-      someDeny();
-      break;
-    case State.STATELESS:
-      grant();
-      ungrant();
-      break;
-    default:
-      break;
+      case State.GRANTED:
+        grant();
+        break;
+      case State.DENIED:
+        deny();
+        break;
+      case State.SOMEGRANTED:
+        someGrant();
+        break;
+      case State.SOMEDENIED:
+        someDeny();
+        break;
+      case State.STATELESS:
+        grant();
+        ungrant();
+        break;
+      default:
+        break;
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/Permission.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/Permission.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import ch.ivyteam.ivy.security.IPermission;
 import ch.ivyteam.ivy.security.IPermissionAccess;
+import ch.ivyteam.ivy.security.IRole;
 
 public class Permission extends AbstractPermission {
   private boolean explicit;
@@ -13,11 +14,11 @@ public class Permission extends AbstractPermission {
 
   public Permission(IPermissionAccess access, PermissionBean bean) {
     super(access.getPermission().getName(),
-            access.isGranted(),
-            access.isDenied());
+        access.isGranted(),
+        access.isDenied());
     this.explicit = access.isExplicit();
-    this.permissionHolder = Optional.ofNullable(access.getPermissionHolder()).map(r -> r.getName())
-            .orElse(null);
+    this.permissionHolder = Optional.ofNullable(access.getPermissionHolder()).map(IRole::getName)
+        .orElse(null);
     this.permission = access.getPermission();
     this.bean = bean;
     initialState();
@@ -82,8 +83,7 @@ public class Permission extends AbstractPermission {
   }
 
   @Override
-  public void group() {
-  }
+  public void group() {}
 
   public IPermission permission() {
     return permission;
@@ -94,10 +94,10 @@ public class Permission extends AbstractPermission {
     if (obj == this) {
       return true;
     }
-    if (obj == null || ! obj.getClass().equals(Permission.class)) {
+    if (obj == null || !obj.getClass().equals(Permission.class)) {
       return false;
     }
-    var other = (Permission)obj;
+    var other = (Permission) obj;
     return permission.equals(other.permission);
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionBean.java
@@ -14,6 +14,7 @@ import org.primefaces.model.TreeNode;
 import ch.ivyteam.enginecockpit.commons.ResponseHelper;
 import ch.ivyteam.enginecockpit.commons.TreeView;
 import ch.ivyteam.ivy.persistence.db.ISystemDatabasePersistencyService;
+import ch.ivyteam.ivy.security.IRole;
 import ch.ivyteam.ivy.security.ISecurityContextRepository;
 import ch.ivyteam.ivy.security.ISecurityDescriptor;
 import ch.ivyteam.ivy.security.ISecurityMember;
@@ -74,22 +75,21 @@ public class PermissionBean extends TreeView<AbstractPermission> {
 
   @Override
   public void setFilter(String filter) {
-    if (StringUtils.isBlank(filter))
-    {
+    if (StringUtils.isBlank(filter)) {
       if (StringUtils.isNotBlank(this.filter)) {
         reloadTree();
       }
       return;
     }
-    filteredTreeNode = new DefaultTreeNode<AbstractPermission>("Filtered tree", null, null);
+    filteredTreeNode = new DefaultTreeNode<>("Filtered tree", null, null);
     var rootPermissionGroup = securityDescriptor.getSecurityDescriptorType().getRootPermissionGroup();
     rootPermissionGroup.getAllPermissions().stream()
-            .filter(permission -> StringUtils.containsIgnoreCase(permission.getName(), filter))
-            .map(permission -> {
-              var access = securityDescriptor.getPermissionAccess(permission, securityMember);
-              return new Permission(access, this);
-            })
-            .forEach(permission -> addPermissionNode(filteredTreeNode, permission));
+        .filter(permission -> StringUtils.containsIgnoreCase(permission.getName(), filter))
+        .map(permission -> {
+          var access = securityDescriptor.getPermissionAccess(permission, securityMember);
+          return new Permission(access, this);
+        })
+        .forEach(permission -> addPermissionNode(filteredTreeNode, permission));
     this.filter = filter;
   }
 
@@ -242,6 +242,6 @@ public class PermissionBean extends TreeView<AbstractPermission> {
     permission.setDeny(permissionAccess.isDenied());
     permission.setExplicit(permissionAccess.isExplicit());
     permission.setPermissionHolder(
-            Optional.ofNullable(permissionAccess.getPermissionHolder()).map(r -> r.getName()).orElse(null));
+        Optional.ofNullable(permissionAccess.getPermissionHolder()).map(IRole::getName).orElse(null));
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionGroup.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/permission/PermissionGroup.java
@@ -11,8 +11,8 @@ public class PermissionGroup extends AbstractPermission {
 
   public PermissionGroup(IPermissionGroupAccess groupAccess, PermissionBean bean) {
     super(groupAccess.getPermissionGroup().getName(),
-            groupAccess.isGrantedAllPermissions(),
-            groupAccess.isDeniedAllPermissions());
+        groupAccess.isGrantedAllPermissions(),
+        groupAccess.isDeniedAllPermissions());
     this.someDeny = groupAccess.isDeniedAnyPermission();
     this.someGrant = groupAccess.isGrantedAnyPermission();
     this.bean = bean;
@@ -79,8 +79,7 @@ public class PermissionGroup extends AbstractPermission {
   }
 
   @Override
-  public void group() {
-  }
+  public void group() {}
 
   public IPermissionGroup permissionGroup() {
     return permissionGroup;
@@ -91,13 +90,13 @@ public class PermissionGroup extends AbstractPermission {
     if (obj == this) {
       return true;
     }
-    if (obj == null || ! obj.getClass().equals(PermissionGroup.class)) {
+    if (obj == null || !obj.getClass().equals(PermissionGroup.class)) {
       return false;
     }
-    var other = (PermissionGroup)obj;
+    var other = (PermissionGroup) obj;
     return permissionGroup != null &&
-           other.permissionGroup != null &&
-           permissionGroup.equals(other.permissionGroup);
+        other.permissionGroup != null &&
+        permissionGroup.equals(other.permissionGroup);
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityBean.java
@@ -32,7 +32,7 @@ public class SecurityBean {
   private String newSecuritySystemName;
   private String newSecuritySystemProvider;
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public SecurityBean() {
     managerBean = ManagerBean.instance();
@@ -65,8 +65,8 @@ public class SecurityBean {
 
   public Collection<String> getAvailableSecuritySystems() {
     return readAllSecurityContexts()
-            .map(s -> s.getName())
-            .collect(Collectors.toList());
+        .map(ISecurityContext::getName)
+        .collect(Collectors.toList());
   }
 
   public void triggerSyncForSelectedSecuritySystem() {
@@ -95,7 +95,7 @@ public class SecurityBean {
 
   public boolean isAnySyncRunning() {
     return systems.stream()
-            .anyMatch(system -> system.getSecurityContext().isSynchronizationRunning());
+        .anyMatch(system -> system.getSecurityContext().isSynchronizationRunning());
   }
 
   public String getNewSecuritySystemName() {
@@ -125,7 +125,7 @@ public class SecurityBean {
       loadSecuritySystems();
     } catch (IllegalArgumentException ex) {
       FacesContext.getCurrentInstance().addMessage("msgs",
-              new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", ex.getMessage()));
+          new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", ex.getMessage()));
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityConfigBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityConfigBean.java
@@ -22,14 +22,14 @@ import ch.ivyteam.ivy.security.ISecurityManager;
 @SuppressWarnings("restriction")
 @ManagedBean
 @ViewScoped
-public class SecurityConfigBean  {
+public class SecurityConfigBean {
 
   private String name;
 
   private Locale language;
   private Locale formattingLanguage;
   private SecuritySystem securitySystem;
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public SecurityConfigBean() {
     managerBean = ManagerBean.instance();
@@ -53,9 +53,9 @@ public class SecurityConfigBean  {
 
   private void loadSecuritySystem() {
     securitySystem = managerBean.getSecuritySystems().stream()
-            .filter(system -> StringUtils.equals(system.getSecuritySystemName(), name))
-            .findAny()
-            .orElseThrow();
+        .filter(system -> StringUtils.equals(system.getSecuritySystemName(), name))
+        .findAny()
+        .orElseThrow();
 
     var languageConfigurator = languageConfigurator();
     language = languageConfigurator.content();
@@ -120,7 +120,7 @@ public class SecurityConfigBean  {
     languageConfigurator.content(LocaleUtils.toLocale(language));
     languageConfigurator.formatting(LocaleUtils.toLocale(formattingLanguage));
     FacesContext.getCurrentInstance().addMessage("securityLanguageSaveSuccess",
-            new FacesMessage("Security System Languages saved"));
+        new FacesMessage("Security System Languages saved"));
   }
 
   public String deleteConfiguration() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityProviderBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityProviderBean.java
@@ -1,6 +1,5 @@
 package ch.ivyteam.enginecockpit.security.system;
 
-
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
@@ -58,9 +57,9 @@ public class SecurityProviderBean {
 
   public void loadConfiguration() {
     securitySystem = ManagerBean.instance().getSecuritySystems().stream()
-            .filter(system -> StringUtils.equals(system.getSecuritySystemName(), name))
-            .findAny()
-            .orElseThrow();
+        .filter(system -> StringUtils.equals(system.getSecuritySystemName(), name))
+        .findAny()
+        .orElseThrow();
 
     provider = systemConfig.identity().getName();
     var synch = systemConfig.userSynch();
@@ -73,13 +72,13 @@ public class SecurityProviderBean {
 
   public String getCronHelp() {
     return """
-           Legend<br/>
-           1st - second (optional)(0 - 59)<br/>
-           2nd - minute           (0 - 59)<br/>
-           3rd - hour             (0 - 23)<br/>
-           4th - day of the month (1 - 31)<br/>
-           5th - month            (1 - 12)<br/>
-           6th - day of the week  (1 - 7)""";
+      Legend<br/>
+      1st - second (optional)(0 - 59)<br/>
+      2nd - minute           (0 - 59)<br/>
+      3rd - hour             (0 - 23)<br/>
+      4th - day of the month (1 - 31)<br/>
+      5th - month            (1 - 12)<br/>
+      6th - day of the week  (1 - 7)""";
   }
 
   public boolean isNotIvySecuritySystem() {
@@ -162,7 +161,7 @@ public class SecurityProviderBean {
 
     setShowWarningMessage(false);
     FacesContext.getCurrentInstance().addMessage("securityProviderSaveSuccess",
-            new FacesMessage("Security System Identity Provider saved"));
+        new FacesMessage("Security System Identity Provider saved"));
   }
 
   private boolean validateUpdateTime() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityWorkflowLanguageBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/SecurityWorkflowLanguageBean.java
@@ -28,7 +28,7 @@ public class SecurityWorkflowLanguageBean {
   private String name;
 
   private SecuritySystem securitySystem;
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   private LanguageRepository languages;
   private Locale editLanguage;
@@ -55,9 +55,9 @@ public class SecurityWorkflowLanguageBean {
 
   private void loadSecuritySystem() {
     securitySystem = managerBean.getSecuritySystems().stream()
-            .filter(system -> StringUtils.equals(system.getSecuritySystemName(), name))
-            .findAny()
-            .orElseThrow();
+        .filter(system -> StringUtils.equals(system.getSecuritySystemName(), name))
+        .findAny()
+        .orElseThrow();
     languages = LanguageManager.instance().languages(securitySystem.getSecurityContext());
   }
 
@@ -76,7 +76,7 @@ public class SecurityWorkflowLanguageBean {
   }
 
   public Set<Locale> getAddable() {
-    Set<Locale> addable = new HashSet<Locale>(languages.allContent());
+    Set<Locale> addable = new HashSet<>(languages.allContent());
     addable.removeAll(languages.allWorkflow());
     return addable;
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/compare/SecuritySystemCompareBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/system/compare/SecuritySystemCompareBean.java
@@ -47,15 +47,15 @@ public class SecuritySystemCompareBean {
   public boolean globalFilterFunction(Object value, Object filter, @SuppressWarnings("unused") Locale locale) {
     String filterText = (filter == null) ? null : filter.toString().trim().toLowerCase();
     if (StringUtils.isBlank(filterText)) {
-        return true;
+      return true;
     }
     var issue = (Issue) value;
     return toLower(issue.id()).contains(filterText)
-            || toLower(issue.name()).contains(filterText)
-            || toLower(issue.what().toString()).contains(filterText)
-            || toLower(issue.entity().toString()).contains(filterText)
-            || toLower(issue.target()).contains(filterText)
-            || toLower(issue.source()).contains(filterText);
+        || toLower(issue.name()).contains(filterText)
+        || toLower(issue.what().toString()).contains(filterText)
+        || toLower(issue.entity().toString()).contains(filterText)
+        || toLower(issue.target()).contains(filterText)
+        || toLower(issue.source()).contains(filterText);
   }
 
   private String toLower(String value) {
@@ -117,13 +117,13 @@ public class SecuritySystemCompareBean {
 
   private void solveIssues(Solver.Type type) {
     result.stream()
-      .filter(issue -> !isSolved(issue))
-      .filter(issue -> issue.solver().type() == type)
-      .forEach(issue -> solveIssue(issue, false));
+        .filter(issue -> !isSolved(issue))
+        .filter(issue -> issue.solver().type() == type)
+        .forEach(issue -> solveIssue(issue, false));
   }
 
   public String styleClassForButton(Issue issue) {
-    return switch(issue.solver().type()) {
+    return switch (issue.solver().type()) {
       case DELETE -> "ui-button-danger";
       case CREATE -> "ui-button-success";
       default -> "";
@@ -136,9 +136,9 @@ public class SecuritySystemCompareBean {
 
   public List<String> getSecuritySystems() {
     return ISecurityManager.instance().securityContexts().allWithSystem().stream()
-            .map(ISecurityContext::getName)
-            .filter(name -> !name.equals(sourceSecuritySystem))
-            .collect(Collectors.toList());
+        .map(ISecurityContext::getName)
+        .filter(name -> !name.equals(sourceSecuritySystem))
+        .collect(Collectors.toList());
   }
 
   public String getTargetSecuritySystem() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/DatabaseBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/DatabaseBean.java
@@ -20,7 +20,7 @@ public class DatabaseBean {
   private List<DatabaseDto> filteredDatabases;
   private String filter;
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public DatabaseBean() {
     managerBean = ManagerBean.instance();
@@ -29,10 +29,10 @@ public class DatabaseBean {
 
   public void reloadDatabases() {
     databases = Databases.of(managerBean.getSelectedIApplication())
-            .all().stream()
-            .filter(db -> !StringUtils.equals(db.name(), "IvySystemDatabase"))
-            .map(db -> new DatabaseDto(db))
-            .collect(Collectors.toList());
+        .all().stream()
+        .filter(db -> !StringUtils.equals(db.name(), "IvySystemDatabase"))
+        .map(DatabaseDto::new)
+        .collect(Collectors.toList());
   }
 
   public List<DatabaseDto> getDatabases() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/DatabaseDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/DatabaseDetailBean.java
@@ -98,14 +98,14 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
 
     database = new DatabaseDto(db);
     var externalDb = IExternalDatabaseManager.instance()
-            .getExternalDatabaseApplicationContext(app)
-            .getExternalDatabase(db.name());
+        .getExternalDatabaseApplicationContext(app)
+        .getExternalDatabase(db.name());
     history = externalDb.getExecutionHistory().stream()
-            .map(ExecStatement::new)
-            .collect(Collectors.toList());
+        .map(ExecStatement::new)
+        .collect(Collectors.toList());
     connections = externalDb.getConnections().stream()
-            .map(Connection::new)
-            .collect(Collectors.toList());
+        .map(Connection::new)
+        .collect(Collectors.toList());
   }
 
   public DatabaseDto getDatabase() {
@@ -126,7 +126,7 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
   }
 
   public void removeProperty(String name) {
-    databases.remove(database.getName()+ "." +"Properties"+ "." +name);
+    databases.remove(database.getName() + "." + "Properties" + "." + name);
     reloadExternalDb();
   }
 
@@ -140,12 +140,12 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
 
   public List<String> completeDriver(String value) {
     return JdbcDriver.all().stream()
-            .filter(driver -> driver.isInstalled())
-            .map(driver -> driver.getDriverName())
-            .filter(name -> !StringUtils.startsWith(name, SystemDatabaseBean.HSQL_DB))
-            .filter(name -> StringUtils.startsWith(name, value))
-            .distinct()
-            .collect(Collectors.toList());
+        .filter(JdbcDriver::isInstalled)
+        .map(JdbcDriver::getDriverName)
+        .filter(name -> !StringUtils.startsWith(name, SystemDatabaseBean.HSQL_DB))
+        .filter(name -> StringUtils.startsWith(name, value))
+        .distinct()
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -178,7 +178,7 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
   }
 
   public void testDbConnection() {
-    testResult = (ConnectionTestResult) connectionTest.test(() -> testConnection());
+    testResult = (ConnectionTestResult) connectionTest.test(this::testConnection);
   }
 
   private ConnectionTestResult testConnection() {
@@ -189,11 +189,11 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
       var productVersion = metaData.getDatabaseProductVersion();
       var jdbcVersion = metaData.getJDBCMajorVersion();
       return new ConnectionTestResult("", 0, TestResult.SUCCESS,
-              "Successfully connected to database: " + productName
-                      + " (" + productVersion + ") with JDBC Version " + jdbcVersion);
+          "Successfully connected to database: " + productName
+              + " (" + productVersion + ") with JDBC Version " + jdbcVersion);
     } catch (Exception ex) {
       return new ConnectionTestResult("", 0, TestResult.ERROR,
-              "An error occurred: " + ExceptionUtils.getStackTrace(ex));
+          "An error occurred: " + ExceptionUtils.getStackTrace(ex));
     }
   }
 
@@ -202,8 +202,7 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
     dbConfig.setConnectionUrl(database.getUrl());
     dbConfig.setDriverName(database.getDriver());
     dbConfig.setUserName(database.getUserName());
-    if (StringUtils.isNotBlank(database.getPassword()))
-    {
+    if (StringUtils.isNotBlank(database.getPassword())) {
       dbConfig.setPassword(database.getPassword());
     }
     return dbConfig;
@@ -212,16 +211,16 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
   public void saveDbConfig() {
     connectionTest.stop();
     var dbBuilder = dbBuilder()
-            .url(database.getUrl())
-            .driver(database.getDriver())
-            .user(database.getUserName())
-            .maxConnections(database.getMaxConnections());
+        .url(database.getUrl())
+        .driver(database.getDriver())
+        .user(database.getUserName())
+        .maxConnections(database.getMaxConnections());
     if (database.passwordChanged()) {
       dbBuilder.password(database.getPassword());
     }
     saveDatabase(dbBuilder);
     FacesContext.getCurrentInstance().addMessage("databaseConfigMsg",
-            new FacesMessage("Database configuration saved", ""));
+        new FacesMessage("Database configuration saved", ""));
     reloadExternalDb();
   }
 
@@ -229,7 +228,7 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
     connectionTest.stop();
     databases.remove(databaseName);
     FacesContext.getCurrentInstance().addMessage("databaseConfigMsg",
-            new FacesMessage("Database configuration reset", ""));
+        new FacesMessage("Database configuration reset", ""));
     reloadExternalDb();
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/FeatureEditor.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/FeatureEditor.java
@@ -8,13 +8,13 @@ import javax.faces.context.FacesContext;
 import ch.ivyteam.enginecockpit.commons.Feature;
 
 public interface FeatureEditor {
-  
+
   List<Feature> getFeatures();
-  
+
   Feature getFeature();
-  
+
   void saveFeature(boolean isNewFeature);
-  
+
   default Feature findFeature(String clazz) {
     return getFeatures().stream()
         .filter(feature -> feature.getClazz().equals(clazz))
@@ -23,7 +23,7 @@ public interface FeatureEditor {
   }
 
   void setFeature(String key);
-  
+
   default boolean isExistingFeature() {
     for (Feature feature : getFeatures()) {
       if (feature.getClazz().equals(getFeature().getClazz())) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/PropertyEditor.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/PropertyEditor.java
@@ -8,11 +8,11 @@ import javax.faces.context.FacesContext;
 import ch.ivyteam.enginecockpit.commons.Property;
 
 public interface PropertyEditor {
-  
+
   List<Property> getProperties();
-  
+
   Property getProperty();
-  
+
   void saveProperty(boolean isNewProperty);
 
   default Property findProperty(String key) {
@@ -39,7 +39,7 @@ public interface PropertyEditor {
   }
 
   void setProperty(String key);
-  
+
   default boolean isSensitive() {
     if (getProperty() == null || getProperty().getName() == null || getProperties() == null) {
       return false;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/WebServiceExecHistory.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/WebServiceExecHistory.java
@@ -11,7 +11,7 @@ public record WebServiceExecHistory(String endpoint, Instant timestamp, long exe
   public String getPrettyTime() {
     return new PrettyTime().format(timestamp);
   }
-  
+
   public String getFormattedTime() {
     return DateUtil.formatInstantAsDateTime(timestamp);
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/WebserviceBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/WebserviceBean.java
@@ -17,7 +17,7 @@ public class WebserviceBean {
   private List<Webservice> filteredWebservices;
   private String filter;
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public WebserviceBean() {
     managerBean = ManagerBean.instance();
@@ -26,10 +26,10 @@ public class WebserviceBean {
 
   public void reloadWebservices() {
     webservices = WebServiceClients
-            .of(managerBean.getSelectedIApplication())
-            .all().stream()
-            .map(web -> new Webservice(web))
-            .collect(Collectors.toList());
+        .of(managerBean.getSelectedIApplication())
+        .all().stream()
+        .map(Webservice::new)
+        .collect(Collectors.toList());
   }
 
   public List<Webservice> getWebservices() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/WebserviceDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/WebserviceDetailBean.java
@@ -88,11 +88,11 @@ public class WebserviceDetailBean extends HelpServices implements IConnectionTes
     reloadExternalWebservice();
     liveStats = new WebServiceMonitor(appName, webserviceId);
   }
-  
+
   @SuppressWarnings("restriction")
   private void reloadExternalWebservice() {
     var webService = IWebserviceExecutionManager.instance().getSoapWebServiceApplicationContext(app).getSoapWebService(webserviceId);
-    
+
     history = new ArrayList<>(webService.getCallHistory().stream()
         .map(call -> new WebServiceExecHistory(
             call.getEndpoint(),
@@ -102,9 +102,9 @@ public class WebserviceDetailBean extends HelpServices implements IConnectionTes
             call.getPort()))
         .toList());
   }
-  
+
   public List<WebServiceExecHistory> getExecutionHistory() {
-      return history;
+    return history;
   }
 
   public String getViewUrl() {
@@ -179,7 +179,7 @@ public class WebserviceDetailBean extends HelpServices implements IConnectionTes
   }
 
   public void testWsEndpointUrl() {
-    testResult = (ConnectionTestResult) connectionTest.test(() -> testConnection());
+    testResult = (ConnectionTestResult) connectionTest.test(this::testConnection);
   }
 
   private ConnectionTestResult testConnection() {
@@ -192,31 +192,31 @@ public class WebserviceDetailBean extends HelpServices implements IConnectionTes
       int status = client.target(activeEndpointUrl).request().post(Entity.json("")).getStatus();
       if (status == 401) {
         return new ConnectionTestResult("POST", status, TestResult.WARNING,
-                "Authentication (only HttpBasic supported) was not successful");
+            "Authentication (only HttpBasic supported) was not successful");
       } else if (status == 404) {
         return new ConnectionTestResult("POST", status, TestResult.WARNING, "Service not found");
       } else {
         return new ConnectionTestResult("POST", status, TestResult.SUCCESS,
-                "Successfully reached web service");
+            "Successfully reached web service");
       }
     } catch (ProcessingException ex) {
       return new ConnectionTestResult("", 0, TestResult.ERROR,
-              "The URL seems to be not correct or contains scripting context (can not be evaluated)\n"
-                      + "An error occurred: " + ExceptionUtils.getStackTrace(ex));
+          "The URL seems to be not correct or contains scripting context (can not be evaluated)\n"
+              + "An error occurred: " + ExceptionUtils.getStackTrace(ex));
     }
   }
 
   private boolean authSupportedForTesting() {
     return StringUtils.equals(webservice.getAuthType(), "HttpBasic")
-            || StringUtils.equals(webservice.getAuthType(), "HTTP_BASIC");
+        || StringUtils.equals(webservice.getAuthType(), "HTTP_BASIC");
   }
 
   private String parseEndpointsToYaml(Map<String, PortType> portTypes) {
     return portTypes.entrySet().stream()
-            .map(e -> e.getKey() + ": \n        - " + e.getValue().getLinks().stream()
-                    .map(v -> "\"" + v + "\"")
-                    .collect(Collectors.joining("\n        - ")))
-            .collect(Collectors.joining("\n      "));
+        .map(e -> e.getKey() + ": \n        - " + e.getValue().getLinks().stream()
+            .map(v -> "\"" + v + "\"")
+            .collect(Collectors.joining("\n        - ")))
+        .collect(Collectors.joining("\n      "));
   }
 
   public void saveConfig() {
@@ -249,8 +249,8 @@ public class WebserviceDetailBean extends HelpServices implements IConnectionTes
 
   public void savePortType() {
     var client = wsBuilder()
-            .endpoints(activePortType.getName(), activePortType.getLinks())
-            .toWebServiceClient();
+        .endpoints(activePortType.getName(), activePortType.getLinks())
+        .toWebServiceClient();
     webServiceClients.set(client);
     var msg = new FacesMessage("EndPoint saved", "");
     FacesContext.getCurrentInstance().addMessage("wsConfigMsg", msg);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/help/HelpServices.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/help/HelpServices.java
@@ -8,8 +8,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 
-import ch.ivyteam.enginecockpit.commons.Property;
 import ch.ivyteam.enginecockpit.commons.Feature;
+import ch.ivyteam.enginecockpit.commons.Property;
 import ch.ivyteam.enginecockpit.util.UrlUtil;
 
 public abstract class HelpServices {
@@ -37,23 +37,23 @@ public abstract class HelpServices {
 
   public static String parsePropertiesToYaml(Map<String, String> properties) {
     return properties.entrySet().stream().map(p -> p.getKey() + ": " + p.getValue())
-            .collect(Collectors.joining("\n      "));
+        .collect(Collectors.joining("\n      "));
   }
 
   public static String parsePropertiesToYaml(List<Property> properties) {
     return properties.stream()
-            .map(property -> {
-              if (property.isSensitive()) {
-                return property.getName() + ": \"${encrypt:*****}\"";
-              }
-              return property.getName() + ": " + property.getValue();
-            })
-            .collect(Collectors.joining("\n      "));
+        .map(property -> {
+          if (property.isSensitive()) {
+            return property.getName() + ": \"${encrypt:*****}\"";
+          }
+          return property.getName() + ": " + property.getValue();
+        })
+        .collect(Collectors.joining("\n      "));
   }
 
   public static String parseFeaturesToYaml(List<Feature> features) {
     return features.stream()
-        .map(feature -> feature.getClazz())
+        .map(Feature::getClazz)
         .collect(Collectors.joining("\n      "));
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/ConnectionTestResult.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/ConnectionTestResult.java
@@ -5,10 +5,10 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 
 public class ConnectionTestResult {
-  private String method;
-  private int statusCode;
-  private TestResult restResult;
-  private String message;
+  private final String method;
+  private final int statusCode;
+  private final TestResult restResult;
+  private final String message;
 
   public ConnectionTestResult(String method, int statusCode, TestResult testResult, String message) {
     this.method = method;
@@ -37,13 +37,13 @@ public class ConnectionTestResult {
     ConnectionTestResult getResult();
   }
 
-  public static enum TestResult {
+  public enum TestResult {
     SUCCESS("Success", "green"), WARNING("Warning", "#FFC107"), ERROR("Error", "red");
 
     private final String name;
     private final String color;
 
-    private TestResult(String name, String color) {
+    TestResult(String name, String color) {
       this.name = name;
       this.color = color;
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/ConnectionTestWrapper.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/ConnectionTestWrapper.java
@@ -11,7 +11,7 @@ public class ConnectionTestWrapper {
   private static final Logger LOGGER = Logger.getLogger(ConnectionTestWrapper.class);
 
   private Callable<?> callable;
-  private Object defaultValue;
+  private final Object defaultValue;
 
   public ConnectionTestWrapper() {
     this(null);

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/DatabaseDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/DatabaseDto.java
@@ -12,13 +12,13 @@ import ch.ivyteam.ivy.db.IExternalDatabaseRuntimeConnection;
 import ch.ivyteam.ivy.db.IStatementExecution;
 
 public class DatabaseDto implements IService {
-  private String name;
+  private final String name;
   private String url;
   private String driver;
   private String userName;
   private String password;
   private int maxConnections;
-  private List<Property> properties;
+  private final List<Property> properties;
   private boolean passwordChanged;
 
   public DatabaseDto(Database db) {
@@ -29,8 +29,8 @@ public class DatabaseDto implements IService {
     password = db.password();
     maxConnections = db.maxConnections();
     properties = db.properties().stream()
-          .map(entry -> new Property(entry.key(), entry.value(), entry.isDefault()))
-          .collect(Collectors.toList());
+        .map(entry -> new Property(entry.key(), entry.value(), entry.isDefault()))
+        .collect(Collectors.toList());
     passwordChanged = false;
   }
 
@@ -96,12 +96,12 @@ public class DatabaseDto implements IService {
   }
 
   public static class ExecStatement {
-    private String time;
-    private String execTime;
-    private String resultTime;
-    private String sql;
-    private String element;
-    private long rowsAffected;
+    private final String time;
+    private final String execTime;
+    private final String resultTime;
+    private final String sql;
+    private final String element;
+    private final long rowsAffected;
 
     public ExecStatement(IStatementExecution statement) {
       time = DateUtil.formatDate(statement.getExecutionTimestamp());
@@ -138,8 +138,8 @@ public class DatabaseDto implements IService {
   }
 
   public static class Connection {
-    private String lastUsed;
-    private boolean inUse;
+    private final String lastUsed;
+    private final boolean inUse;
 
     public Connection(IExternalDatabaseRuntimeConnection conn) {
       lastUsed = DateUtil.formatDate(conn.getLastUsed());

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientAuthTypeCalculator.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientAuthTypeCalculator.java
@@ -17,9 +17,9 @@ public class RestClientAuthTypeCalculator {
 
   public String get() {
     return features.stream().filter(f -> StringUtils.contains(f.getClazz(), "authentication"))
-            .map(f -> StringUtils.substringBetween(f.getClazz(), "authentication.", "AuthenticationFeature"))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse("");
+        .map(f -> StringUtils.substringBetween(f.getClazz(), "authentication.", "AuthenticationFeature"))
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse("");
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/RestClientDto.java
@@ -17,14 +17,14 @@ import ch.ivyteam.ivy.rest.client.config.restricted.ClientProperties;
 
 @SuppressWarnings("restriction")
 public class RestClientDto implements IService {
-  private String name;
+  private final String name;
   private String url;
-  private String description;
-  private List<Property> properties;
+  private final String description;
+  private final List<Property> properties;
   private String password;
   private String username;
-  private List<Feature> features;
-  private UUID uniqueId;
+  private final List<Feature> features;
+  private final UUID uniqueId;
   private boolean passwordChanged;
   private final Map<String, Object> connectionProps;
 
@@ -35,19 +35,19 @@ public class RestClientDto implements IService {
     uniqueId = client.uniqueId();
     var metas = client.metas();
     properties = client.properties().stream()
-            .map(p -> new Property(p.key(), p.value(), metas.get(p.key()), p.isDefault()))
-            .collect(Collectors.toList());
+        .map(p -> new Property(p.key(), p.value(), metas.get(p.key()), p.isDefault()))
+        .collect(Collectors.toList());
     password = properties.stream().filter(p -> StringUtils.equals(p.getName(), "password"))
-        .map(p -> p.getValue()).findFirst().orElse("");
+        .map(Property::getValue).findFirst().orElse("");
     username = properties.stream().filter(p -> StringUtils.equals(p.getName(), "username"))
-        .map(p -> p.getValue()).findFirst().orElse("");
+        .map(Property::getValue).findFirst().orElse("");
     features = client.features().stream()
         .map(f -> new Feature(f.clazz(), f.isDefault()))
         .collect(Collectors.toList());
     passwordChanged = false;
-    var propMap = new HashMap<String,String>();
+    var propMap = new HashMap<String, String>();
     for (ch.ivyteam.ivy.rest.client.RestClientProperty prop : client.properties()) {
-        propMap.put(prop.key(), prop.value());
+      propMap.put(prop.key(), prop.value());
     }
     connectionProps = ClientProperties.clientProps(propMap);
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/SearchEngine.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/SearchEngine.java
@@ -17,12 +17,12 @@ public class SearchEngine {
     List<String> INDEX = List.of("_mapping");
   }
 
-  private SearchEngineInfo info;
-  private Watermark watermark;
+  private final SearchEngineInfo info;
+  private final Watermark watermark;
 
   public SearchEngine(SearchEngineInfo info, Watermark watermark) {
     this.info = info;
-    this.watermark= watermark;
+    this.watermark = watermark;
   }
 
   public String getServerUrl() {
@@ -60,11 +60,11 @@ public class SearchEngine {
     return watermark;
   }
 
-  public static enum SearchEngineHealth {
+  public enum SearchEngineHealth {
 
     GREEN("green", "check-circle-1", "Everything is ok"),
     YELLOW("yellow", "check-circle-1", "Everything is ok, if you run on a single node cluster, like the internal ivy ES, this is normal."
-                                     + "On an external multi node cluster this can indicate some upcoming issues. Please check the ES logs."),
+        + "On an external multi node cluster this can indicate some upcoming issues. Please check the ES logs."),
     RED("red", "remove-circle", "There is a problem which needs your attention. Some data may be unavailable or functions are not working correctly."),
     UNKNOWN("unknown", "question-circle", "Health state unknown");
 
@@ -72,7 +72,7 @@ public class SearchEngine {
     private final String icon;
     private final String hint;
 
-    private SearchEngineHealth(String state, String icon, String hint) {
+    SearchEngineHealth(String state, String icon, String hint) {
       this.state = state;
       this.icon = icon;
       this.hint = hint;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/WebServiceClientAuthTypeCalcuator.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/WebServiceClientAuthTypeCalcuator.java
@@ -17,9 +17,9 @@ public class WebServiceClientAuthTypeCalcuator {
 
   public String get() {
     return features.stream().filter(f -> StringUtils.contains(f.getClazz(), "AuthenticationFeature"))
-            .map(f -> StringUtils.substringBetween(f.getClazz(), "cxf.feature.", "AuthenticationFeature"))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse("");
+        .map(f -> StringUtils.substringBetween(f.getClazz(), "cxf.feature.", "AuthenticationFeature"))
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse("");
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/Webservice.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/Webservice.java
@@ -16,17 +16,17 @@ import ch.ivyteam.enginecockpit.commons.Property;
 import ch.ivyteam.ivy.webservice.client.WebServiceClient;
 
 public class Webservice implements IService {
-  private String name;
-  private String genId;
-  private String description;
-  private String wsdlUrl;
-  private List<Feature> features;
-  private List<Property> properties;
+  private final String name;
+  private final String genId;
+  private final String description;
+  private final String wsdlUrl;
+  private final List<Feature> features;
+  private final List<Property> properties;
   private String username;
   private String password;
   private boolean passwordChanged;
-  private TreeNode<EndPoint> portTypes = new DefaultTreeNode<>("PortTypes", null, null);
-  private Map<String, PortType> portTypeMap = new HashMap<>();
+  private final TreeNode<EndPoint> portTypes = new DefaultTreeNode<>("PortTypes", null, null);
+  private final Map<String, PortType> portTypeMap = new HashMap<>();
 
   public Webservice(WebServiceClient webservice) {
     name = webservice.name();
@@ -34,25 +34,25 @@ public class Webservice implements IService {
     wsdlUrl = webservice.wsdlUrl();
     var metas = webservice.metas();
     properties = webservice.properties().stream()
-            .map(p -> new Property(p.key(), p.value(), metas.get(p.key()),p.isDefault()))
-            .collect(Collectors.toList());
+        .map(p -> new Property(p.key(), p.value(), metas.get(p.key()), p.isDefault()))
+        .collect(Collectors.toList());
     password = properties.stream().filter(p -> StringUtils.equals(p.getName(), "password"))
-            .map(p -> p.getValue()).findFirst().orElse("");
+        .map(Property::getValue).findFirst().orElse("");
     username = properties.stream().filter(p -> StringUtils.equals(p.getName(), "username"))
-            .map(p -> p.getValue()).findFirst().orElse("");
+        .map(Property::getValue).findFirst().orElse("");
     passwordChanged = false;
     features = webservice.features().stream()
-           .map(f -> new Feature(f.clazz(), f.isDefault()))
-           .collect(Collectors.toList());
+        .map(f -> new Feature(f.clazz(), f.isDefault()))
+        .collect(Collectors.toList());
     genId = webservice.id();
 
     webservice.portTypes()
-            .forEach(p -> {
-              var portType = new DefaultTreeNode<>(new EndPoint("port", p), portTypes);
-              portType.setExpanded(true);
-              webservice.endpoints().get(p)
-                      .forEach(e -> new DefaultTreeNode<>(new EndPoint("link", e), portType));
-            });
+        .forEach(p -> {
+          var portType = new DefaultTreeNode<>(new EndPoint("port", p), portTypes);
+          portType.setExpanded(true);
+          webservice.endpoints().get(p)
+              .forEach(e -> new DefaultTreeNode<>(new EndPoint("link", e), portType));
+        });
     webservice.portTypes().forEach(p -> portTypeMap.put(p, new PortType(p, webservice.endpoints().get(p))));
   }
 
@@ -122,12 +122,12 @@ public class Webservice implements IService {
   }
 
   public String getEndpoints() {
-    return getPortTypeMap().values().stream().map(pt -> pt.getDefault()).collect(Collectors.joining(", "));
+    return getPortTypeMap().values().stream().map(PortType::getDefault).collect(Collectors.joining(", "));
   }
 
   public static class EndPoint {
-    private String type;
-    private String name;
+    private final String type;
+    private final String name;
 
     public EndPoint(String type, String name) {
       this.type = type;
@@ -144,7 +144,7 @@ public class Webservice implements IService {
   }
 
   public static class PortType {
-    private String name;
+    private final String name;
     private String defaultLink = "";
     private String fallbacks = "";
 
@@ -164,8 +164,8 @@ public class Webservice implements IService {
       var links = new ArrayList<String>();
       links.add(defaultLink);
       Arrays.stream(StringUtils.split(fallbacks, "\n"))
-              .map(link -> StringUtils.trim(link))
-              .forEach(link -> links.add(link));
+          .map(StringUtils::trim)
+          .forEach(link -> links.add(link));
       return links;
     }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationBean.java
@@ -25,8 +25,8 @@ public class NotificationBean {
     }
 
     var n = NotificationRepository.of(securityContext).query()
-            .where().notificationId().isEqual(id)
-            .executor().firstResult();
+        .where().notificationId().isEqual(id)
+        .executor().firstResult();
     if (n == null) {
       ResponseHelper.notFound("Could not find notification " + id);
       return;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDetailBean.java
@@ -51,9 +51,9 @@ public class NotificationChannelDetailBean {
     }
 
     var notificationChannel = NotificationChannel.all(securityContext).stream()
-            .filter(c -> c.id().equals(this.channelId))
-            .findAny()
-            .orElse(null);
+        .filter(c -> c.id().equals(this.channelId))
+        .findAny()
+        .orElse(null);
 
     if (notificationChannel == null) {
       ResponseHelper.notFound("Channel '" + channelId + "' not found");
@@ -63,9 +63,9 @@ public class NotificationChannelDetailBean {
     channel = NotificationChannelDto.instance(securityContext, notificationChannel);
     liveStats = new NotificationChannelMonitor(securityContext, this.channelId, channel.getDisplayName());
     dynamicConfig = DynamicConfig.create()
-            .configurator(notificationChannel.configurator())
-            .config(channel.getConfig().config())
-            .toDynamicConfig();
+        .configurator(notificationChannel.configurator())
+        .config(channel.getConfig().config())
+        .toDynamicConfig();
   }
 
   public DynamicConfig getDynamicConfig() {
@@ -78,19 +78,19 @@ public class NotificationChannelDetailBean {
       config.enabled(channel.isEnabled());
       config.allEventsEnabled(channel.isAllEventsEnabled());
       var events = channel.getEvents().stream()
-              .filter(NotificationEventDto::isEnabled)
-              .map(NotificationEventDto::getEvent)
-              .toList();
+          .filter(NotificationEventDto::isEnabled)
+          .map(NotificationEventDto::getEvent)
+          .toList();
       config.events(events);
       Message.info()
-              .clientId("msgs")
-              .summary("Successfully saved")
-              .show();
+          .clientId("msgs")
+          .summary("Successfully saved")
+          .show();
     } catch (Exception ex) {
       Message.error()
-              .clientId("msgs")
-              .exception(ex)
-              .show();
+          .clientId("msgs")
+          .exception(ex)
+          .show();
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDto.java
@@ -24,7 +24,7 @@ public class NotificationChannelDto {
   private final String system;
 
   private final NotificationChannel channel;
-  private NotificationChannelSystemConfig config;
+  private final NotificationChannelSystemConfig config;
 
   private boolean enabled;
   private boolean allEvents;
@@ -104,7 +104,7 @@ public class NotificationChannelDto {
   }
 
   PushNotificationChannel pushChannel() {
-    return (PushNotificationChannel)channel;
+    return (PushNotificationChannel) channel;
   }
 
   public String getStateText() {
@@ -115,20 +115,19 @@ public class NotificationChannelDto {
   }
 
   public String getStateIcon() {
-    var icon =  switch(getStateText()) {
+    return switch (getStateText()) {
       case "Open" -> "si si-check-circle-1 state-active";
       case "Locked" -> "si si-remove-circle state-inactive";
       default -> "";
     };
-    return icon;
   }
 
   public String getViewUrl() {
     return UriBuilder.fromPath("notification-channel-detail.xhtml")
-            .queryParam("system", system)
-            .queryParam("channel", channel.id())
-            .build()
-            .toString();
+        .queryParam("system", system)
+        .queryParam("channel", channel.id())
+        .build()
+        .toString();
   }
 
   NotificationChannelSystemConfig getConfig() {
@@ -140,11 +139,11 @@ public class NotificationChannelDto {
     var allEvents = Event.all();
     var presentEvents = config.events();
     var events = allEvents.stream()
-            .map(event -> new NotificationEventDto(event, presentEvents.contains(event)))
-            .collect(Collectors.toList());
+        .map(event -> new NotificationEventDto(event, presentEvents.contains(event)))
+        .collect(Collectors.toList());
 
     return new NotificationChannelDto(channel, config,
-            config.enabled(), config.allEventsEnabled(), events, securityContext.getName());
+        config.enabled(), config.allEventsEnabled(), events, securityContext.getName());
   }
 
   public static class NotificationEventDto {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelsBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelsBean.java
@@ -2,8 +2,10 @@ package ch.ivyteam.enginecockpit.services.notification;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
+
 import ch.ivyteam.enginecockpit.system.ManagerBean;
 import ch.ivyteam.ivy.notification.channel.NotificationChannel;
 
@@ -24,8 +26,8 @@ public class NotificationChannelsBean {
   public void onload() {
     var securityContext = managerBean.getSelectedSecuritySystem().getSecurityContext();
     channels = NotificationChannel.all(securityContext).stream()
-            .map(channel -> NotificationChannelDto.instance(securityContext, channel))
-            .collect(Collectors.toList());
+        .map(channel -> NotificationChannelDto.instance(securityContext, channel))
+        .collect(Collectors.toList());
   }
 
   public List<NotificationChannelDto> getChannels() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDataModel.java
@@ -3,17 +3,19 @@ package ch.ivyteam.enginecockpit.services.notification;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.primefaces.model.FilterMeta;
 import org.primefaces.model.LazyDataModel;
 import org.primefaces.model.SortMeta;
 import org.primefaces.model.SortOrder;
+
 import ch.ivyteam.ivy.jsf.primefaces.sort.SortMetaConverter;
 import ch.ivyteam.ivy.notification.query.NotificationDeliveryQuery;
 
 public class NotificationDataModel extends LazyDataModel<NotificationDeliveryDto> {
 
-  private NotificationDto notification;
+  private final NotificationDto notification;
   private String filter;
 
   public NotificationDataModel(NotificationDto notification) {
@@ -36,10 +38,10 @@ public class NotificationDataModel extends LazyDataModel<NotificationDeliveryDto
     applyOrdering(query, sortBy);
 
     var deliveries = query
-            .executor()
-            .results(first, pageSize).stream()
-            .map(NotificationDeliveryDto::new)
-            .collect(Collectors.toList());
+        .executor()
+        .results(first, pageSize).stream()
+        .map(NotificationDeliveryDto::new)
+        .collect(Collectors.toList());
     setRowCount((int) query.executor().count());
     return deliveries;
   }
@@ -48,9 +50,9 @@ public class NotificationDataModel extends LazyDataModel<NotificationDeliveryDto
     if (StringUtils.isNotEmpty(filter)) {
       var dbFilter = "%" + filter + "%";
       query.where().and(query().where()
-             .channel().isLikeIgnoreCase(dbFilter))
+          .channel().isLikeIgnoreCase(dbFilter))
           .or()
-            .notificationDeliveryId().isLikeIgnoreCase(dbFilter);
+          .notificationDeliveryId().isLikeIgnoreCase(dbFilter);
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDeliveryDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDeliveryDto.java
@@ -41,7 +41,7 @@ public class NotificationDeliveryDto {
 
   public String getChannel() {
     return NotificationChannel.byId(delivery.securityContext(), delivery.channel())
-        .map(channel -> channel.displayName())
+        .map(NotificationChannel::displayName)
         .orElse(delivery.channel());
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationDto.java
@@ -16,7 +16,7 @@ import ch.ivyteam.ivy.notification.delivery.NotificationDeliveryRepository;
 
 public class NotificationDto {
 
-  private Notification notification;
+  private final Notification notification;
   private final Date createdAt;
 
   public NotificationDto(Notification notification) {
@@ -81,10 +81,10 @@ public class NotificationDto {
 
   public String getViewUrl() {
     return UriBuilder.fromPath("notificationDeliveries.xhtml")
-            .queryParam("system", notification.securityContext().getName())
-            .queryParam("id", notification.uuid())
-            .build()
-            .toString();
+        .queryParam("system", notification.securityContext().getName())
+        .queryParam("id", notification.uuid())
+        .build()
+        .toString();
   }
 
   public void reusher() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationsDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationsDataModel.java
@@ -23,7 +23,7 @@ import ch.ivyteam.ivy.security.query.UserQuery;
 
 public class NotificationsDataModel extends LazyDataModel<NotificationDto> {
 
-  private SecuritySystem securitySystem;
+  private final SecuritySystem securitySystem;
   private String filter;
 
   public NotificationsDataModel(SecuritySystem securitySystem) {
@@ -46,10 +46,10 @@ public class NotificationsDataModel extends LazyDataModel<NotificationDto> {
     applyOrdering(query, sortBy);
 
     var notifications = query
-            .executor()
-            .results(first, pageSize).stream()
-            .map(NotificationDto::new)
-            .collect(Collectors.toList());
+        .executor()
+        .results(first, pageSize).stream()
+        .map(NotificationDto::new)
+        .collect(Collectors.toList());
     setRowCount((int) query.executor().count());
     return notifications;
   }
@@ -86,7 +86,7 @@ public class NotificationsDataModel extends LazyDataModel<NotificationDto> {
         .name().isEqual(filter).or()
         .fullName().isEqual(filter)
         .executor()
-        .results(0,  2);
+        .results(0, 2);
     receiverIds.addAll(matchingUsers.stream().map(IUser::getSecurityMemberId).toList());
     var matchingRole = securitySystem.getSecurityContext().roles().find(filter);
     if (matchingRole != null) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/ExecHistory.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/ExecHistory.java
@@ -6,12 +6,12 @@ import org.ocpsoft.prettytime.PrettyTime;
 
 import ch.ivyteam.enginecockpit.util.DateUtil;
 
-public record ExecHistory(Date timestamp, long execTime, String requestUrl, String requestMethod, String processElementId ) {
-  
+public record ExecHistory(Date timestamp, long execTime, String requestUrl, String requestMethod, String processElementId) {
+
   public String getPrettyTime() {
     return new PrettyTime().format(timestamp);
   }
-  
+
   public String getFormattedTime() {
     return DateUtil.formatDate(timestamp, "dd-MM-yyyy HH:mm");
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestClientDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestClientDetailBean.java
@@ -101,7 +101,7 @@ public class RestClientDetailBean extends HelpServices implements IConnectionTes
     history = new ArrayList<>(restWebService.getCallHistory().stream()
         .map(call -> new ExecHistory(
             call.getExecutionTimestamp(),
-            (call.getExecutionTimeInMicroSeconds())/1000L,
+            (call.getExecutionTimeInMicroSeconds()) / 1000L,
             call.getRequestUrl(),
             call.getRequestMethod(),
             call.getProcessElementId()))
@@ -175,10 +175,10 @@ public class RestClientDetailBean extends HelpServices implements IConnectionTes
 
   public void testRestConnection() {
     var uiClient = new UiStateClient(findRestClient())
-      .setUiState(restClient)
-      .setTimeout(TimeUnit.SECONDS, 5)
-      .setReadTimeout(TimeUnit.SECONDS, 5)
-      .toClient();
+        .setUiState(restClient)
+        .setTimeout(TimeUnit.SECONDS, 5)
+        .setReadTimeout(TimeUnit.SECONDS, 5)
+        .toClient();
     WebTarget target = RestTestRunner.createTarget(app, uiClient);
     testResult = (ConnectionTestResult) connectionTest.test(() -> RestTestRunner.testConnection(target));
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestClientsBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestClientsBean.java
@@ -18,7 +18,7 @@ public class RestClientsBean {
   private List<RestClientDto> filteredRestClients;
   private String filter;
 
-  private ManagerBean managerBean;
+  private final ManagerBean managerBean;
 
   public RestClientsBean() {
     managerBean = ManagerBean.instance();
@@ -27,9 +27,9 @@ public class RestClientsBean {
 
   public void reloadRestClients() {
     restClients = RestClients.of(managerBean.getSelectedIApplication())
-            .all().stream()
-            .map(rest -> new RestClientDto(rest))
-            .collect(Collectors.toList());
+        .all().stream()
+        .map(RestClientDto::new)
+        .collect(Collectors.toList());
   }
 
   public List<RestClientDto> getRestClients() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestTestRunner.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestTestRunner.java
@@ -23,9 +23,7 @@ public class RestTestRunner {
   @SuppressWarnings("restriction")
   public static WebTarget createTarget(IApplication app, RestClient uiStateClient) {
     var clientPmv = findClientPmv(app, uiStateClient.uniqueId());
-    return createInContext(clientPmv, () ->
-      new ch.ivyteam.ivy.rest.client.internal.ExternalRestWebService(app, uiStateClient).getWebTargetFactory().create()
-    );
+    return createInContext(clientPmv, () -> new ch.ivyteam.ivy.rest.client.internal.ExternalRestWebService(app, uiStateClient).getWebTargetFactory().create());
   }
 
   @SuppressWarnings("restriction")
@@ -41,11 +39,10 @@ public class RestTestRunner {
   @SuppressWarnings("restriction")
   private static Optional<IProcessModelVersion> findClientPmv(IApplication app, UUID clientId) {
     var restManager = ch.ivyteam.ivy.rest.client.config.restricted.IRestClientsManager.instance();
-    var clientPmv = app.getProcessModels().stream()
-      .map(IProcessModel::getReleasedProcessModelVersion)
-      .filter(pmv ->  restManager.getProjectDataModelFor(pmv).findRestClient(clientId).isPresent())
-      .findAny();
-    return clientPmv;
+    return app.getProcessModels().stream()
+        .map(IProcessModel::getReleasedProcessModelVersion)
+        .filter(pmv -> restManager.getProjectDataModelFor(pmv).findRestClient(clientId).isPresent())
+        .findAny();
   }
 
   public static ConnectionTestResult testConnection(WebTarget client) {
@@ -56,14 +53,14 @@ public class RestTestRunner {
       }
     } catch (ProcessingException ex) {
       return new ConnectionTestResult("", 0, TestResult.ERROR, "Invalid Url (may contains script context)\n"
-              + "An error occurred: " + ExceptionUtils.getStackTrace(ex));
+          + "An error occurred: " + ExceptionUtils.getStackTrace(ex));
     }
   }
 
   static ConnectionTestResult toTestResult(StatusType status) {
     var code = status.getStatusCode();
     Family family = status.getFamily();
-    if (family.equals(Family.SUCCESSFUL) || family.equals(Family.REDIRECTION)) {
+    if (Family.SUCCESSFUL.equals(family) || Family.REDIRECTION.equals(family)) {
       return new ConnectionTestResult("HEAD", code, TestResult.SUCCESS, "Successfully sent test request to REST service");
     }
     if (code == 400) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/UiStateClient.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/UiStateClient.java
@@ -17,7 +17,7 @@ public class UiStateClient {
   @SuppressWarnings("restriction")
   public UiStateClient setUiState(RestClientDto dto) {
     builder.uri(dto.getConnectionUrl())
-      .property(ch.ivyteam.ivy.rest.client.config.RestClientProperty.Authentication.USERNAME, dto.getUsername());
+        .property(ch.ivyteam.ivy.rest.client.config.RestClientProperty.Authentication.USERNAME, dto.getUsername());
     if (dto.passwordChanged()) {
       builder.property(ch.ivyteam.ivy.rest.client.config.RestClientProperty.Authentication.PASSWORD, dto.getPassword());
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineBean.java
@@ -19,14 +19,14 @@ import ch.ivyteam.ivy.searchengine.server.ServerConfig;
 @ViewScoped
 public class SearchEngineBean {
 
-  private SearchEngineManager searchEngineManager = (SearchEngineManager) ISearchEngineManager.instance();
+  private final SearchEngineManager searchEngineManager = (SearchEngineManager) ISearchEngineManager.instance();
   private SearchEngine searchEngine;
   private Exception esConnectionException;
   private String filter;
   private SearchEngineIndex activeIndex;
   private String query;
   private String queryResult;
-  private SearchEngineIndexDataModel model;
+  private final SearchEngineIndexDataModel model;
 
   public SearchEngineBean() {
     if (!hasFailure()) {
@@ -112,9 +112,9 @@ public class SearchEngineBean {
 
   public List<String> queryProposals(String value) {
     return getQueryApis().stream()
-            .filter(api -> StringUtils.startsWith(api, value))
-            .distinct()
-            .collect(Collectors.toList());
+        .filter(api -> StringUtils.startsWith(api, value))
+        .distinct()
+        .collect(Collectors.toList());
   }
 
   private List<String> getQueryApis() {
@@ -136,8 +136,8 @@ public class SearchEngineBean {
       }
       path += query;
       searchEngine
-              .executeRequest(path)
-              .ifPresent(result -> queryResult = result);
+          .executeRequest(path)
+          .ifPresent(result -> queryResult = result);
     } catch (Exception ex) {
       queryResult = ex.getMessage();
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
@@ -26,9 +26,9 @@ public class SearchEngineIndex {
 
   public String getViewUrl() {
     return UriBuilder.fromPath("searchindex.xhtml")
-            .queryParam("index", info.indexName().name())
-            .build()
-            .toString();
+        .queryParam("index", info.indexName().name())
+        .build()
+        .toString();
   }
 
   public long getCountIndexed() {
@@ -49,7 +49,7 @@ public class SearchEngineIndex {
   }
 
   public SearchEngineHealth getHealth() {
-    return  SearchEngineHealth.getHealth(info.health());
+    return SearchEngineHealth.getHealth(info.health());
   }
 
   public IndexStatus getStatus() {
@@ -68,7 +68,7 @@ public class SearchEngineIndex {
     return info.status();
   }
 
-  public static enum IndexStatus {
+  public enum IndexStatus {
     OPEN("open", "pi pi-lock-open state-active", "Everything is okay, the index is open."),
     CLOSED("closed", "pi pi-lock-closed state-inactive", "It seems like your machine is out of disk space. Please check your search engine watermark settings."),
     UNKNOWN("unknown", "si si-question-circle", "");
@@ -77,7 +77,7 @@ public class SearchEngineIndex {
     private final String icon;
     private final String hint;
 
-    private IndexStatus(String status, String icon, String hint) {
+    IndexStatus(String status, String icon, String hint) {
       this.state = status;
       this.icon = icon;
       this.hint = hint;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndexDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndexDataModel.java
@@ -8,8 +8,8 @@ import org.primefaces.model.FilterMeta;
 import org.primefaces.model.LazyDataModel;
 import org.primefaces.model.SortMeta;
 
-import ch.ivyteam.ivy.searchengine.index.IndexInfo;
 import ch.ivyteam.ivy.searchengine.ISearchEngineManager;
+import ch.ivyteam.ivy.searchengine.index.IndexInfo;
 
 public class SearchEngineIndexDataModel extends LazyDataModel<SearchEngineIndex> {
 
@@ -22,10 +22,10 @@ public class SearchEngineIndexDataModel extends LazyDataModel<SearchEngineIndex>
 
   @Override
   public List<SearchEngineIndex> load(int first, int pageSize, Map<String, SortMeta> sortBy,
-          Map<String, FilterMeta> filterBy) {
+      Map<String, FilterMeta> filterBy) {
     return searchEngine.indices(first, pageSize).stream()
-            .map(index -> toSearchEngineIndex(index))
-            .collect(Collectors.toList());
+        .map(SearchEngineIndexDataModel::toSearchEngineIndex)
+        .collect(Collectors.toList());
   }
 
   public static SearchEngineIndex toSearchEngineIndex(IndexInfo index) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineService.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineService.java
@@ -17,17 +17,17 @@ public class SearchEngineService {
       filter = "*";
     }
     return searcher.search("""
-                           {
-                             "from": ${from},
-                             "size": ${size},
-                             "query": {
-                               "simple_query_string": {
-                                 "query": "${query}"
-                              }
-                           }}
-                           """
-                            .replace("${from}", String.valueOf(from))
-                            .replace("${size}", String.valueOf(size))
-                            .replace("${query}", filter));
+      {
+        "from": ${from},
+        "size": ${size},
+        "query": {
+          "simple_query_string": {
+            "query": "${query}"
+         }
+      }}
+      """
+        .replace("${from}", String.valueOf(from))
+        .replace("${size}", String.valueOf(size))
+        .replace("${query}", filter));
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/index/SearchIndexDocDataModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/index/SearchIndexDocDataModel.java
@@ -30,8 +30,8 @@ public class SearchIndexDocDataModel extends LazyDataModel<SearchIndexDoc> {
     var filter = filter(filterBy);
     var result = SearchEngineService.instance().search(index, filter, first, pageSize);
     return result.getDocs()
-            .map(doc -> new SearchIndexDoc(doc.getId(), doc.getJson()))
-            .collect(Collectors.toList());
+        .map(doc -> new SearchIndexDoc(doc.getId(), doc.getJson()))
+        .collect(Collectors.toList());
   }
 
   private String filter(Map<String, FilterMeta> filterBy) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/StorageBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/StorageBean.java
@@ -19,14 +19,14 @@ public class StorageBean extends StepStatus {
   private static final String DATA_DIR = DATA + "Directory";
 
   private String appDir;
-  private String appDirHelp;
+  private final String appDirHelp;
   private String dataDir;
-  private String dataDirHelp;
+  private final String dataDirHelp;
 
   public StorageBean() {
     initConfigs();
-    appDirHelp = IConfiguration.instance().getMetadata(APP_DIR).description().replaceAll("\n", "<br/>");
-    dataDirHelp = IConfiguration.instance().getMetadata(DATA_DIR).description().replaceAll("\n", "<br/>");
+    appDirHelp = IConfiguration.instance().getMetadata(APP_DIR).description().replace("\n", "<br/>");
+    dataDirHelp = IConfiguration.instance().getMetadata(DATA_DIR).description().replace("\n", "<br/>");
   }
 
   public String getAppDir() {
@@ -77,7 +77,7 @@ public class StorageBean extends StepStatus {
 
   private void showChangeMessage() {
     FacesContext.getCurrentInstance().addMessage("",
-            new FacesMessage(FacesMessage.SEVERITY_INFO, "Directory changes saved successfully", ""));
+        new FacesMessage(FacesMessage.SEVERITY_INFO, "Directory changes saved successfully", ""));
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/WebServerConnectorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/WebServerConnectorBean.java
@@ -69,7 +69,7 @@ public class WebServerConnectorBean extends StepStatus {
   private void setConfig(String key, Object httpEnabled) {
     IConfiguration.instance().set(key, httpEnabled);
     FacesContext.getCurrentInstance().addMessage("",
-            new FacesMessage(FacesMessage.SEVERITY_INFO, "'" + key + "' changed successfully", ""));
+        new FacesMessage(FacesMessage.SEVERITY_INFO, "'" + key + "' changed successfully", ""));
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/WizardBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/WizardBean.java
@@ -72,7 +72,7 @@ public class WizardBean {
     }
   }
 
-  public static enum Steps {
+  public enum Steps {
     LICENCE(0, "Licence"),
     ADMINS(1, "Administrators"),
     WEBSERVER(2, "Web Server"),

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/MigrationBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/MigrationBean.java
@@ -34,7 +34,7 @@ public class MigrationBean {
   private EngineMigrator.Result result;
   private boolean writeToTmp = false;
   private UploadedFile uploadedLicenceFile;
-  private Set<String> showLogs = new HashSet<>();
+  private final Set<String> showLogs = new HashSet<>();
   private String finishedMessage;
   private String finishedSeverity;
 
@@ -54,10 +54,10 @@ public class MigrationBean {
       running = MigrationState.START;
     } catch (Exception ex) {
       Message.error()
-              .clientId("migrateGrowl")
-              .summary("Error during validation of the location")
-              .exception(ex)
-              .show();
+          .clientId("migrateGrowl")
+          .summary("Error during validation of the location")
+          .exception(ex)
+          .show();
     }
   }
 
@@ -123,7 +123,7 @@ public class MigrationBean {
   }
 
   public String getStartMigrationButtonIcon() {
-    return switch(running) {
+    return switch (running) {
       case START -> "si si-controls-play";
       case RUNNING -> "si si-button-refresh-arrows si-is-spinning";
       case FINISHED -> "si si-check-1";
@@ -131,7 +131,7 @@ public class MigrationBean {
   }
 
   public String getStartMigrationButtonName() {
-    return switch(running) {
+    return switch (running) {
       case START -> "Start";
       case RUNNING -> "Running " + client.taskCountDone() + "/" + client.taskCountAll();
       case FINISHED -> "Done";
@@ -149,8 +149,8 @@ public class MigrationBean {
   private static List<Task> loadTasks(EngineMigrator.Result result) {
     if (result.success()) {
       return result.tasks().stream()
-              .map(Task::new)
-              .collect(Collectors.toList());
+          .map(Task::new)
+          .collect(Collectors.toList());
     }
     return new ArrayList<>();
   }
@@ -219,7 +219,7 @@ public class MigrationBean {
     return running;
   }
 
-  public static enum MigrationState {
+  public enum MigrationState {
     START, RUNNING, FINISHED,
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/MigrationRunner.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/MigrationRunner.java
@@ -26,8 +26,8 @@ public class MigrationRunner implements MigrationClient {
 
   public long taskCountDone() {
     return tasks.values().stream()
-            .filter(t -> t.isDone())
-            .count();
+        .filter(Task::isDone)
+        .count();
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
@@ -11,8 +11,8 @@ public class Task {
   private String state;
   private String stateIcon;
   private final MigrationTask task;
-  private String script;
-  private int version;
+  private final String script;
+  private final int version;
   private String log = "";
 
   public Task(MigrationTask task) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdministratorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdministratorBean.java
@@ -15,7 +15,7 @@ import ch.ivyteam.ivy.security.administrator.AdministratorService;
 @ManagedBean
 @ViewScoped
 public class AdministratorBean extends StepStatus {
-  private List<User> admins;
+  private final List<User> admins;
   private User editAdmin;
 
   public AdministratorBean() {
@@ -24,8 +24,8 @@ public class AdministratorBean extends StepStatus {
 
   private static List<User> reloadAdmins() {
     return AdministratorService.instance().allConfigured().stream()
-            .map(admin -> new User(admin))
-            .collect(Collectors.toList());
+        .map(User::new)
+        .collect(Collectors.toList());
   }
 
   public List<User> getAdmins() {
@@ -38,10 +38,10 @@ public class AdministratorBean extends StepStatus {
 
   public void removeAdmin() {
     AdministratorService.instance().find(editAdmin.getName())
-            .ifPresent(a -> AdministratorService.instance().remove(a));
+        .ifPresent(a -> AdministratorService.instance().remove(a));
     FacesContext.getCurrentInstance().addMessage("",
-            new FacesMessage(FacesMessage.SEVERITY_INFO, "'" + editAdmin.getName() + "' removed successfully",
-                    ""));
+        new FacesMessage(FacesMessage.SEVERITY_INFO, "'" + editAdmin.getName() + "' removed successfully",
+            ""));
     admins.remove(editAdmin);
   }
 
@@ -65,11 +65,11 @@ public class AdministratorBean extends StepStatus {
 
   public void saveAdmin() {
     var message = new FacesMessage(FacesMessage.SEVERITY_INFO,
-            "'" + editAdmin.getName() + "' modified successfully", "");
+        "'" + editAdmin.getName() + "' modified successfully", "");
     if (!admins.contains(editAdmin)) {
       admins.add(editAdmin);
       message = new FacesMessage(FacesMessage.SEVERITY_INFO,
-              "'" + editAdmin.getName() + "' added successfully", "");
+          "'" + editAdmin.getName() + "' added successfully", "");
     }
     FacesContext.getCurrentInstance().addMessage("", message);
     AdministratorService.instance().save(editAdmin.getAdmin());

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdvisorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdvisorBean.java
@@ -58,7 +58,7 @@ public class AdvisorBean {
   public String getDesignerGuideBaseUrl() {
     return UrlUtil.getDesignerGuideBaseUrl();
   }
-  
+
   public String getInstallationDirectory() {
     return Paths.get("").toAbsolutePath().toString();
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ClusterBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ClusterBean.java
@@ -14,14 +14,14 @@ import ch.ivyteam.ivy.cluster.restricted.IClusterManager;
 @ViewScoped
 public class ClusterBean {
 
-  private boolean isClusterServer;
-  private List<ClusterNode> clusterNodes;
+  private final boolean isClusterServer;
+  private final List<ClusterNode> clusterNodes;
   private ClusterNode activeClusterNode;
 
   private List<ClusterNode> filteredNodes;
   private String filter;
 
-  private IClusterManager clusterManager = IClusterManager.instance();
+  private final IClusterManager clusterManager = IClusterManager.instance();
 
   public ClusterBean() {
     isClusterServer = clusterManager.isClusterServer();
@@ -34,8 +34,8 @@ public class ClusterBean {
   }
 
   private List<ClusterNode> loadClusterNodes() {
-    return clusterManager.getClusterNodes().stream().map(node -> new ClusterNode(node))
-            .collect(Collectors.toList());
+    return clusterManager.getClusterNodes().stream().map(ClusterNode::new)
+        .collect(Collectors.toList());
   }
 
   public List<ClusterNode> getNodes() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/EmailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/EmailBean.java
@@ -81,7 +81,7 @@ public class EmailBean {
       facesMessage = new FacesMessage("Successfully sent test mail", "");
     } catch (Exception ex) {
       facesMessage = new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error while sending test mail",
-              ex.getMessage());
+          ex.getMessage());
     }
     FacesContext.getCurrentInstance().addMessage("msgs", facesMessage);
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/LicenceBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/LicenceBean.java
@@ -38,7 +38,7 @@ public class LicenceBean extends StepStatus {
   private static final String USER_LIMIT = "server.users.limit";
   private static final String SESSION_LIMIT = "server.sessions.limit";
 
-  private ISecurityManager securityManager = ISecurityManager.instance();
+  private final ISecurityManager securityManager = ISecurityManager.instance();
 
   private String users;
   private String sessions;
@@ -153,7 +153,7 @@ public class LicenceBean extends StepStatus {
 
   public String getProblemMessage() {
     var maintenanceMode = EngineMode.is(EngineMode.MAINTENANCE) ? " Your engine runs in maintenance mode."
-            : "";
+        : "";
     if (isExpired()) {
       return "Your licence has expired." + maintenanceMode;
     }
@@ -212,8 +212,8 @@ public class LicenceBean extends StepStatus {
 
   private void reloadLicenceMessages() {
     unconfirmedLicenceEvents = LicenceEventManager.getInstance().getUnconfirmedLicenceEvents().stream()
-            .map(LicenceMessage::new)
-            .collect(Collectors.toList());
+        .map(LicenceMessage::new)
+        .collect(Collectors.toList());
   }
 
   private String getSessionUsername() {
@@ -221,8 +221,8 @@ public class LicenceBean extends StepStatus {
   }
 
   public class UserSession {
-    private String name;
-    private int count;
+    private final String name;
+    private final int count;
 
     public UserSession(ISession session) {
       this.name = session.getSessionUserName();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/LoginBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/LoginBean.java
@@ -44,7 +44,7 @@ public class LoginBean {
       return;
     }
     FacesContext.getCurrentInstance().addMessage(null,
-            new FacesMessage(FacesMessage.SEVERITY_ERROR, "Login failed", "Login failed"));
+        new FacesMessage(FacesMessage.SEVERITY_ERROR, "Login failed", "Login failed"));
   }
 
   public void logout() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ManagerBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ManagerBean.java
@@ -37,8 +37,8 @@ public class ManagerBean {
 
   private Locale formattingLocale;
 
-  private IApplicationRepository apps = IApplicationRepository.instance();
-  private ISecurityManager securityManager = ISecurityManager.instance();
+  private final IApplicationRepository apps = IApplicationRepository.instance();
+  private final ISecurityManager securityManager = ISecurityManager.instance();
 
   public ManagerBean() {
     reloadSecuritySystems();
@@ -62,8 +62,8 @@ public class ManagerBean {
   public void reloadApplications() {
     int appCount = applications.size();
     applications = getIApplications().stream()
-            .map(app -> new Application(app))
-            .collect(Collectors.toList());
+        .map(Application::new)
+        .collect(Collectors.toList());
     if (selectedApplicationIndex != 0 && appCount != applications.size()) {
       selectedApplicationIndex = 0;
     }
@@ -164,9 +164,9 @@ public class ManagerBean {
 
   public List<IApplication> getIApplications() {
     return apps.all().stream()
-            .filter(app -> !app.isSystem())
-            .sorted(Comparator.comparing(IApplication::getName, String.CASE_INSENSITIVE_ORDER))
-            .collect(Collectors.toList());
+        .filter(app -> !app.isSystem())
+        .sorted(Comparator.comparing(IApplication::getName, String.CASE_INSENSITIVE_ORDER))
+        .collect(Collectors.toList());
   }
 
   public String getSessionCount() {
@@ -182,7 +182,7 @@ public class ManagerBean {
   }
 
   public String getRunningCasesCount() {
-    return formatNumber(getApplications().stream().mapToLong(a -> a.getRunningCasesCount()).sum());
+    return formatNumber(getApplications().stream().mapToLong(Application::getRunningCasesCount).sum());
   }
 
   public boolean isIvySecuritySystemForSelectedSecuritySystem() {
@@ -204,8 +204,8 @@ public class ManagerBean {
   public static ManagerBean instance() {
     var context = FacesContext.getCurrentInstance();
     return context
-            .getApplication()
-            .evaluateExpressionGet(context, "#{managerBean}", ManagerBean.class);
+        .getApplication()
+        .evaluateExpressionGet(context, "#{managerBean}", ManagerBean.class);
   }
 
   public String getConfigLogUrl() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/RestartBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/RestartBean.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.SystemUtils;
 
 import ch.ivyteam.ivy.configuration.restricted.IConfiguration;
 import ch.ivyteam.ivy.security.ISecurityContextRepository;
+import ch.ivyteam.ivy.security.ISession;
 import ch.ivyteam.ivy.server.restricted.EngineMode;
 
 @ManagedBean
@@ -67,13 +68,13 @@ public class RestartBean {
 
   public long getWorkingUsers() {
     return ISecurityContextRepository.instance().allWithSystem()
-      .stream()
-      .flatMap(s -> s.sessions().all().stream())
-      .filter(s -> !s.isSessionUserSystemUser())
-      .filter(s -> !s.isSessionUserUnknown())
-      .map(s -> s.getSessionUserName())
-      .distinct()
-      .count();
+        .stream()
+        .flatMap(s -> s.sessions().all().stream())
+        .filter(s -> !s.isSessionUserSystemUser())
+        .filter(s -> !s.isSessionUserUnknown())
+        .map(ISession::getSessionUserName)
+        .distinct()
+        .count();
   }
 
   public boolean isRestartable() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SupportBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SupportBean.java
@@ -29,7 +29,7 @@ import ch.ivyteam.log.Logger;
 public class SupportBean {
 
   private final static Logger LOGGER = Logger.getLogger(SupportBean.class);
-  private ISystemDatabasePersistencyService systemDbService = ISystemDatabasePersistencyService.instance();
+  private final ISystemDatabasePersistencyService systemDbService = ISystemDatabasePersistencyService.instance();
 
   public StreamedContent getSupportReport() throws IOException {
     var errorReport = createSupportReport();
@@ -41,7 +41,7 @@ public class SupportBean {
     var tempSupportDir = Files.createTempDirectory("SupportReport");
     var zipFile = tempSupportDir.resolve("support-engine-report.zip").toFile();
     try (var fos = new FileOutputStream(zipFile);
-            var zos = new ZipOutputStream(fos)) {
+        var zos = new ZipOutputStream(fos)) {
       addEntryToZip(zos, "report.txt", errorReport.getBytes());
       LogFileRepository.instance().all().forEach(log -> addLogToZip(zos, log));
     }
@@ -66,16 +66,16 @@ public class SupportBean {
 
   private StreamedContent createStreamedContent(File zipFile) {
     return DefaultStreamedContent.builder()
-            .stream(() -> DownloadUtil.getFileStream(zipFile))
-            .contentType("application/zip")
-            .name("support-engine-report.zip")
-            .build();
+        .stream(() -> DownloadUtil.getFileStream(zipFile))
+        .contentType("application/zip")
+        .name("support-engine-report.zip")
+        .build();
   }
 
   private String createSupportReport() {
     var dumpers = ErrorReport.addStandardDumpers(false,
-            new ApplicationConfigurationDumper(IApplicationRepository.instance()),
-            new PersistencyDumper(systemDbService));
+        new ApplicationConfigurationDumper(IApplicationRepository.instance()),
+        new PersistencyDumper(systemDbService));
     return ErrorReport.createErrorReport(null, dumpers);
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SystemDatabaseInfoBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/SystemDatabaseInfoBean.java
@@ -30,7 +30,7 @@ public class SystemDatabaseInfoBean {
   private String filterTable;
   private String filterIndex;
   private String filterTrigger;
-  private LongValueFormatter scaleValue = new LongValueFormatter(4);
+  private final LongValueFormatter scaleValue = new LongValueFormatter(4);
 
   public void loadData() throws SQLException {
     var dbs = (DatabasePersistencyService) ISystemDatabasePersistencyService.instance();
@@ -40,7 +40,7 @@ public class SystemDatabaseInfoBean {
     this.triggers = systemDbInfo.getTriggers();
   }
 
-  public String formatByteValue (long size) {
+  public String formatByteValue(long size) {
     if (size != Long.MIN_VALUE && size != 0) {
       return scaleValue.format(size, Unit.BYTES);
     }
@@ -74,11 +74,11 @@ public class SystemDatabaseInfoBean {
   public void setFilteredIndexes(List<SystemDbIndex> filteredIndex) {
     this.filteredIndexes = filteredIndex;
   }
-  
+
   public List<SystemDbTrigger> getFilteredTriggers() {
     return filteredTriggers;
   }
-  
+
   public void setFilteredTriggers(List<SystemDbTrigger> filteredTrigger) {
     this.filteredTriggers = filteredTrigger;
   }
@@ -86,11 +86,11 @@ public class SystemDatabaseInfoBean {
   public String getFilterTable() {
     return filterTable;
   }
-  
+
   public String getFilterTrigger() {
     return filterTrigger;
   }
-  
+
   public void setFilterTrigger(String filter) {
     this.filterTrigger = filter;
   }
@@ -144,7 +144,7 @@ public class SystemDatabaseInfoBean {
   }
 
   public String backgroundRow(long rows) {
-    var maxRows = tables.stream().mapToLong(i -> i.getRows()).max().orElse(rows);
+    var maxRows = tables.stream().mapToLong(SystemDbTable::getRows).max().orElse(rows);
     var background = BackgroundMeterUtil.background(rows, maxRows);
     return "background: " + background + ";";
   }
@@ -156,11 +156,11 @@ public class SystemDatabaseInfoBean {
   }
 
   public String backgroundTableDiskSize(long diskSize) {
-    return backgroundDiskSize(diskSize, tables.stream().mapToLong(i -> i.getDiskSize()).sum());
+    return backgroundDiskSize(diskSize, tables.stream().mapToLong(SystemDbTable::getDiskSize).sum());
   }
 
   public String backgroundIndexDiskSize(long diskSize) {
-    return backgroundDiskSize(diskSize, indexes.stream().mapToLong(i -> i.getDiskSize()).sum());
+    return backgroundDiskSize(diskSize, indexes.stream().mapToLong(SystemDbIndex::getDiskSize).sum());
   }
 
   private String backgroundDiskSize(long diskSize, long maxDiskSize) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/WebServerBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/WebServerBean.java
@@ -33,7 +33,7 @@ public class WebServerBean {
     var request = getRequest();
     var requestData = new ArrayList<RequestData>();
     request.getHeaderNames().asIterator()
-            .forEachRemaining(header -> requestData.add(new RequestData(header, request.getHeader(header))));
+        .forEachRemaining(header -> requestData.add(new RequestData(header, request.getHeader(header))));
     return requestData;
   }
 
@@ -68,8 +68,8 @@ public class WebServerBean {
   }
 
   public class RequestData {
-    private String data;
-    private String value;
+    private final String data;
+    private final String value;
 
     RequestData(String data, String value) {
       this.data = data;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorBean.java
@@ -35,17 +35,17 @@ public class EditorBean {
   public List<EditorFile> completeFiles(String query) {
     String queryLowerCase = query.toLowerCase();
     return configFiles.stream()
-            .filter(file -> file.getFileName().toLowerCase().contains(queryLowerCase))
-            .toList();
+        .filter(file -> file.getFileName().toLowerCase().contains(queryLowerCase))
+        .toList();
   }
 
   public void onload() {
     configFiles = ConfigFileRepository.instance().all().map(EditorFile::new).toList();
     selectedFile = selectedFile == null ? "ivy.yaml" : selectedFile;
     activeConfigFile = configFiles.stream()
-            .filter(f -> f.getFileName().equalsIgnoreCase(selectedFile))
-            .findFirst()
-            .orElse(null);
+        .filter(f -> f.getFileName().equalsIgnoreCase(selectedFile))
+        .findFirst()
+        .orElse(null);
     if (activeConfigFile == null) {
       ResponseHelper.notFound("Config File '" + selectedFile + "' not found");
       return;
@@ -74,23 +74,23 @@ public class EditorBean {
   }
 
   public StreamedContent getFile() {
-      return stream;
+    return stream;
   }
 
   public void fileDownloadView() {
     stream = DefaultStreamedContent.builder()
-            .name(activeConfigFile.getPath().getFileName().toString())
-            .stream(() -> getInputStream())
-            .build();
+        .name(activeConfigFile.getPath().getFileName().toString())
+        .stream(this::getInputStream)
+        .build();
   }
 
   public InputStream getInputStream() {
-      try {
-        var path = activeConfigFile.getPath();
-        return Files.newInputStream(path);
-      } catch (IOException ex) {
-        throw new RuntimeException(ex);
-      }
+    try {
+      var path = activeConfigFile.getPath();
+      return Files.newInputStream(path);
+    } catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   public long getSize() {
@@ -107,16 +107,16 @@ public class EditorBean {
       String extension = originalFileName.substring(originalFileName.lastIndexOf('.') + 1);
       if (!activeConfigFile.getFileName().endsWith(extension)) {
         Message.error()
-                .summary("Invalid extension")
-                .detail("'" + originalFileName + "' could not be uploaded because of wrong file extension.")
-                .show();
+            .summary("Invalid extension")
+            .detail("'" + originalFileName + "' could not be uploaded because of wrong file extension.")
+            .show();
         return;
       }
       activeConfigFile.setBinary(is);
       Message.info()
-              .summary("File Uploaded")
-              .detail("'" + originalFileName + "' uploaded successfully and stored as " + getName() + ".")
-              .show();
+          .summary("File Uploaded")
+          .detail("'" + originalFileName + "' uploaded successfully and stored as " + getName() + ".")
+          .show();
     } catch (Exception ex) {
       throw new RuntimeException("Failed to load inputstream", ex);
     }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorFile.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorFile.java
@@ -42,14 +42,14 @@ public class EditorFile {
     try {
       file.write(content);
       Message.info()
-              .clientId("editorMessage")
-              .summary("Saved " + file.name() + " successfully")
-              .show();
+          .clientId("editorMessage")
+          .summary("Saved " + file.name() + " successfully")
+          .show();
     } catch (Exception ex) {
       Message.error()
-              .clientId("editorMessage")
-              .exception(ex)
-              .show();
+          .clientId("editorMessage")
+          .exception(ex)
+          .show();
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorFileConverter.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/editor/EditorFileConverter.java
@@ -25,13 +25,13 @@ public class EditorFileConverter implements Converter {
     }
     try {
       return ConfigFileRepository.instance().all()
-              .filter(conf -> conf.file().toString().equalsIgnoreCase(value))
-              .findFirst()
-              .map(EditorFile::new)
-              .orElseThrow();
+          .filter(conf -> conf.file().toString().equalsIgnoreCase(value))
+          .findFirst()
+          .map(EditorFile::new)
+          .orElseThrow();
     } catch (NoSuchElementException e) {
       throw new ConverterException(
-              new FacesMessage(FacesMessage.SEVERITY_ERROR, "Conversion Error", "Not a valid file."));
+          new FacesMessage(FacesMessage.SEVERITY_ERROR, "Conversion Error", "Not a valid file."));
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ClusterNode.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ClusterNode.java
@@ -10,7 +10,7 @@ import ch.ivyteam.util.Version;
 @SuppressWarnings("restriction")
 public class ClusterNode {
 
-  private IClusterNode node;
+  private final IClusterNode node;
   private String name;
   private String hostName;
   private String ipAddress;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ConnectionInfo.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ConnectionInfo.java
@@ -4,10 +4,10 @@ import ch.ivyteam.ivy.persistence.db.connection.ConnectionTestResult;
 
 @SuppressWarnings("restriction")
 public class ConnectionInfo {
-  private String label;
-  private String advise;
-  private String messageLevel;
-  private String icon;
+  private final String label;
+  private final String advise;
+  private final String messageLevel;
+  private final String icon;
   private boolean mustConvert;
   private boolean mustCreate;
   private boolean successful;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/LicenceMessage.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/LicenceMessage.java
@@ -6,10 +6,10 @@ import ch.ivyteam.licence.LicenceEvent.Level;
 
 public class LicenceMessage {
 
-  private Level level;
-  private String message;
-  private String timestamp;
-  private LicenceEvent event;
+  private final Level level;
+  private final String message;
+  private final String timestamp;
+  private final LicenceEvent event;
 
   public LicenceMessage(LicenceEvent event) {
     level = event.getLevel();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/SystemDbConnectionProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/SystemDbConnectionProperty.java
@@ -7,9 +7,9 @@ import ch.ivyteam.db.jdbc.ConnectionProperty;
 public class SystemDbConnectionProperty {
 
   private String value;
-  private String defaultValue;
+  private final String defaultValue;
   private boolean isDefault;
-  private ConnectionProperty property;
+  private final ConnectionProperty property;
 
   public SystemDbConnectionProperty(ConnectionProperty connectionProperty, String defaultValue) {
     this.property = connectionProperty;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/SystemDbCreationParameter.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/SystemDbCreationParameter.java
@@ -5,7 +5,7 @@ import ch.ivyteam.db.jdbc.DatabaseCreationParameter;
 public class SystemDbCreationParameter {
 
   private String value;
-  private DatabaseCreationParameter param;
+  private final DatabaseCreationParameter param;
 
   public SystemDbCreationParameter(DatabaseCreationParameter param, String defaultValue) {
     this.param = param;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/KeyStoreBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/KeyStoreBean.java
@@ -1,6 +1,7 @@
 package ch.ivyteam.enginecockpit.system.ssl;
 
 import java.io.InputStream;
+import java.security.Provider;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
@@ -30,7 +31,6 @@ public class KeyStoreBean implements SslTableStore {
   private String provider;
   private String type;
   private String algorithm;
-
 
   public KeyStoreBean() {
     this.store = SslClientSettings.instance().getKeyStore();
@@ -69,16 +69,15 @@ public class KeyStoreBean implements SslTableStore {
 
   @SuppressWarnings("hiding")
   public List<String> getProviders() {
-      List<String> providers = new ArrayList<>(Arrays.stream(Security.getProviders())
-              .map(provider -> provider.getName())
-              .toList());
-      providers.add("");
-      return providers;
+    List<String> providers = new ArrayList<>(Arrays.stream(Security.getProviders())
+        .map(Provider::getName)
+        .toList());
+    providers.add("");
+    return providers;
   }
 
   public List<String> getTypes() {
-    List<String> types = new ArrayList<>();
-    types.addAll(SecurityProviders.getTypes(getProvider()));
+    List<String> types = new ArrayList<>(SecurityProviders.getTypes(getProvider()));
     types.add("");
     return types;
   }
@@ -133,7 +132,7 @@ public class KeyStoreBean implements SslTableStore {
     store.setType(type);
     store.setAlgorithm(algorithm);
     FacesContext.getCurrentInstance().addMessage("sslKeystoreSaveSuccess",
-            new FacesMessage("Key Store configurations saved"));
+        new FacesMessage("Key Store configurations saved"));
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/KeyStoreUtils.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/KeyStoreUtils.java
@@ -43,7 +43,7 @@ class KeyStoreUtils {
       ivyKS.addCert(certFile);
       ivyKS.store(password);
     } catch (KeyStoreException ex) {
-      LOGGER.error("failed to add certificat to "+file, ex);
+      LOGGER.error("failed to add certificat to " + file, ex);
     }
   }
 
@@ -51,10 +51,10 @@ class KeyStoreUtils {
     try {
       var certs = loadInternal().getStoredCertificates();
       return certs.stream()
-        .map(cert -> new StoredCert(cert.alias(), cert.cert()))
-        .toList();
+          .map(cert -> new StoredCert(cert.alias(), cert.cert()))
+          .toList();
     } catch (KeyStoreException ex) {
-      LOGGER.error("failed to read certificates of "+file, ex);
+      LOGGER.error("failed to read certificates of " + file, ex);
       return List.of();
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/SecurityProviders.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/SecurityProviders.java
@@ -1,6 +1,7 @@
 package ch.ivyteam.enginecockpit.system.ssl;
 
 import java.security.Provider;
+import java.security.Provider.Service;
 import java.security.Security;
 import java.util.Arrays;
 import java.util.List;
@@ -18,20 +19,20 @@ class SecurityProviders {
   static List<String> getTypes(String selectedProvider) {
     Provider[] providers = Security.getProviders();
     return Arrays.stream(providers)
-            .filter(provider -> StringUtils.isEmpty(selectedProvider)
-                    || provider.getName().equals(selectedProvider))
-            .flatMap(provider -> provider.getServices().stream())
-            .filter(service -> service.getType().equals(Key.STORE))
-            .map(service -> service.getAlgorithm())
-            .collect(Collectors.toList());
+        .filter(provider -> StringUtils.isEmpty(selectedProvider)
+            || provider.getName().equals(selectedProvider))
+        .flatMap(provider -> provider.getServices().stream())
+        .filter(service -> Key.STORE.equals(service.getType()))
+        .map(Service::getAlgorithm)
+        .collect(Collectors.toList());
   }
 
   static List<String> getAlgorithms(String type) {
     Provider[] providers = Security.getProviders();
     Stream<String> algorithmsStream = Arrays.stream(providers)
-            .flatMap(provider -> provider.getServices().stream())
-            .filter(service -> service.getType().equals(type))
-            .map(service -> service.getAlgorithm());
+        .flatMap(provider -> provider.getServices().stream())
+        .filter(service -> service.getType().equals(type))
+        .map(Service::getAlgorithm);
     return Stream.concat(algorithmsStream, Stream.of("")).collect(Collectors.toList());
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/StoredCert.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/StoredCert.java
@@ -33,12 +33,12 @@ public class StoredCert {
   public static String shortSubject(String fullName) {
     String[] parts = fullName.split(",");
     for (String part : parts) {
-        if (part.trim().startsWith("CN=")) {
-            return part.trim().substring(3);
-        }
+      if (part.trim().startsWith("CN=")) {
+        return part.trim().substring(3);
+      }
     }
     return parts[0].trim();
-}
+  }
 
   public boolean isValid() {
     return invalidityMessage == null;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
@@ -41,6 +41,7 @@ public class TlsTesterBean {
     missingCert = test.getMissingCert();
     infos = test.getExtendedInformations();
   }
+
   public List<TLSTestData> getTestResult() {
     return testResult;
   }
@@ -55,7 +56,7 @@ public class TlsTesterBean {
 
   public boolean isExecuted(String logEntry) {
     return !logEntry.contains("2");
-}
+  }
 
   public String backgroundColor(String logEntry) {
     if (logEntry.contains("2")) {
@@ -70,9 +71,9 @@ public class TlsTesterBean {
 
   public String getExtendedInformations(String logEntry) {
     return infos.stream()
-            .filter(info -> info.contains(getSubject(logEntry)))
-            .findFirst()
-            .orElse("");
+        .filter(info -> info.contains(getSubject(logEntry)))
+        .findFirst()
+        .orElse("");
   }
 
   String getSubject(String inputStrings) {
@@ -84,7 +85,7 @@ public class TlsTesterBean {
   }
 
   public boolean hasMissingCerts(String Uri) {
-    if (!(getMissingCert() == null) && isHttps(Uri) && tlsTestRendered == true) {
+    if (!(getMissingCert() == null) && isHttps(Uri) && tlsTestRendered) {
       return true;
     }
     return false;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TrustStoreBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TrustStoreBean.java
@@ -1,6 +1,7 @@
 package ch.ivyteam.enginecockpit.system.ssl;
 
 import java.io.InputStream;
+import java.security.Provider;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -30,7 +31,7 @@ public class TrustStoreBean implements SslTableStore {
   private String type;
   private String algorithm;
   private String enableInsecureSSL;
-  private SslClientSettings sslClientSettings;
+  private final SslClientSettings sslClientSettings;
 
   public TrustStoreBean() {
     this.sslClientSettings = SslClientSettings.instance();
@@ -58,8 +59,8 @@ public class TrustStoreBean implements SslTableStore {
   @SuppressWarnings("hiding")
   public List<String> getProviders() {
     List<String> providers = new ArrayList<>(Arrays.stream(Security.getProviders())
-            .map(provider -> provider.getName())
-            .toList());
+        .map(Provider::getName)
+        .toList());
     providers.add("");
     return providers;
   }
@@ -69,10 +70,9 @@ public class TrustStoreBean implements SslTableStore {
   }
 
   public List<String> getTypes() {
-      List<String> types = new ArrayList<>();
-      types.addAll(SecurityProviders.getTypes(getProvider()));
-      types.add("");
-      return types;
+    List<String> types = new ArrayList<>(SecurityProviders.getTypes(getProvider()));
+    types.add("");
+    return types;
   }
 
   public String getAlgorithm() {
@@ -122,7 +122,7 @@ public class TrustStoreBean implements SslTableStore {
     store.setAlgorithm(algorithm);
     sslClientSettings.setEnableInsecureSSL(enableInsecureSSL);
     FacesContext.getCurrentInstance().addMessage("sslTruststoreSaveSuccess",
-            new FacesMessage("Trust Store configurations saved"));
+        new FacesMessage("Trust Store configurations saved"));
   }
 
   @Override
@@ -139,13 +139,13 @@ public class TrustStoreBean implements SslTableStore {
 
   public void addToStore(Certificate cert) {
     getKeyStoreUtils().addNewCert(cert);
-    if (cert.getPublicKey().getFormat().equals("X.509")) {
+    if ("X.509".equals(cert.getPublicKey().getFormat())) {
       X509Certificate X509cert = (X509Certificate) cert;
       FacesContext.getCurrentInstance().addMessage("addMissingCertSuccess",
-              new FacesMessage(X509cert.getSubjectX500Principal() + " was successfully added"));
+          new FacesMessage(X509cert.getSubjectX500Principal() + " was successfully added"));
     } else {
-    FacesContext.getCurrentInstance().addMessage("addMissingCertSuccess",
-            new FacesMessage("The certificate was successfully added."));
+      FacesContext.getCurrentInstance().addMessage("addMissingCertSuccess",
+          new FacesMessage("The certificate was successfully added."));
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DateUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DateUtil.java
@@ -22,7 +22,7 @@ public class DateUtil {
 
   public static String formatInstantAsDateTime(Instant instant) {
     var dateTime = instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
-    return DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm").format(dateTime);
+    return DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").format(dateTime);
 
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DownloadUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DownloadUtil.java
@@ -20,23 +20,23 @@ public class DownloadUtil {
   public static void zipDir(Path source, OutputStream out) throws IOException {
     try (var zs = new ZipOutputStream(out)) {
       Files.walk(source)
-              .filter(path -> !Files.isDirectory(path))
-              .forEach(path -> {
-                var zipEntry = new ZipEntry(source.relativize(path).toString());
-                try {
-                  zs.putNextEntry(zipEntry);
-                  Files.copy(path, zs);
-                  zs.closeEntry();
-                } catch (IOException ex) {
-                  LOGGER.info(ex);
-                }
-              });
+          .filter(path -> !Files.isDirectory(path))
+          .forEach(path -> {
+            var zipEntry = new ZipEntry(source.relativize(path).toString());
+            try {
+              zs.putNextEntry(zipEntry);
+              Files.copy(path, zs);
+              zs.closeEntry();
+            } catch (IOException ex) {
+              LOGGER.info(ex);
+            }
+          });
     }
   }
 
   public static InputStream getFileStream(File file) {
     try {
-      return new FileInputStream(file) {
+      return new FileInputStream(file){
         @Override
         public void close() throws IOException {
           super.close();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DurationFormat.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/DurationFormat.java
@@ -47,7 +47,7 @@ public class DurationFormat {
     if (value == null) {
       return nullStr;
     }
-    return format((long)value, unit);
+    return format((long) value, unit);
   }
 
   private String format(long value, Unit baseUnit) {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/EmailUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/EmailUtil.java
@@ -10,15 +10,15 @@ import ch.ivyteam.ivy.mail.MailMessage;
 public class EmailUtil {
 
   private static final Pattern EMAIL_REGEX = Pattern
-          .compile("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
+      .compile("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
 
   public static void sendTestMail(String subject, String to, String message) throws Exception {
     try (var mailClient = MailClient.newMailClient()) {
       var mailMessage = MailMessage.create()
-              .to(to)
-              .subject(subject)
-              .textContent(message)
-              .toMailMessage();
+          .to(to)
+          .subject(subject)
+          .textContent(message)
+          .toMailMessage();
       mailClient.send(mailMessage);
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/ErrorHandler.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/ErrorHandler.java
@@ -7,8 +7,8 @@ import ch.ivyteam.log.Logger;
 
 public class ErrorHandler {
 
-  private String growlId;
-  private Logger logger;
+  private final String growlId;
+  private final Logger logger;
 
   public ErrorHandler(String growlId, Logger logger) {
     this.growlId = growlId;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/ErrorValue.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/ErrorValue.java
@@ -4,7 +4,7 @@ import javax.management.openmbean.CompositeData;
 
 public class ErrorValue {
 
-  private CompositeData error;
+  private final CompositeData error;
 
   public ErrorValue(CompositeData error) {
     this.error = error;
@@ -14,14 +14,14 @@ public class ErrorValue {
     if (!isAvailable()) {
       return "n.a.";
     }
-    return (String)error.get("stackTrace");
+    return (String) error.get("stackTrace");
   }
 
   public String getMessage() {
     if (!isAvailable()) {
       return "n.a.";
     }
-    return (String)error.get("message");
+    return (String) error.get("message");
   }
 
   public boolean isAvailable() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/UrlUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/UrlUtil.java
@@ -10,10 +10,10 @@ import ch.ivyteam.ivy.Advisor;
 public class UrlUtil {
 
   private static final Pattern URL_PATTERN = Pattern.compile(
-          "(?:^|[\\W])((ht|f)tp(s?):\\/\\/|www\\.)"
-                  + "(([\\w\\-]+\\.){1,}?([\\w\\-.~]+\\/?)*"
-                  + "[\\p{Alnum}.,%_=?&#\\-+()\\[\\]\\*$~@!:/{};']*)",
-          Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
+      "(?:^|[\\W])((ht|f)tp(s?):\\/\\/|www\\.)"
+          + "(([\\w\\-]+\\.){1,}?([\\w\\-.~]+\\/?)*"
+          + "[\\p{Alnum}.,%_=?&#\\-+()\\[\\]\\*$~@!:/{};']*)",
+      Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL);
   private static final String ENGINE_GUIDE_URL_PATTERN = "@engine.guide.url@";
   private static final String DESIGNER_GUIDE_URL_PATTERN = "@designer.guide.url@";
 


### PR DESCRIPTION
Done by Eclipse's 'Source Clean Up' function with the options enabled:
- Change non static accesses to static members using declaring type
- Change indirect accesses to static members to direct accesses (accesses through subtypes)
- Convert control statement bodies to block
- Convert to enhanced 'for' loops only if the loop variable is used
- Convert to enhanced 'for' loops
- Convert if/else if/else chain to switch
- Add elements in collections without loop
- Add final modifier to private fields
- Use instanceof keyword instead of Class.isInstance()
- Exit loop earlier
- Make inner classes static where possible
- Convert StringBuffer to StringBuilder for local variables
- Use String.replace() instead of String.replaceAll() when possible
- String.isBlank() rather than String.strip().isEmpty()
- Use lazy logical operator (&& and ||)
- Primitive comparison
- Primitive parsing
- Primitive serialization
- Use boolean literals instead of Boolean.TRUE/FALSE when used as a primitive
- Remove unused imports
- Add missing '@OverRide' annotations
- Add missing '@OverRide' annotations to implementations of interface methods
- Add missing '@deprecated' annotations
- Remove unnecessary casts
- Remove redundant modifiers
- Remove redundant semicolons
- Implicit comparator
- Remove unnecessary array creation for varargs
- Create array with curly
- Remove variable assignment before return
- Convert loop into if
- Remove unnecessary '$NON-NLS$' tags
- Organize imports
- Format source code
- Remove trailing white spaces on all lines
- Remove redundant String.substring() parameter
- Use Arrays.fill() when possible
- Remove overridden assignment
- Remove redundant super() call in constructor
- Remove unreachable block
- Operate on Maps directly
- Initialize collection at creation
- Initialize map at creation
- Avoid Object.equals() or String.equalsIgnoreCase() on null objects
- Compare to zero
- Pull out a duplicate 'if' from an if/else
- Use pattern matching for instanceof
- Convert to switch expression where possible
- Simplify lambda expression and method reference syntax
- Use Comparator.comparing()
- Use String.join()
- Use diamond operator