### PR TITLE
XIVY-15895 Do not show protocol and port if protocol is not defined

### DIFF
--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/system/overview/TestTrafficGraphBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/system/overview/TestTrafficGraphBean.java
@@ -17,8 +17,10 @@ import ch.ivyteam.enginecockpit.monitor.trace.TracerAccess;
 import ch.ivyteam.enginecockpit.monitor.trace.TstSpan;
 import ch.ivyteam.ivy.trace.Span;
 import ch.ivyteam.ivy.trace.SpanResult;
+import ch.ivyteam.ivy.trace.SystemOverview.SystemLink;
 
 class TestTrafficGraphBean {
+
   private final TrafficGraphBean bean = new TrafficGraphBean();
   private final TraceBean trace = new TraceBean();
 
@@ -120,6 +122,22 @@ class TestTrafficGraphBean {
     assertThat(bean.getModel().getElements()).hasSize(1);
   }
 
+  @Test
+  void system_ivy() {
+    var testee = new TrafficGraphBean.System("ivy");
+    assertThat(testee.getName()).isEqualTo("ivy");
+    assertThat(testee.getHost()).isNull();
+    assertThat(testee.getProtocolAndPort()).isEmpty();
+  }
+
+  @Test
+  void system_link() {
+    var testee = new TrafficGraphBean.System(new SystemLinkImpl());
+    assertThat(testee.getName()).isEqualTo("System Database");
+    assertThat(testee.getHost()).isEqualTo("db");
+    assertThat(testee.getProtocolAndPort()).isEqualTo("jdbc [1234]");
+  }
+
   private LabelOverlay toLabel(Connection con) {
     assertThat(con.getOverlays()).hasSize(2);
     return con
@@ -144,4 +162,25 @@ class TestTrafficGraphBean {
     assertThat(ivy.getStyleClass()).isEqualTo(styleClass);
   }
 
+  private static final class SystemLinkImpl implements SystemLink {
+    @Override
+    public String host() {
+      return "db";
+    }
+
+    @Override
+    public String name() {
+      return "System Database";
+    }
+
+    @Override
+    public int port() {
+      return 1234;
+    }
+
+    @Override
+    public String protocol() {
+      return "jdbc";
+    }
+  }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/system/overview/TrafficGraphBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/system/overview/TrafficGraphBean.java
@@ -233,6 +233,9 @@ public class TrafficGraphBean {
     }
 
     public String getProtocolAndPort() {
+      if (protocol == null) {
+        return "";
+      }
       return this.protocol + (this.port == -1 ? "" : " [" + this.port + "]");
     }
 

--- a/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
+++ b/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
@@ -42,11 +42,11 @@
             <p:diagram id="diagram" style="border-right: dotted 1px; border-bottom: dotted 1px; height: #{trafficGraphBean.height}px; width: #{trafficGraphBean.width}px; overflow: hidden;" value="#{trafficGraphBean.model}" styleClass="ui-widget-content" var="system">
               <f:facet name="element">
                 <h:outputText value="#{system.name}" />
-                <h:panelGroup rendered="#{system.host != null}">
+                <h:panelGroup rendered="#{not empty system.host}">
                   <br/>
                   <h:outputText value="#{system.host}"/>
                 </h:panelGroup>
-                <h:panelGroup rendered="#{system.protocolAndPort != null}">
+                <h:panelGroup rendered="#{not empty system.protocolAndPort}">
                   <br/>
                   <h:outputText value="#{system.protocolAndPort}"/>
                 </h:panelGroup>


### PR DESCRIPTION
The method getProtocolAndPort returns empty string now if protocol is not defined.

Add more tests

Use not empty instead of != null in monitorTrafficGraph.xhml page

Cherry-Pick 40a71fa15afe7ff50f42fc7cc70cec3b340bb81a from master

Same as https://github.com/axonivy/engine-cockpit/pull/1176