### PR TITLE
XIVY-16766 Fix clickareas of buttons and linkButtons

### DIFF
--- a/engine-cockpit/webContent/includes/components/application/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/information.xhtml
@@ -11,10 +11,10 @@
         <h6 class="m-0">Application information</h6>
         <p:linkButton id="home" title="Application Home" icon="si si-house-chimney-2"
           href="#{applicationDetailBean.application.homeUrl}" disabled="#{applicationDetailBean.application.disabled}"
-          styleClass="col-fixed ml-auto rounded-button"/>
+          styleClass="flex-shrink-0 ml-auto rounded-button"/>
         <p:linkButton id="workflow" title="Workflow UI" icon="si si-layout-bullets" 
           href="#{applicationDetailBean.application.devWorkflowUrl}" disabled="#{applicationDetailBean.application.disabled}"
-          styleClass="col-fixed ml-1 rounded-button"/>
+          styleClass="flex-shrink-0 ml-1 rounded-button"/>
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/components/application/security.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/security.xhtml
@@ -10,7 +10,7 @@
         <i class="pr-3 si si-lock-1"></i>
         <h6 class="m-0">Security System</h6>
         <p:commandButton id="moveApplication" title="Change Security System" type="button" icon="si si-pencil" onclick="PF('moveApplicationModal').show();"
-          styleClass="col-fixed ml-auto rounded-button">
+          styleClass="flex-shrink-0 ml-auto rounded-button">
             <p:ajax listener="#{moveApplicationBean.setApp(applicationDetailBean.application)}" update="moveApplicationForm" />
         </p:commandButton>
         <p:commandButton id="synchronizeSecurity"

--- a/engine-cockpit/webContent/includes/components/application/state.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/state.xhtml
@@ -11,15 +11,15 @@
         <h6 class="m-0">Activity</h6>
         
         <p:commandButton id="activateApplication" title="Activate" type="button" icon="si si-controls-play"
-          disabled="#{applicationDetailBean.application.notStartable}" styleClass="col-fixed ml-auto ui-button-success rounded-button">
+          disabled="#{applicationDetailBean.application.notStartable}" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.activate}" update="@form" />
         </p:commandButton>
         <p:commandButton id="deActivateApplication" title="Deactivate" type="button" icon="si si-controls-stop"
-          disabled="#{applicationDetailBean.application.notStopable}" styleClass="col-fixed ml-1 ui-button-danger rounded-button">
+          disabled="#{applicationDetailBean.application.notStopable}" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.deactivate}" update="@form" />
         </p:commandButton>
         <p:commandButton id="lockApplication" title="Lock" type="button" icon="si si-lock-1"
-          disabled="#{applicationDetailBean.application.notLockable}" styleClass="col-fixed ml-1 ui-button-warning rounded-button">
+          disabled="#{applicationDetailBean.application.notLockable}" styleClass="flex-shrink-0 ml-1 ui-button-warning rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.lock}" update="@form" />
         </p:commandButton>
       </div>

--- a/engine-cockpit/webContent/includes/components/configuration/ssl-keystore.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/ssl-keystore.xhtml
@@ -18,7 +18,7 @@
         <i class="pr-3 si si-information-circle"></i>
         <h6 class="m-0">Key Store configurations</h6>
         <p:commandButton title="Save" icon="si si-floppy-disk" id="save"
-          styleClass="col-fixed ml-auto ml-1 ui-button-success rounded-button"
+          styleClass="flex-shrink-0 ml-auto ml-1 ui-button-success rounded-button"
           actionListener="#{keyStoreBean.saveKeyStore}" />
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/configuration/ssl-truststore.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/ssl-truststore.xhtml
@@ -19,7 +19,7 @@
         <i class="pr-3 si si-information-circle"></i>
         <h6 class="m-0">Trust Store configurations</h6>
         <p:commandButton title="Save" icon="si si-floppy-disk" id="save"
-          styleClass="col-fixed ml-auto ml-1 ui-button-success rounded-button"
+          styleClass="flex-shrink-0 ml-auto ml-1 ui-button-success rounded-button"
           actionListener="#{trustStoreBean.saveTrustStore}" />
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/dashboard/health.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/health.xhtml
@@ -10,9 +10,9 @@
         <i class="pr-3 si si-road-sign-warning"></i>
         <h6 class="m-0" style="margin: 0; padding-left: 0">Health</h6>
         <p:linkButton id="detail" title="Health Details" type="button" href="monitor-health.xhtml"
-           icon="si si-road-sign-warning" styleClass="col-fixed ml-auto ui-button-secondary rounded-button" />
+           icon="si si-road-sign-warning" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="runCheck" title="Run Health Checks" action="#{healthBean.checkNow()}"
-            update="healthForm" icon="si si-controls-play" styleClass="col-fixed ml-1 ui-button-secondary rounded-button" />
+            update="healthForm" icon="si si-controls-play" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
       </div>
     </div>
     <p:panelGrid id="content" columns="2" layout="flex" columnClasses="col-12 md:col-4 lg:col-4, col-12 md:col-8 lg:col-8"

--- a/engine-cockpit/webContent/includes/components/dashboard/java.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/java.xhtml
@@ -9,7 +9,7 @@
       <i class="pr-3 si si-information-circle"></i>
       <h6 class="m-0" style="margin: 0; padding-left: 0">Java</h6>
       <p:commandButton id="tasksButtonJavaDetail" onclick="PF('javaDetailDialog').show();" title="Java Details" type="button"
-        icon="si si-information-circle" styleClass="col-fixed ml-auto ui-button-secondary rounded-button" />
+        icon="si si-information-circle" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
     </div>
   </div>
   <p:panelGrid columns="2" layout="flex" columnClasses="col-12 md:col-4 lg:col-4, col-12 md:col-8 lg:col-8"

--- a/engine-cockpit/webContent/includes/components/security/member-properties.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/member-properties.xhtml
@@ -12,7 +12,7 @@
         <h6 class="m-0">Properties</h6>
         <p:commandButton id="newPropertyBtn" oncomplete="PF('propertyModal').show();" process="@this"
           actionListener="#{memberProperty.setProperty(null)}" update="propertyModalForm:propertyModal" title="Add"
-          icon="si si-add" styleClass="col-fixed ml-auto rounded-button" />
+          icon="si si-add" styleClass="flex-shrink-0 ml-auto rounded-button" />
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/components/security/permissions.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/permissions.xhtml
@@ -24,7 +24,7 @@
       </span>
       <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
         actionListener="#{permissionBean.collapseAllNodes}" update="permissionTable" title="Collapse all"
-        styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined" />
+        styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
     </div>
     <p:treeTable id="permissionTable" value="#{permissionBean.tree}" var="permission">
       <p:ajax event="expand" listener="#{permissionBean.nodeExpand}" />

--- a/engine-cockpit/webContent/includes/components/security/roledetail-information.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-information.xhtml
@@ -13,10 +13,10 @@
         <i class="pr-3 si si-information-circle"></i>
         <h6 class="m-0">Role information</h6>
         <p:commandButton id="createNewChildRole" type="button" onclick="PF('newChildRoleModal').show()"
