### PR TITLE
XIVY-13920 Test JDBC connection in the PMV Context that declares the DB

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/DatabaseDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/DatabaseDetailBean.java
@@ -183,6 +183,10 @@ public class DatabaseDetailBean extends HelpServices implements IConnectionTestR
 
   private ConnectionTestResult testConnection() {
     var dbConfig = prepareDatabaseConnection();
+    return databases.getInDeclaringPmvContext(databaseName, () -> testConnection(dbConfig));
+  }
+
+  private ConnectionTestResult testConnection(DatabaseConnectionConfiguration dbConfig) {
     try (var connection = DatabaseUtil.openConnection(dbConfig)) {
       var metaData = connection.getMetaData();
       var productName = metaData.getDatabaseProductName();


### PR DESCRIPTION
In order to support JDBC drivers that are loaded via an ivy project we need to set the correct PMV context before testing the connection.

Market Artifact that provides IBM DB2 driver in an ivy project: https://github.com/weissreto/ibm-db2 
Core PR: https://github.com/axonivy/core/pull/8020