### PR TITLE
XIVY-15527 Improve the performance of the Applications view

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModel.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModel.java
@@ -9,11 +9,13 @@ import ch.ivyteam.ivy.application.ILibrary;
 import ch.ivyteam.ivy.application.IProcessModel;
 import ch.ivyteam.ivy.application.IProcessModelVersion;
 import ch.ivyteam.ivy.workflow.IWorkflowContext;
+import ch.ivyteam.ivy.workflow.restricted.WorkflowContextInternal;
 
 public class ProcessModel extends AbstractActivity {
   private final IProcessModel pm;
   private Boolean isOverrideProject;
   private long runningCasesCount = -1;
+  private List<String> deletable;
 
   public ProcessModel(IProcessModel pm, ApplicationBean bean) {
     super(pm.getName(), pm.getId(), pm, bean);
@@ -26,8 +28,12 @@ public class ProcessModel extends AbstractActivity {
   }
 
   @Override
+  @SuppressWarnings("restriction")
   public long getRunningCasesCount() {
-    countRunningCases();
+    if (runningCasesCount < 0) {
+      var wf = (WorkflowContextInternal) IWorkflowContext.current();
+      runningCasesCount = wf.getRunningCasesCount(pm);
+    }
     return runningCasesCount;
   }
 
@@ -63,7 +69,10 @@ public class ProcessModel extends AbstractActivity {
 
   @Override
   public List<String> isDeletable() {
-    return pm.isDeletableInternal();
+    if (deletable == null) {
+      deletable = pm.isDeletableInternal();
+    }
+    return deletable;
   }
 
   @Override
@@ -93,13 +102,4 @@ public class ProcessModel extends AbstractActivity {
     }
     return isOverrideProject;
   }
-
-  private void countRunningCases() {
-    if (pm != null && runningCasesCount < 0) {
-      var wf = IWorkflowContext.current();
-      runningCasesCount = pm.getProcessModelVersions().parallelStream()
-          .mapToLong(pmv -> wf.getRunningCasesCount(pmv)).sum();
-    }
-  }
-
 }


### PR DESCRIPTION
Use the new API to get the number of running cases for a process model that only fires one SQL statement and not one per PMV of the process model.

Cache the deletable information so that it is not evaluated on every request. It triggers also the running cases query.

Cherry-Pick 51b5d8ed5fb3a18bffe1f6a3f201043c9ebfe7c7 from master