-          title="Add new child role" icon="si si-add" styleClass="col-fixed ml-auto rounded-button" />
+          title="Add new child role" icon="si si-add" styleClass="flex-shrink-0 ml-auto rounded-button" />
         <p:commandButton id="deleteRole" rendered="#{roleDetailBean.canDeleteRole()}" type="button"
           onclick="PF('deleteRoleConfirmDialog').show()" title="Delete this role" icon="si si-bin-1"
-          styleClass="col-fixed ml-1 ui-button-danger rounded-button" />
+          styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
         <p:confirmDialog id="deleteRoleConfirmDialog"
           message="Are you sure you want to delete the role '#{roleDetailBean.name}'?" header="Delete Role" severity="alert"
           widgetVar="deleteRoleConfirmDialog">
@@ -27,7 +27,7 @@
             action="#{roleDetailBean.deleteRole}" styleClass="modal-input-button" icon="si si-bin-1" />
         </p:confirmDialog>
         <p:commandButton id="saveRoleInformation" actionListener="#{roleDetailBean.saveRoleInfos}" title="Save changes"
-          icon="si si-floppy-disk" styleClass="col-fixed ml-1 ui-button-success rounded-button" update="usersOfRoleForm" />
+          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" update="usersOfRoleForm" />
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/components/security/roledetail-members.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-members.xhtml
@@ -21,7 +21,7 @@
         placeholder="Search role to add" />
       <p:commandButton id="addMemberToRoleBtn" update="membersOfRoleForm" actionListener="#{roleDetailBean.addMember}"
         icon="si si-add" title="Add" 
-        styleClass="ml-1 col-fixed rounded-button" />
+        styleClass="ml-1 flex-shrink-0 rounded-button" />
     </div>
     <p:dataTable id="roleMemberTable" value="#{roleDetailBean.membersOfRole}" widgetVar="membersOfRoleTable" var="member"
       filteredValue="#{roleDetailBean.filteredMembers}" lazy="false" paginator="true" rows="10" paginatorPosition="bottom"

--- a/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
@@ -23,7 +23,7 @@
           placeholder="Search user to add" disabled="#{roleDetailBean.managed}" />
         <p:commandButton id="addUserToRoleBtn" update="usersOfRoleForm" actionListener="#{roleDetailBean.addUser}"
           icon="si si-add" title="Add" disabled="#{roleDetailBean.managed}" 
-          styleClass="ml-1 col-fixed rounded-button" />
+          styleClass="ml-1 flex-shrink-0 rounded-button" />
       </div>
       <p:dataTable id="roleUserTable" value="#{roleDetailBean.usersOfRole}" widgetVar="usersOfRoleTable" var="user"
         lazy="true" paginator="true" rows="10" paginatorPosition="bottom" paginatorAlwaysVisible="false"
@@ -36,7 +36,7 @@
             </span>
             
             <p:commandButton id="filterBtn" title="Filter: #{roleDetailBean.usersOfRole.contentFilterText}" type="button" icon="si si-filter-1"
-              styleClass="ml-1 col-fixed ui-button-secondary rounded-button" onclick="PF('filterPanel').show();" />
+              styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button" onclick="PF('filterPanel').show();" />
             <p:overlayPanel id="filterPanel" for="filterBtn" widgetVar="filterPanel" styleClass="table-content-filter">
               <p:selectManyCheckbox id="filterCheckboxes" layout="grid" columns="1" value="#{roleDetailBean.usersOfRole.selectedContentFilters}">
                 <f:selectItems value="#{roleDetailBean.usersOfRole.contentFilters}"/>

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-info.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-info.xhtml
@@ -14,14 +14,14 @@
         <i class="pr-3 si si-information-circle"></i>
         <h6 class="m-0">Security System</h6>
         <p:commandButton id="downloadSecurityReport" title="Download Security Report" icon="si si-office-file-xls-1"
-          styleClass="col-fixed ml-auto rounded-button" onclick="PF('securityReportDownloadModal').show();"/>
+          styleClass="flex-shrink-0 ml-auto rounded-button" onclick="PF('securityReportDownloadModal').show();"/>
         <p:linkButton outcome="securitysystem-merge.xhtml" id="compareSecuritySystemBtn" type="button" 
-                title="Merge Security Systems" icon="si si-move-to-bottom" styleClass="col-fixed ml-1 rounded-button">
+                title="Merge Security Systems" icon="si si-move-to-bottom" styleClass="flex-shrink-0 ml-1 rounded-button">
           <f:param name="source" value="#{securityConfigBean.name}"/>
         </p:linkButton>
         
         <p:commandButton id="deleteSecuritySystem" type="button" onclick="PF('deleteSecuritySystemConfirmDialog').show()"
-              title="Delete this security system" icon="si si-bin-1" styleClass="col-fixed ml-1 ui-button-danger rounded-button" />
+              title="Delete this security system" icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
         <p:confirmDialog id="deleteSecuritySystemConfirmDialog"
           message="#{securityConfigBean.notToDeleteReason}"
           header="Delete Security System" severity="alert" widgetVar="deleteSecuritySystemConfirmDialog">

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-language.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-language.xhtml
@@ -13,7 +13,7 @@
         <i class="pr-3 si si-conversation-chat-2"></i>
         <h6 class="m-0">Languages</h6>
         <p:commandButton title="Save" icon="si si-floppy-disk" id="saveLanguageConfigBtn"
-              styleClass="col-fixed ml-auto ui-button-success rounded-button" actionListener="#{securityConfigBean.saveLanguages}"/>
+              styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" actionListener="#{securityConfigBean.saveLanguages}"/>
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-workflow-language.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-workflow-language.xhtml
@@ -11,7 +11,7 @@
         <h6 class="m-0">Workflow Languages</h6>
         <p:commandButton id="addBtn" oncomplete="PF('addWorkflowLanguageModal').show();" process="@this"
           update="securityWorkflowLanguageForm" title="Add a new language"
-          icon="si si-add" styleClass="col-fixed ml-auto rounded-button" disabled="#{empty securityWorkflowLanguageBean.addable}"/>
+          icon="si si-add" styleClass="flex-shrink-0 ml-auto rounded-button" disabled="#{empty securityWorkflowLanguageBean.addable}"/>
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/components/security/userdetail-information.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-information.xhtml
@@ -13,17 +13,17 @@
         <i class="pr-3 si si-information-circle"></i>
         <h6 class="m-0">User information</h6>
         <p:commandButton title="Synch" id="userSynchBtn" rendered="#{!userDetailBean.ivySecuritySystem}" type="button"
-          icon="si si-button-refresh-arrows" styleClass="col-fixed ml-auto ui-button-secondary rounded-button" onclick="PF('synchUserModal').show()" />
+          icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" onclick="PF('synchUserModal').show()" />
 
         <h:panelGroup rendered="#{!userDetailBean.user.external or userDetailBean.ivySecuritySystem}">
           <p:commandButton id="disableUser" actionListener="#{userDetailBean.disableUser}" title="Disable this user"
