### PR TITLE
XIVY-15972 Setup min. context so that basic Ivy.xyz work in REST tests

### DIFF
--- a/engine-cockpit-test-data/src/com/axonivy/engine/cockpit/testdata/rest/MyFakeOAuthFeature.java
+++ b/engine-cockpit-test-data/src/com/axonivy/engine/cockpit/testdata/rest/MyFakeOAuthFeature.java
@@ -8,6 +8,8 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
+import ch.ivyteam.ivy.environment.Ivy;
+
 public class MyFakeOAuthFeature implements Feature {
 
   @Override
@@ -19,6 +21,7 @@ public class MyFakeOAuthFeature implements Feature {
   private static class BearerFilter implements ClientRequestFilter {
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
+      Ivy.log().debug("Setting the 'Authentication' request header to 'Bearer ******");
       requestContext.getHeaders().add("Authentication", "Bearer 1234MyCoolJWTtoken");
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestClientDetailBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/rest/RestClientDetailBean.java
@@ -9,7 +9,6 @@ import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
-import javax.ws.rs.client.WebTarget;
 
 import org.apache.commons.lang.text.StrSubstitutor;
 
@@ -180,8 +179,8 @@ public class RestClientDetailBean extends HelpServices implements IConnectionTes
         .setTimeout(TimeUnit.SECONDS, 5)
         .setReadTimeout(TimeUnit.SECONDS, 5)
         .toClient();
-    WebTarget target = RestTestRunner.createTarget(app, uiClient);
-    testResult = (ConnectionTestResult) connectionTest.test(() -> RestTestRunner.testConnection(target));
+    var runner = new RestTestRunner(app, uiClient);
+    testResult = (ConnectionTestResult) connectionTest.test(runner::test);
   }
 
   public void saveConfig() {


### PR DESCRIPTION
Setup thread contexts for security context, application and pmv for REST connection tests so that Ivy.log() and similar basic infrastructure works.

Cherry-Pick 73a3aeca3b84198045891f79e5b7d50c71799615 from master

Same as https://github.com/axonivy/engine-cockpit/pull/1416 on master