### PR TITLE
Fix build

### DIFF
--- a/build/build.groovy
+++ b/build/build.groovy
@@ -32,7 +32,7 @@ def build(def phase = 'verify', def mvnArgs = '', def profiles = '-Pcockpit') {
                 "-Dselenide.remote=http://${seleniumName}:4444/wd/hub " +
                 "-Ddb.host=${dbName} " + 
                 "-Dmaven.test.skip=false " +
-                profiles
+                profiles + " " +
                 mvnArgs;
 
             buildMvn(phase, mvnBuildArgs);


### PR DESCRIPTION
Fix missing maven args on main build, since: https://github.com/axonivy/engine-cockpit/pull/1280

![image](https://github.com/user-attachments/assets/01f914b6-f509-44d1-a253-9ffb04f231d0)
instead of 
![image](https://github.com/user-attachments/assets/60b94831-b284-4f7d-963a-26cd7def62d8)