-            styleClass="p-col-fixed ml-#{!userDetailBean.ivySecuritySystem ? '1' : 'auto'} ui-button-warning rounded-button"
+            styleClass="p-flex-shrink-0 ml-#{!userDetailBean.ivySecuritySystem ? '1' : 'auto'} ui-button-warning rounded-button"
             icon="si si-delete" update="userInformationForm"  rendered="#{userDetailBean.isUserEnabled()}" />
           <p:commandButton id="enableUser" actionListener="#{userDetailBean.enableUser}" title="Enable this user"
-            styleClass="p-col-fixed ml-#{!userDetailBean.ivySecuritySystem ? '1' : 'auto'} rounded-button" 
+            styleClass="p-flex-shrink-0 ml-#{!userDetailBean.ivySecuritySystem ? '1' : 'auto'} rounded-button" 
             icon="si si-check-circle-1" update="userInformationForm" rendered="#{userDetailBean.isUserDisabled()}" />
           <p:commandButton id="deleteUser" type="button" onclick="PF('deleteUserConfirmDialog').show()"
-            title="Delete this user" icon="si si-bin-1" styleClass="col-fixed ml-1 ui-button-danger rounded-button" />
+            title="Delete this user" icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
           <p:confirmDialog id="deleteUserConfirmDialog" header="Delete User" severity="alert"
             widgetVar="deleteUserConfirmDialog" message="#{userDetailBean.userDeleteHint()}">
             <p:commandButton value="Cancel" onclick="PF('deleteUserConfirmDialog').hide();" type="button"
@@ -36,7 +36,7 @@
           </p:confirmDialog>
         </h:panelGroup>
         <p:commandButton id="saveUserInformation" actionListener="#{userDetailBean.saveUserInfos}" title="Save changes"
-          icon="si si-floppy-disk" styleClass="col-fixed ml-1 ui-button-success rounded-button" />
+          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" />
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
@@ -14,9 +14,9 @@
         <h6 class="m-0">Notification Channels</h6>
       </div>
       <p:commandButton id="reset" actionListener="#{userDetailBean.notificationChannels.reset}" title="Reset to default"
-        icon="si si-undo" styleClass="col-fixed ml-auto ui-button-danger rounded-button" update="notificationsForm" />
+        icon="si si-undo" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" update="notificationsForm" />
       <p:commandButton id="save" actionListener="#{userDetailBean.notificationChannels.save}" title="Save changes"
-        icon="si si-floppy-disk" styleClass="col-fixed ml-1 ui-button-success rounded-button" />
+        icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" />
     </div>
     
     <p:dataTable paginator="true" rows="10" paginatorPosition="bottom" paginatorAlwaysVisible="false"

--- a/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
@@ -24,10 +24,10 @@
       </span>
       <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
         actionListener="#{userDetailBean.roles.expandAllNodes}" update="rolesTree" title="Expand all"
-        styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined expand-all" />
+        styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
       <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
         actionListener="#{userDetailBean.roles.collapseAllNodes}" update="rolesTree" title="Collapse all"
-        styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined" />
+        styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
     </div>
     <p:treeTable id="rolesTree" value="#{userDetailBean.roles.tree}" var="role" nodeVar="node">
       <p:ajax event="expand" listener="#{userDetailBean.roles.nodeExpand}" />

--- a/engine-cockpit/webContent/includes/components/security/users-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/users-table.xhtml
@@ -15,7 +15,7 @@
           <p:inputText id="globalFilter" onkeyup="PF('usersTable_#{app.id}').filter()" placeholder="Search" value="#{userBean.userDataModel.filter}" />
         </span>
         <p:commandButton id="filterBtn" title="Filter: #{userBean.userDataModel.contentFilterText}" type="button" icon="si si-filter-1"
-          styleClass="ml-1 col-fixed ui-button-secondary rounded-button" onclick="PF('filterPanel_#{securitySystem.id}').show();" />
+          styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button" onclick="PF('filterPanel_#{securitySystem.id}').show();" />
         <p:overlayPanel id="filterPanel" for="filterBtn" widgetVar="filterPanel_#{securitySystem.id}" styleClass="table-content-filter">
           <p:selectManyCheckbox id="filterCheckboxes" layout="grid" columns="1" value="#{userBean.userDataModel.selectedContentFilters}">
             <f:selectItems value="#{userBean.userDataModel.contentFilters}"/>

--- a/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
@@ -16,9 +16,9 @@
         <p:commandButton id="testDatabaseBtn" title="Test Database Connection" update="connResult:connectionTestModel"
           oncomplete="PF('connectionTestModel').show()" icon="si si-phone-actions-call"
           actionListener="#{tlsTesterBean.setTlsTestRendered(false)}"
-          styleClass="col-fixed ml-auto ui-button-secondary rounded-button" />
+          styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetDbConfirmDialog').show()"
-          title="Reset configuration" icon="si si-undo" styleClass="col-fixed ml-1 ui-button-danger rounded-button" />
+          title="Reset configuration" icon="si si-undo" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
         <p:confirmDialog id="resetDbConfirmDialog" message="Are you sure you want to reset this Database?"
           header="Reset Database" severity="alert" widgetVar="resetDbConfirmDialog">
           <p:commandButton value="Cancel" onclick="PF('resetDbConfirmDialog').hide();" type="button"
@@ -28,7 +28,7 @@
             styleClass="modal-input-button" />
         </p:confirmDialog>
         <p:commandButton id="saveDatabaseConfig" actionListener="#{databaseDetailBean.saveDbConfig}"
-          title="Save changes" icon="si si-floppy-disk" styleClass="col-fixed ml-1 ui-button-success rounded-button"
+          title="Save changes" icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"
           update="@form, connResult:connectionTestModel" />
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
@@ -16,9 +16,9 @@
         <p:commandButton id="testRestBtn" title="Test Rest Connection" oncomplete="PF('connectionTestModel').show()"
           icon="si si-phone-actions-call" update="restClientAdditionalConfigForm, connResult:connectionTestModel"
           actionListener="#{tlsTesterBean.setTlsTestRendered(false)}"
-          styleClass="col-fixed ml-auto ui-button-secondary rounded-button" />
+          styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetRestConfirmDialog').show()"
-          title="Reset configuration" icon="si si-undo" styleClass="col-fixed ml-1 ui-button-danger rounded-button" />
+          title="Reset configuration" icon="si si-undo" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
         <p:confirmDialog id="resetRestConfirmDialog" message="Are you sure you want to reset this Rest Client?"
           header="Reset Rest Client" severity="alert" widgetVar="resetRestConfirmDialog">
           <p:commandButton value="Cancel" onclick="PF('resetRestConfirmDialog').hide();" type="button"
@@ -27,7 +27,7 @@
             icon="si si-undo" update="@form, restClientAdditionalConfigForm" styleClass="modal-input-button" />
         </p:confirmDialog>
         <p:commandButton id="saveRestConfig" actionListener="#{restClientDetailBean.saveConfig}" title="Save changes"
