### PR TITLE
Improve copy to clipboard function

### DIFF
--- a/engine-cockpit/webContent/includes/components/services/database-history.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-history.xhtml
@@ -29,7 +29,7 @@
       </p:column>
       <p:column headerText="SQL" sortBy="#{exec.sql}">
         <h:outputText value="#{exec.sql}" title="#{exec.sql}" styleClass="table-cell-autocut" style="width: calc(100% - 3rem);"/>
-        <p:commandButton icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="copyToClipboard($(this).siblings('.table-cell-autocut').text())"
+        <p:commandButton icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="var button=this; copyToClipboard($(this).siblings('.table-cell-autocut').text(), button)"
           styleClass="ui-button-flat rounded-button"/>
       </p:column>
       <p:column headerText="Process Element" style="width: 75px; word-wrap: anywhere;" sortBy="#{exec.element}">

--- a/engine-cockpit/webContent/includes/dialogs/error.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/error.xhtml
@@ -10,7 +10,7 @@
       <h:outputText id="message" value="#{errorBean.selected.message}"/>
       <h:panelGroup>
         <p:outputLabel for="stackTrace" value="Stack Trace"/>
-        <p:commandButton id="copyError" icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="copyToClipboard($('#error\\:stackTrace').text())"
+        <p:commandButton id="copyError" icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="var button=this; copyToClipboard($('#error\\:stackTrace').text(), button)"
             styleClass="ui-button-flat rounded-button"/>
       </h:panelGroup>
       <p:outputPanel id="stackTrace" styleClass="code">

--- a/engine-cockpit/webContent/resources/js/copyToClipboard.js
+++ b/engine-cockpit/webContent/resources/js/copyToClipboard.js
@@ -1,6 +1,16 @@
-function copyToClipboard(content) {
-  if (navigator.clipboard) {
+function copyToClipboard(content, button) {
+  try {
     navigator.clipboard.writeText(content);
+    if (button) {
+      const icon = $(button).find('.ui-icon');
+      icon.removeClass('si-copy-paste')
+      icon.addClass('si-check-1');
+      setTimeout(() => {
+        icon.removeClass('si-check-1');
+        icon.addClass('si-copy-paste')
+      }, 1000);
+    }
+  } catch {
+    alert(content);
   }
-  alert(content);
 }

--- a/engine-cockpit/webContent/view/monitorJobs.xhtml
+++ b/engine-cockpit/webContent/view/monitorJobs.xhtml
@@ -121,7 +121,7 @@
             <h:outputText id="lastErrorTime" value="#{jobBean.selected.lastErrorTime}"/>
             <h:panelGroup>
               <p:outputLabel for="lastError" value="Last Error"/>
-              <p:commandButton id="copyError" icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="copyToClipboard($('#job\\:lastError').text())"
+              <p:commandButton id="copyError" icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="var button=this; copyToClipboard($('#job\\:lastError').text(), button)"
                   styleClass="ui-button-flat rounded-button"/>
             </h:panelGroup>
             <p:outputPanel id="lastError" styleClass="code">#{jobBean.selected.lastError}</p:outputPanel>  

--- a/engine-cockpit/webContent/view/monitorThreads.xhtml
+++ b/engine-cockpit/webContent/view/monitorThreads.xhtml
@@ -135,7 +135,7 @@
               <p:outputPanel id="lockedMonitors" styleClass="code">#{threadBean.selected.lockedMonitors}</p:outputPanel>
               <h:panelGroup>
                 <p:outputLabel for="stackTrace" value="Stack Trace"/>
-                <p:commandButton id="copyStack" icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="copyToClipboard($('#thread\\:stackTrace').text())"
+                <p:commandButton id="copyStack" icon="si si-copy-paste" type="button" title="Copy to clipboard" onclick="var button=this; copyToClipboard($('#thread\\:stackTrace').text(), button)"
                     styleClass="ui-button-flat rounded-button"/>
               </h:panelGroup>
               <p:outputPanel id="stackTrace" styleClass="code">#{threadBean.selected.stackTrace}</p:outputPanel>  


### PR DESCRIPTION
- Do not show alert dialog if wirte to clipboard api was successful. Otherwise customers think they need to copy it from there. And somethimes the alert dialog also cuts content.
- Show check icon if copy to clipboard was successful

![Screen Recording 2025-01-29 at 16 05 04](https://github.com/user-attachments/assets/59354939-bde3-489a-9711-259edbcf44f8)
