### PR TITLE
XIVY-16725 Table global filter values 

### DIFF
--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/IntermediateEventBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/IntermediateEventBean.java
@@ -21,6 +21,7 @@ public class IntermediateEventBean {
 
   private List<IntermediateEvent> beans;
   private IntermediateEvent selected;
+  private String filter;
 
   public IntermediateEventBean() {
     refresh();
@@ -41,6 +42,14 @@ public class IntermediateEventBean {
 
   public List<IntermediateEvent> getBeans() {
     return beans;
+  }
+
+  public String getFilter() {
+    return filter;
+  }
+
+  public void setFilter(String filter) {
+    this.filter = filter;
   }
 
   public IntermediateEvent getSelected() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/StartEventBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/StartEventBean.java
@@ -21,6 +21,7 @@ public class StartEventBean {
 
   private List<StartEvent> beans;
   private StartEvent selected;
+  private String filter;
 
   public StartEventBean() {
     refresh();
@@ -41,6 +42,14 @@ public class StartEventBean {
 
   public List<StartEvent> getBeans() {
     return beans;
+  }
+
+  public String getFilter() {
+    return filter;
+  }
+
+  public void setFilter(String filter) {
+    this.filter = filter;
   }
 
   public StartEvent getSelected() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
@@ -20,6 +20,7 @@ public class HealthBean {
   private final List<Check> checks;
   private List<Message> messages;
   private String check;
+  private String filter;
 
   public HealthBean() {
     checks = checker.checks().stream().map(Check::new).collect(Collectors.toList());
@@ -93,6 +94,14 @@ public class HealthBean {
 
   public List<Check> getChecks() {
     return checks;
+  }
+
+  public String getFilter() {
+    return filter;
+  }
+
+  public void setFilter(String filter) {
+    this.filter = filter;
   }
 
   public String getCheck() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ThreadBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ThreadBean.java
@@ -60,6 +60,10 @@ public class ThreadBean {
     return f;
   }
 
+  public void setFilter(String filter) {
+    this.filter = filter;
+  }
+
   public void refresh() {
     isCpuEnabled = threadMxBean().isThreadCpuTimeSupported() && threadMxBean().isThreadCpuTimeEnabled();
     deadLocked = threadMxBean().findDeadlockedThreads();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/RoleDetailBean.java
@@ -52,6 +52,7 @@ public class RoleDetailBean {
   private RoleDataModel roleDataModel;
   private List<Role> membersOfRole;
   private List<Role> filteredMembers;
+  private String membersFilter;
 
   private MemberProperty roleProperties;
 
@@ -326,6 +327,14 @@ public class RoleDetailBean {
 
   public void setFilteredMembers(List<Role> filteredMembers) {
     this.filteredMembers = filteredMembers;
+  }
+
+  public String getMembersFitler() {
+    return membersFilter;
+  }
+
+  public void setMembersFitler(String membersFilter) {
+    this.membersFilter = membersFilter;
   }
 
   public void addMember() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdministratorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/AdministratorBean.java
@@ -16,6 +16,7 @@ import ch.ivyteam.ivy.security.administrator.AdministratorService;
 @ViewScoped
 public class AdministratorBean extends StepStatus {
   private final List<User> admins;
+  private String filter;
   private User editAdmin;
 
   public AdministratorBean() {
@@ -30,6 +31,14 @@ public class AdministratorBean extends StepStatus {
 
   public List<User> getAdmins() {
     return admins;
+  }
+
+  public String getFilter() {
+    return filter;
+  }
+
+  public void setFilter(String filter) {
+    this.filter = filter;
   }
 
   public void setAdmin(User admin) {

--- a/engine-cockpit/webContent/includes/components/security/roledetail-members.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-members.xhtml
@@ -29,7 +29,7 @@
       <f:facet name="header">
         <div class="ui-input-icon-left filter-container">
           <i class="pi pi-search"/>
-          <p:inputText onkeyup="PF('membersOfRoleTable').filter()" placeholder="Search" id="globalFilter" />
+          <p:inputText onkeyup="PF('membersOfRoleTable').filter()" placeholder="Search" id="globalFilter" value="#{roleDetailBean.membersFitler}" />
         </div>
       </f:facet>
       

--- a/engine-cockpit/webContent/resources/composite/Administrators.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Administrators.xhtml
@@ -12,7 +12,7 @@
       <f:facet name="header">
         <div class="ui-input-icon-left filter-container">
           <i class="pi pi-search"/>
-          <p:inputText id="globalFilter" onkeyup="PF('adminTable').filter()" placeholder="Search" />
+          <p:inputText id="globalFilter" onkeyup="PF('adminTable').filter()" value="#{administratorBean.filter}" placeholder="Search" />
         </div>
       </f:facet>
       

--- a/engine-cockpit/webContent/view/monitor-health-checks.xhtml
+++ b/engine-cockpit/webContent/view/monitor-health-checks.xhtml
@@ -46,7 +46,7 @@
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
                 <i class="pi pi-search"/>
-                <p:inputText id="globalFilter" onkeyup="PF('checkTable').filter()" placeholder="Search"/>
+                <p:inputText id="globalFilter" onkeyup="PF('checkTable').filter()" value="#{healthBean.filter}" placeholder="Search"/>
               </div>
             </f:facet>
              <p:column width="7%" headerText="Severity" filterBy="#{check.severity}" sortBy="#{check.severity}" sortOrder="desc">

--- a/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
@@ -38,7 +38,7 @@
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
                 <i class="pi pi-search"/>
-                <p:inputText id="globalFilter" onkeyup="PF('beanTable').filter()" placeholder="Search" />
+                <p:inputText id="globalFilter" onkeyup="PF('beanTable').filter()" value="#{intermediateEventBean.filter}" placeholder="Search" />
               </div>
             </f:facet>
 

--- a/engine-cockpit/webContent/view/monitorStartEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorStartEvents.xhtml
@@ -41,7 +41,7 @@
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
                 <i class="pi pi-search"/>
-                <p:inputText id="globalFilter" onkeyup="PF('beanTable').filter()" placeholder="Search"/>
+                <p:inputText id="globalFilter" onkeyup="PF('beanTable').filter()" value="#{startEventBean.filter}" placeholder="Search"/>
               </div>
             </f:facet>
 

--- a/engine-cockpit/webContent/view/monitorThreads.xhtml
+++ b/engine-cockpit/webContent/view/monitorThreads.xhtml
@@ -45,10 +45,10 @@
                 <f:facet name="header">
                   <div class="ui-input-icon-left filter-container">
                     <i class="pi pi-search"/>
-                    <p:inputText id="globalFilter" onkeyup="PF('threadTable').filter()" placeholder="Search"/>
+                    <p:inputText id="globalFilter" onkeyup="PF('threadTable').filter()" value="#{threadBean.filter}" placeholder="Search"/>
                   </div>
                 </f:facet>
-                <p:column headerText="Id" sortBy="#{thread.id}" filterBy="#{thread.id}" width="5%">              
+                <p:column headerText="Id" sortBy="#{thread.id}" filterBy="#{thread.id}" width="5%">
                   <p:commandLink oncomplete="PF('threadDialog').show();" title="Thread Detail" action="#{threadBean.setSelected(thread)}" update="threadDialog">
                     <i class="pr-3 si si-synchronize-arrow-clock"></i>
                     <h:outputText value="#{thread.id}"/>

--- a/engine-cockpit/webContent/view/searchindex.xhtml
+++ b/engine-cockpit/webContent/view/searchindex.xhtml
@@ -37,7 +37,7 @@
             globalFilter="#{searchIndexBean.filter}" id="docTable">
             <f:facet name="header">
               <div class="flex align-items-center justify-content-between">
-                <p:inputText id="globalFilter" onkeyup="PF('docTable').filter()" style="width:100%;" />
+                <p:inputText id="globalFilter" value="#{searchIndexBean.filter}" onkeyup="PF('docTable').filter()" style="width:100%;" />
               </div>
             </f:facet>
 


### PR DESCRIPTION
An input with no value will be logged with e.g: 
```
[2025-04-07 08:43:57.718][WARN ][javax.faces.validator.BeanValidator][https-jsse-nio-8443-exec-11]{client=81.10.214.99, executionContext=SYSTEM, requestId=1-67f3904d-12c1a90a523b7c2d2e9de292, securityContext=system, session=1 admin}
cannot validate component with empty value: form:beanTable:globalFilter
```

Since myFaces v2.3 this only will be logged in Dev Stage. As we are still on v2.2 this is still fills our log.

Maybe another solution would be to patch the BeanValidator class via our osgi patcher stuff...