-          icon="si si-floppy-disk" styleClass="col-fixed ml-1 ui-button-success rounded-button"
+          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"
           update="@form, restClientAdditionalConfigForm, connResult:connectionTestModel" />
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/webservice-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/webservice-configuration.xhtml
@@ -14,7 +14,7 @@
         <i class="pr-3 si si-information-circle"></i>
         <h6 class="m-0">Web Service configurations</h6>
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetWsConfirmDialog').show()"
-          title="Reset configuration" icon="si si-undo" styleClass="col-fixed ml-auto ui-button-danger rounded-button" />
+          title="Reset configuration" icon="si si-undo" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" />
         <p:confirmDialog id="resetWsConfirmDialog" message="Are you sure you want to reset this Web Service?"
           header="Reset Web Service" severity="alert" widgetVar="resetWsConfirmDialog">
           <p:commandButton value="Cancel" onclick="PF('resetWsConfirmDialog').hide();" type="button"
@@ -23,7 +23,7 @@
             icon="si si-undo" update="@form, webserviceAdditionalConfigForm, webservcieEndPointForm" styleClass="modal-input-button" />
         </p:confirmDialog>
         <p:commandButton id="saveWsConfig" actionListener="#{webserviceDetailBean.saveConfig}" title="Save changes"
-          icon="si si-floppy-disk" styleClass="col-fixed ml-1 ui-button-success rounded-button" update="@form, webserviceAdditionalConfigForm, webservcieEndPointForm" />
+          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" update="@form, webserviceAdditionalConfigForm, webservcieEndPointForm" />
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
@@ -15,7 +15,7 @@
               <h:outputText styleClass="text-sm name" value="#{event.timestamp}" style="color: var(--text-color-secondary);" />
               <h:outputText styleClass="message" value="#{event.message}" />
             </div>
-            <p:commandButton icon="si si-check-1" title="Confirm" styleClass="col-fixed ml-auto ui-button-secondary rounded-button ui-button-outlined"
+            <p:commandButton icon="si si-check-1" title="Confirm" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button ui-button-outlined"
               id="confirmEventBtn" actionListener="#{licenceBean.confirmLicenceEvent(event)}" update="@form" />
           </li>
         </ui:repeat>

--- a/engine-cockpit/webContent/resources/composite/Bean.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Bean.xhtml
@@ -14,9 +14,9 @@
         <i class="pr-3 si si-cog"></i>
         <h6 class="m-0">Bean</h6>
         <p:commandButton id="start" title="Starts the bean" icon="si si-controls-play"
-            action="#{cc.attrs.event.start()}" update="@form" styleClass="col-fixed ml-auto ui-button-success rounded-button" disabled="#{cc.attrs.event.running}"/>
+            action="#{cc.attrs.event.start()}" update="@form" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{cc.attrs.event.running}"/>
         <p:commandButton id="stop" title="Stops the bean" icon="si si-controls-stop"
-            action="#{cc.attrs.event.stop()}" update="@form" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{!cc.attrs.event.running}"/>
+            action="#{cc.attrs.event.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{!cc.attrs.event.running}"/>
       </div>
     </div>
     

--- a/engine-cockpit/webContent/resources/composite/Configuration.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Configuration.xhtml
@@ -22,7 +22,7 @@
             <p:inputText id="globalFilter" onkeyup="PF('configTable').filter()" placeholder="Search" value="#{cc.attrs.bean.filter}" />
           </span>
           <p:commandButton id="filterBtn" title="Filter: #{cc.attrs.bean.contentFilterText}" type="button" icon="si si-filter-1"
-            styleClass="ui-button-secondary rounded-button ml-1 col-fixed" onclick="PF('filterPanel').show();"
+            styleClass="ui-button-secondary rounded-button ml-1 flex-shrink-0" onclick="PF('filterPanel').show();"
             rendered="#{cc.attrs.showContentFilter}" />
         </div>
       </f:facet>
@@ -43,11 +43,11 @@
       </p:column>
       <p:column styleClass="table-btn-2">
         <p:commandButton id="editConfigBtn" icon="si si-pencil" title="Edit"
-          styleClass="col-fixed ml-1 ui-button-secondary rounded-button" process="@this"
+          styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" process="@this"
           actionListener="#{cc.attrs.bean.setActiveConfig(config.key)}" update=":#{cc.clientId}:editConfigurationModal"
           oncomplete="PF('editConfigurationModal').show();" />
         <p:commandButton title="More" id="tasksButton" disabled="#{config.default}" type="button"
-          icon="si si-navigation-menu" styleClass="col-fixed ml-1 ui-button-secondary ui-button-outlined rounded-button" />
+          icon="si si-navigation-menu" styleClass="flex-shrink-0 ml-1 ui-button-secondary ui-button-outlined rounded-button" />
         <p:menu overlay="true" trigger="tasksButton" my="right top" at="right bottom" id="activityMenu">
           <p:menuitem value="View File" icon="si si-common-file-search"
             oncomplete="PF('showConfigurationFileModal').show()"

--- a/engine-cockpit/webContent/resources/composite/DynamicConfig.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DynamicConfig.xhtml
@@ -25,7 +25,7 @@
 
               <p:commandButton title="Save" icon="si si-floppy-disk"
                 id="save"
-                styleClass="col-fixed ml-auto ml-1 ui-button-success rounded-button"
+                styleClass="flex-shrink-0 ml-auto ml-1 ui-button-success rounded-button"
                 rendered="#{!group.keyValue}"
                 actionListener="#{cc.attrs.dynamicConfig.save(group)}" />
 
@@ -36,7 +36,7 @@
                 process="@this"
                 update="identityProvider:dynamicConfigKeyValueForm"
                 title="Add" icon="si si-add"
-                styleClass="col-fixed ml-auto rounded-button" />
+                styleClass="flex-shrink-0 ml-auto rounded-button" />
 
             </div>
           </div>

--- a/engine-cockpit/webContent/resources/composite/Error.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Error.xhtml
@@ -9,7 +9,7 @@
 <cc:implementation>
   <h:panelGroup styleClass="flex justify-content-between #{cc.attrs.styleClass}">
     <h:outputText id="message" value="#{cc.attrs.error.message}" />
-    <p:commandButton id="showDetails" rendered="#{cc.attrs.error.available}" icon="si si-navigation-menu-horizontal" styleClass="ml-1 col-fixed rounded-button" title="Show full error" 
+    <p:commandButton id="showDetails" rendered="#{cc.attrs.error.available}" icon="si si-navigation-menu-horizontal" styleClass="ml-1 flex-shrink-0 rounded-button" title="Show full error" 
         update="errorDialog" action="#{errorBean.setSelected(cc.attrs.error)}" oncomplete="PF('errorDialog').show();"/>
   </h:panelGroup>
 </cc:implementation>

--- a/engine-cockpit/webContent/resources/composite/FeatureEditor.xhtml
+++ b/engine-cockpit/webContent/resources/composite/FeatureEditor.xhtml
@@ -17,20 +17,20 @@
     icon="si si-pencil" title="Edit" disabled="#{feature.default}"
     update="@form" rendered="#{!cc.attrs.isNewFeature}"
     oncomplete="PF('featureModal').show();" process="@this" 
-    styleClass="col-fixed ml-1 ui-button-secondary rounded-button" />
+    styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
 
   <p:commandButton id="deleteFeatureBtn" disabled="#{feature.default}"
     actionListener="#{cc.attrs.bean.removeFeature(feature.clazz)}"
     update="#{cc.attrs.formName}" icon="si si-bin-1" title="Delete"
     rendered="#{!cc.attrs.isNewFeature}" process="@this"
-    styleClass="col-fixed ml-1 ui-button-danger rounded-button" />
+    styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
 
   <p:commandButton id="newServiceFeatureBtn"
     oncomplete="PF('featureModal').show();" process="@this"
     actionListener="#{cc.attrs.bean.setFeature(null)}"
     update="featureModal" title="Add" icon="si si-add"
     rendered="#{cc.attrs.isNewFeature}"
-    styleClass="col-fixed ml-auto rounded-button" />
+    styleClass="flex-shrink-0 ml-auto rounded-button" />
 
   <p:dialog header="Feature" style="text-align: left;" id="featureModal"
     widgetVar="featureModal" modal="true" responsive="true"

--- a/engine-cockpit/webContent/resources/composite/Poll.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Poll.xhtml
@@ -14,7 +14,7 @@
           <i class="pr-3 si si-time-clock-circle"></i>
           <h6 class="m-0">Poll</h6>
           <p:commandButton id="pollBtn" oncomplete="PF('pollBeanDialog').show();" title="Schedule to poll the bean now" icon="si si-synchronize-arrow-clock"
-              update="polls" styleClass="col-fixed ml-auto rounded-button" />
+              update="polls" styleClass="flex-shrink-0 ml-auto rounded-button" />
         </div>
       </div>
       

--- a/engine-cockpit/webContent/resources/composite/PropertyEditor.xhtml
+++ b/engine-cockpit/webContent/resources/composite/PropertyEditor.xhtml
@@ -13,18 +13,18 @@
     actionListener="#{cc.attrs.bean.setProperty(property.name)}"
     icon="si si-pencil" title="Edit"
     update="propertyModal" rendered="#{!cc.attrs.isNewProperty}"
-    styleClass="col-fixed ml-1 ui-button-secondary rounded-button"
+    styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button"
     oncomplete="PF('propertyModal').show();" process="@this" />
   <p:commandButton id="deletePropertyBtn" disabled="#{property.default}"
     actionListener="#{cc.attrs.bean.removeProperty(property.name)}"
     update="#{cc.attrs.formName}" icon="si si-bin-1" title="Delete"
     rendered="#{!cc.attrs.isNewProperty}" process="@this"
-    styleClass="col-fixed ml-1 ui-button-danger rounded-button" />
+    styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
   <p:commandButton id="newServicePropertyBtn" 
     oncomplete="PF('propertyModal').show();" process="@this"
     actionListener="#{cc.attrs.bean.setProperty(null)}" update="propertyModal" 
     title="Add" icon="si si-add" rendered="#{cc.attrs.isNewProperty}"
-    styleClass="col-fixed ml-auto rounded-button" />
+    styleClass="flex-shrink-0 ml-auto rounded-button" />
 
   <p:dialog header="Property" style="text-align: left;" id="propertyModal" widgetVar="propertyModal" modal="true"
     responsive="true" closeOnEscape="true">

--- a/engine-cockpit/webContent/resources/composite/SslTable.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SslTable.xhtml
@@ -21,7 +21,7 @@
             style="display: none;" />
           <p:commandButton title="Add Certificate" icon="si si-upload-bottom"
             type="button" id="Certbtn"
-            styleClass="col-fixed ml-auto ml-1 mr-1 rounded-button"
+            styleClass="flex-shrink-0 ml-auto ml-1 mr-1 rounded-button"
             onclick="document.getElementById(this.id.replace(':Certbtn',':certUpload_input')).click(); return false;">
           </p:commandButton>
         </div>

--- a/engine-cockpit/webContent/view/applications.xhtml
+++ b/engine-cockpit/webContent/view/applications.xhtml
@@ -32,10 +32,10 @@
             </span>
             <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
               actionListener="#{applicationBean.expandAllNodes}" update="tree" title="Expand all"
-              styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined expand-all" />
+              styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
             <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
               actionListener="#{applicationBean.collapseAllNodes}" update="tree" title="Collapse all"
-              styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined" />
+              styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
           </div>
           <p:treeTable id="tree" value="#{applicationBean.tree}" var="activity">
             <p:ajax event="expand" listener="#{applicationBean.nodeExpand}" />

--- a/engine-cockpit/webContent/view/businesscalendar.xhtml
+++ b/engine-cockpit/webContent/view/businesscalendar.xhtml
@@ -34,10 +34,10 @@
               </span>
               <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
                 actionListener="#{businessCalendarBean.expandAllNodes}" update="tree" title="Expand all"
-                styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined expand-all" />
+                styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
               <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
                 actionListener="#{businessCalendarBean.collapseAllNodes}" update="tree" title="Collapse all"
-                styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined" />
+                styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
             </div>
             <p:treeTable id="tree" value="#{businessCalendarBean.tree}" var="node" styleClass="hide-head">
               <p:ajax event="expand" listener="#{businessCalendarBean.nodeExpand}" />

--- a/engine-cockpit/webContent/view/info.xhtml
+++ b/engine-cockpit/webContent/view/info.xhtml
@@ -121,7 +121,7 @@
                       <i class="si si-module icon-app" />
                     </div>
                     <div class="flex flex-1 justify-content-end">
-                      <p:linkButton href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}" icon="si si-cog-play" styleClass="col-fixed ml-auto rounded-button ui-button-outlined" />
+                      <p:linkButton href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}" icon="si si-cog-play" styleClass="flex-shrink-0 ml-auto rounded-button ui-button-outlined" />
                     </div>
                   </div>
                   

--- a/engine-cockpit/webContent/view/monitor-health-checks.xhtml
+++ b/engine-cockpit/webContent/view/monitor-health-checks.xhtml
@@ -33,7 +33,7 @@
           <i class="pr-3 si si-road-sign-warning card-title-icon"></i>
           <h2 class="m-0">Health Checks</h2>
           <p:commandButton id="refresh" actionListener="#{healthBean.refresh}" update="form" title="Refresh Health Checks"
-              icon="si si-button-refresh-arrows" styleClass="col-fixed ml-auto rounded-button"/>
+              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
           
         </div>
         <h:form id="form" style="overflow: auto;">
@@ -70,11 +70,11 @@
              
              <p:column styleClass="table-btn-3">
                <p:commandButton id="enable" title="Enable the check" icon="si si-check-circle-1"
-                 action="#{check.enable()}" update="@form" styleClass="col-fixed ml-1 ui-button-success rounded-button" disabled="#{check.enabled}"/>
+                 action="#{check.enable()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{check.enabled}"/>
                <p:commandButton id="disable" title="Disable the check" icon="si si-subtract-circle"
-                 action="#{check.disable()}" update="@form" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{! check.enabled}"/>
+                 action="#{check.disable()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{! check.enabled}"/>
                <p:commandButton id="checkNow" icon="si si-controls-play" title="Run check now"
-                 action="#{check.checkNow()}" update="@form" styleClass="col-fixed ml-1 rounded-button" disabled="#{! check.enabled}"/>
+                 action="#{check.checkNow()}" update="@form" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{! check.enabled}"/>
            </p:column>
              
           </p:dataTable>

--- a/engine-cockpit/webContent/view/monitor-health.xhtml
+++ b/engine-cockpit/webContent/view/monitor-health.xhtml
@@ -28,11 +28,11 @@
           <i class="pr-3 si si-road-sign-warning card-title-icon"></i>
           <h2 class="m-0">Health</h2>
           <p:commandButton id="run" title="Run Health Checks" action="#{healthBean.checkNow()}"
-              update="form" icon="si si-controls-play" styleClass="col-fixed ml-auto ui-button-success rounded-button" />
+              update="form" icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
           <p:commandButton id="refresh" actionListener="#{healthBean.refresh}" update="form" title="Refresh Health"
-              icon="si si-button-refresh-arrows" styleClass="col-fixed ml-1 rounded-button"/>
+              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button"/>
           <p:linkButton id="checks" title="Health Checks" type="button" href="monitor-health-checks.xhtml"
-              icon="si si-road-sign-warning" styleClass="col-fixed ml-1 ui-button-secondary rounded-button" />
+              icon="si si-road-sign-warning" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
           
         </div>
         <h:form id="form" style="overflow: auto;">

--- a/engine-cockpit/webContent/view/monitor-sessions.xhtml
+++ b/engine-cockpit/webContent/view/monitor-sessions.xhtml
@@ -30,7 +30,7 @@
                 <i class="pr-3 si si-analytics-graph-line card-title-icon"></i>
                 <h2 class="m-0">Sessions</h2>
                 <p:commandButton id="refresh" update="@form" title="Refresh statistic"
-                    icon="si si-button-refresh-arrows" styleClass="col-fixed ml-auto ui-button-success rounded-button" />
+                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
               </div>
             </div>
             <p:dataTable var="ses" value="#{sessionBean.dataModel}"
@@ -45,7 +45,7 @@
                   </div>
 
                   <p:commandButton id="filterBtn" title="Filter" type="button" icon="si si-filter-1"
-                  styleClass="ml-1 col-fixed ui-button-secondary rounded-button" onclick="PF('filterPanel').show();" />
+                  styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button" onclick="PF('filterPanel').show();" />
                   <p:overlayPanel id="filterPanel" for="filterBtn" widgetVar="filterPanel" styleClass="table-content-filter">
                     <h:panelGroup style="display:block;margin-bottom:5px;">
                       <p:selectBooleanCheckbox value="#{sessionBean.dataModel.showUnauthenticatedSessions}" id="filterUnauthenticatedSession" itemLabel="Show unauthenticated sessions" />

--- a/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
+++ b/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
@@ -29,11 +29,11 @@
                   <i class="pr-3 si si-computer-chip-search"></i>
                   <h2 class="m-0">Class Histogram</h2>
                   <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{classHistogramBean.refresh()}" title="Refresh Class Histogram" 
-                      update="@form" styleClass="col-fixed ml-auto rounded-button"/>
+                      update="@form" styleClass="flex-shrink-0 ml-auto rounded-button"/>
                   <p:commandButton id="clear" actionListener="#{classHistogramBean.clear}" update="@form" title="Clear Class Histogram"
-                      icon="si si-bin-1" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{classHistogramBean.notClearable}"/>
+                      icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{classHistogramBean.notClearable}"/>
                   <p:commandButton id="dump" update="dumpMemory" title="Dump Heap Memory" onclick="PF('dumpMemoryDialog').show();"
-                      icon="si si-download-bottom" styleClass="col-fixed ml-1 ui-button-danger rounded-button"/>
+                      icon="si si-download-bottom" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
                 </div>
               </div>
               <p:dataTable var="class" value="#{classHistogramBean.classes}" filteredValue="#{classHistogramBean.filteredClasses}"

--- a/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
@@ -27,7 +27,7 @@
           <i class="pr-3 si si-navigation-right-circle-1 card-title-icon"></i>
           <h2 class="m-0">Intermediate Events</h2>
           <p:commandButton id="refresh" actionListener="#{intermediateEventBean.refresh}" update="form" title="Refresh Start Events"
-              icon="si si-button-refresh-arrows" styleClass="col-fixed ml-auto rounded-button"/>
+              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
 
         </div>
         <h:form id="form" style="overflow: auto;" onkeypress="if (event.keyCode == 13) return false;">
@@ -79,11 +79,11 @@
 
              <p:column styleClass="table-btn-3">
               <p:commandButton id="start" title="Starts the bean" icon="si si-controls-play"
-                action="#{bean.start()}" update="@form" styleClass="col-fixed ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
+                action="#{bean.start()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
               <p:commandButton id="stop" title="Stops the bean" icon="si si-controls-stop"
-                action="#{bean.stop()}" update="@form" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{! bean.running}"/>
+                action="#{bean.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{! bean.running}"/>
               <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="Schedule to poll the bean now" icon="si si-synchronize-arrow-clock"
-                action="#{intermediateEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="col-fixed ml-1 rounded-button" />
+                action="#{intermediateEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="flex-shrink-0 ml-1 rounded-button" />
             </p:column>
           </p:dataTable>
         </h:form>

--- a/engine-cockpit/webContent/view/monitorJfr.xhtml
+++ b/engine-cockpit/webContent/view/monitorJfr.xhtml
@@ -28,8 +28,8 @@
                 <div class="card-title flex align-items-center">
                   <i class="pr-3 si si-plane-take-off"></i>
                   <h2 class="m-0">Java Flight Recorder</h2>
-                  <p:commandButton id="start" title="Start recording" onclick="PF('startRecordingDialog').show();" icon="si si-controls-play" styleClass="col-fixed ml-auto ui-button-success rounded-button"/>
-                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{jfrBean.refresh()}" update="@form startRecordingDialog" title="Refresh" styleClass="col-fixed ml-1 rounded-button"/>
+                  <p:commandButton id="start" title="Start recording" onclick="PF('startRecordingDialog').show();" icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button"/>
+                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{jfrBean.refresh()}" update="@form startRecordingDialog" title="Refresh" styleClass="flex-shrink-0 ml-1 rounded-button"/>
                 </div>
               </div>
               <p:dataTable var="recording" value="#{jfrBean.recordings}"
@@ -58,12 +58,12 @@
                 </p:column>
                 <p:column styleClass="table-btn-3">
                   <p:commandButton id="stop" action="#{jfrBean.stopRecording(recording)}" update="@form startRecordingDialog" title="Stop recording"
-                    icon="si si-controls-stop" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{not recording.canStop}"/>
-                  <p:commandButton id="download" icon="pi pi-arrow-down" ajax="false" title="Download recording" styleClass="col-fixed ml-1 ui-button-success rounded-button" disabled="#{not recording.canDownload}">
+                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{not recording.canStop}"/>
+                  <p:commandButton id="download" icon="pi pi-arrow-down" ajax="false" title="Download recording" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{not recording.canDownload}">
                     <p:fileDownload value="#{jfrBean.downloadRecording(recording)}"/>
                   </p:commandButton>
                   <p:commandButton id="close" action="#{jfrBean.closeRecording(recording)}" update="@form startRecordingDialog" title="Delete recording" disabled="#{not recording.canClose}"
-                    icon="si si-bin-1" styleClass="col-fixed ml-1 ui-button-danger rounded-button"/>
+                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
                 </p:column>
               </p:dataTable>
             </div>

--- a/engine-cockpit/webContent/view/monitorJobs.xhtml
+++ b/engine-cockpit/webContent/view/monitorJobs.xhtml
@@ -30,7 +30,7 @@
           <i class="pr-3 si si-task-list-approve card-title-icon"></i>
           <h2 class="m-0">Jobs</h2>
           <p:commandButton id="refresh" actionListener="#{jobBean.refresh}" update="form" title="Refresh jobs"
-              icon="si si-button-refresh-arrows" styleClass="col-fixed ml-auto rounded-button"/>
+              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
 
         </div>
         <h:form id="form" style="overflow: auto;" onkeypress="if (event.keyCode == 13) return false;">

--- a/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
+++ b/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
@@ -32,15 +32,15 @@
                 <i class="pr-3 si si-optimization-timer"></i>
                 <h2 class="m-0">Process Execution</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="Start recording"
-                    icon="si si-controls-play" styleClass="col-fixed ml-auto ui-button-success rounded-button" disabled="#{processExecutionBean.notStartable}" />
+                    icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{processExecutionBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{processExecutionBean.stop}" update="@form" title="Stop recording"
-                    icon="si si-controls-stop" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notStoppable}" />
+                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notStoppable}" />
                 <p:commandButton id="clear" actionListener="#{processExecutionBean.clear}" update="@form" title="Clear statistic"
-                    icon="si si-bin-1" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notCleanable}" />
+                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notCleanable}" />
                 <p:commandButton id="refresh" actionListener="#{processExecutionBean.refresh}" update="@form" title="Refresh statistic"
-                    icon="si si-button-refresh-arrows" styleClass="col-fixed ml-1 rounded-button" disabled="#{processExecutionBean.notRefreshable}" />
+                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{processExecutionBean.notRefreshable}" />
                 <p:commandButton id="export" title="Export statistic" ajax="false"
-                    icon="si si-office-file-xls-1" styleClass="col-fixed ml-1 ui-button-secondary rounded-button" disabled="#{processExecutionBean.notCleanable}">
+                    icon="si si-office-file-xls-1" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" disabled="#{processExecutionBean.notCleanable}">
                   <p:dataExporter type="xlsxstream" target="performanceTable" fileName="PerformanceStatistic"/>
                 </p:commandButton>
               </div>

--- a/engine-cockpit/webContent/view/monitorStartEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorStartEvents.xhtml
@@ -30,7 +30,7 @@
           <i class="pr-3 si si-navigation-right-circle-1 card-title-icon"></i>
           <h2 class="m-0">Start Events</h2>
           <p:commandButton id="refresh" actionListener="#{startEventBean.refresh}" update="form" title="Refresh Start Events"
-              icon="si si-button-refresh-arrows" styleClass="col-fixed ml-auto rounded-button"/>
+              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
 
         </div>
         <h:form id="form" style="overflow: auto;" onkeypress="if (event.keyCode == 13) return false;">
@@ -82,11 +82,11 @@
 
              <p:column styleClass="table-btn-3">
               <p:commandButton id="start" title="Starts the bean" icon="si si-controls-play"
-                action="#{bean.start()}" update="@form" styleClass="col-fixed ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
+                action="#{bean.start()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
               <p:commandButton id="stop" title="Stops the bean" icon="si si-controls-stop"
-                action="#{bean.stop()}" update="@form" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{! bean.running}"/>
+                action="#{bean.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{! bean.running}"/>
               <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="Schedule to poll the bean now" icon="si si-synchronize-arrow-clock"
-                action="#{startEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="col-fixed ml-1 rounded-button" />
+                action="#{startEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="flex-shrink-0 ml-1 rounded-button" />
             </p:column>
           </p:dataTable>
         </h:form>

--- a/engine-cockpit/webContent/view/monitorThreads.xhtml
+++ b/engine-cockpit/webContent/view/monitorThreads.xhtml
@@ -32,8 +32,8 @@
                 <div class="card-title flex align-items-center">
                   <i class="pr-3 si si-synchronize-arrow-clock"></i>
                   <h2 class="m-0">Threads</h2>
-                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{threadBean.refresh()}" title="Refresh" styleClass="col-fixed ml-auto rounded-button" update="threadTable"/>
-                  <p:commandButton id="dump" icon="pi pi-arrow-down" ajax="false" title="Save Thread Dump" styleClass="col-fixed ml-1 ui-button-success rounded-button">
+                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{threadBean.refresh()}" title="Refresh" styleClass="flex-shrink-0 ml-auto rounded-button" update="threadTable"/>
+                  <p:commandButton id="dump" icon="pi pi-arrow-down" ajax="false" title="Save Thread Dump" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button">
                     <p:fileDownload value="#{threadBean.dump()}"/>
                   </p:commandButton>
                 </div>

--- a/engine-cockpit/webContent/view/monitorTraceDetail.xhtml
+++ b/engine-cockpit/webContent/view/monitorTraceDetail.xhtml
@@ -36,7 +36,7 @@
                     <h6 class="m-0">Slow Request Detail</h6>
                     <p:commandButton id="export" title="Export span"
                       ajax="false" icon="si si-office-file-xls-1"
-                      styleClass="col-fixed ml-auto ui-button-secondary rounded-button"
+                      styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button"
                       disabled="#{!spanBean.traceAvailable}">
                       <p:dataExporter type="xlsxstream"
                         target="spansTree"

--- a/engine-cockpit/webContent/view/monitorTraces.xhtml
+++ b/engine-cockpit/webContent/view/monitorTraces.xhtml
@@ -30,15 +30,15 @@
                 <i class="pr-3 si si-alarm-bell-timer"></i>
                 <h2 class="m-0">Slow Requests</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="Start recording"
-                    icon="si si-controls-play" styleClass="col-fixed ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
+                    icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{traceBean.stop}" update="@form" title="Stop recording"
-                    icon="si si-controls-stop" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}" />
+                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}" />
                 <p:commandButton id="clear" actionListener="#{traceBean.clear}" update="@form" title="Clear statistic"
-                    icon="si si-bin-1" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notCleanable}" />
+                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notCleanable}" />
                 <p:commandButton id="refresh" actionListener="#{traceBean.refresh}" update="@form" title="Refresh statistic"
-                    icon="si si-button-refresh-arrows" styleClass="col-fixed ml-1 rounded-button" disabled="#{traceBean.notRefreshable}" />
+                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{traceBean.notRefreshable}" />
                 <p:commandButton id="export" title="Export traces" ajax="false"
-                    icon="si si-office-file-xls-1" styleClass="col-fixed ml-1 ui-button-secondary rounded-button" disabled="#{traceBean.notCleanable}">
+                    icon="si si-office-file-xls-1" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" disabled="#{traceBean.notCleanable}">
                   <p:dataExporter type="xlsxstream" target="traceTable" fileName="Traces"/>
                 </p:commandButton>
               </div>

--- a/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
+++ b/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
@@ -30,13 +30,13 @@
                 <i class="pr-3 si si si-view-1"></i>
                 <h2 class="m-0">Traffic Graph</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="Start recording"
-                    icon="si si-controls-play" styleClass="col-fixed ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
+                    icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{traceBean.stop}" update="@form" title="Stop recording"
-                    icon="si si-controls-stop" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}"/>
+                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}"/>
                 <p:commandButton id="clear" actionListener="#{trafficGraphBean.clear}" update="@form" title="Clear statistic"
-                    icon="si si-bin-1" styleClass="col-fixed ml-1 ui-button-danger rounded-button" disabled="#{trafficGraphBean.notClearable}"/>
+                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{trafficGraphBean.notClearable}"/>
                 <p:commandButton id="refresh" actionListener="#{trafficGraphBean.refresh}" update="@form" title="Refresh statistic"
-                    icon="si si-button-refresh-arrows" styleClass="col-fixed ml-1 rounded-button"  disabled="#{traceBean.notRefreshable}"/>
+                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button"  disabled="#{traceBean.notRefreshable}"/>
               </div>
             </div>
             <p:diagram id="diagram" style="border-right: dotted 1px; border-bottom: dotted 1px; height: #{trafficGraphBean.height}px; width: #{trafficGraphBean.width}px; overflow: hidden;" value="#{trafficGraphBean.model}" styleClass="ui-widget-content" var="system">

--- a/engine-cockpit/webContent/view/notification-channel-detail.xhtml
+++ b/engine-cockpit/webContent/view/notification-channel-detail.xhtml
@@ -32,16 +32,16 @@
           <h:outputText value="#{notificationChannelDetailBean.channel.displayIcon}" class="pr-3 si notification-channel-title-icon" escape="false" /> <!-- contains no user input, contains icon -->
           <h2 class="m-0">#{notificationChannelDetailBean.channel.displayName}</h2>
           <p:commandButton id="open" actionListener="#{notificationChannelDetailBean.open}" title="Unlock channel (clear error state)"
-            icon="si si-charger" styleClass="col-fixed ml-auto rounded-button" update="form" 
+            icon="si si-charger" styleClass="flex-shrink-0 ml-auto rounded-button" update="form" 
             rendered="#{notificationChannelDetailBean.channel.push}" disabled="#{not notificationChannelDetailBean.channel.locked}"/>
           <p:commandButton id="resetPush" actionListener="#{notificationChannelDetailBean.onload}" title="Reset changes"
-            icon="si si-undo" styleClass="col-fixed ml-1 ui-button-danger rounded-button" update="form"
+            icon="si si-undo" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" update="form"
             rendered="#{notificationChannelDetailBean.channel.push}"/>
           <p:commandButton id="resetNonPush" actionListener="#{notificationChannelDetailBean.onload}" title="Reset changes"
-            icon="si si-undo" styleClass="col-fixed ml-auto ui-button-danger rounded-button" update="form"
+            icon="si si-undo" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" update="form"
             rendered="#{not notificationChannelDetailBean.channel.push}"/>
           <p:commandButton id="save" actionListener="#{notificationChannelDetailBean.save}" title="Save changes"
-            icon="si si-floppy-disk" styleClass="col-fixed ml-1 ui-button-success rounded-button"/>
+            icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"/>
         </div>
         <h:form id="form">
           <p:panelGrid columns="2" columnClasses="col-12 md:col-2 lg:col-2, col-12 md:col-10 lg:col-10"

--- a/engine-cockpit/webContent/view/notificationDeliveries.xhtml
+++ b/engine-cockpit/webContent/view/notificationDeliveries.xhtml
@@ -29,9 +29,9 @@
           <i class="pr-3 si si-advertising-megaphone-2 card-title-icon"></i>
           <h2 class="m-0">Notification #{notificationBean.notification.id}</h2>
           <p:commandButton id="reusher" actionListener="#{notificationBean.notification.reusher}" title="Reevalute deliveries"
-            icon="si si-multiple-actions-add" styleClass="col-fixed ml-auto rounded-button" update="tableForm"/>
+            icon="si si-multiple-actions-add" styleClass="flex-shrink-0 ml-auto rounded-button" update="tableForm"/>
           <p:commandButton id="retry" actionListener="#{notificationBean.notification.retry}" title="Retry to deliver"
-            icon="si si-send-email" styleClass="col-fixed ml-1 rounded-button" update="tableForm"/>
+            icon="si si-send-email" styleClass="flex-shrink-0 ml-1 rounded-button" update="tableForm"/>
         </div>
 
         <h:form id="tableForm" onkeypress="if (event.keyCode == 13) return false;">

--- a/engine-cockpit/webContent/view/roles.xhtml
+++ b/engine-cockpit/webContent/view/roles.xhtml
@@ -45,10 +45,10 @@
               </span>
               <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
                 actionListener="#{roleBean.roles.expandAllNodes}" update="tree" title="Expand all"
-                styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined expand-all" />
+                styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
               <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
                 actionListener="#{roleBean.roles.collapseAllNodes}" update="tree" title="Collapse all"
-                styleClass="ml-1 col-fixed ui-button-secondary rounded-button ui-button-outlined" />
+                styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
             </div>
             <p:treeTable id="tree" value="#{roleBean.roles.tree}" var="role" nodeVar="node" styleClass="hide-head">
               <p:ajax event="expand" listener="#{roleBean.roles.nodeExpand}" />

--- a/engine-cockpit/webContent/view/webserver.xhtml
+++ b/engine-cockpit/webContent/view/webserver.xhtml
@@ -41,7 +41,7 @@
                     <i class="pr-3 si si-cog"></i>
                     <h6 class="m-0">Base Url Settings</h6>
                     <p:commandButton id="save" actionListener="#{webServerBean.saveBaseUrl}" title="Save changes"
-                      icon="si si-floppy-disk" styleClass="col-fixed ml-auto ui-button-success rounded-button" />
+                      icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
                   </div>
                 </div>
                 <p:panelGrid columns="2" columnClasses="col-12 md:col-3 lg:col-12, col-12 md:col-9 lg:col-12" layout="flex" 


### PR DESCRIPTION
col-fixed adds a `flex-shrink: 0;` but also some padding.
On the UI it makes no difference, but especially on `p:linkButtons` this results in wrong click areas:
![Screenshot 2025-05-16 at 11 39 22](https://github.com/user-attachments/assets/5f16c06a-097d-41e4-b5a5-e1f9fb2a525a)

`flex-shrink-0` adds only what it tells.

This flex-shrink: 0 is needed so the buttons don't get squashed to their icon on smaller screens, which would happen because of flex box nature.