### PR TITLE
XIVY-17200 fix: consume managed commons-lang3 from ivy-api-bom

### DIFF
--- a/engine-cockpit-selenium-test/pom.xml
+++ b/engine-cockpit-selenium-test/pom.xml
@@ -303,14 +303,12 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.axonivy.ivy.webtest</groupId>
       <artifactId>web-tester</artifactId>
-      <version>${web.tester.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -327,5 +325,7 @@
       <version>1.21.1</version>
       <scope>test</scope>
     </dependency>
+    
   </dependencies>
+  
 </project>

--- a/maven-config/pom.xml
+++ b/maven-config/pom.xml
@@ -123,6 +123,16 @@
         <updatePolicy>always</updatePolicy>
       </snapshots>
     </repository>
+    <repository>
+      <id>nexus.axonivy.com</id>
+      <url>https://nexus.axonivy.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -146,4 +156,17 @@
       </snapshots>
     </pluginRepository>
   </pluginRepositories>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.axonivy.ivy.api</groupId>
+        <artifactId>ivy-api-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
 </project>


### PR DESCRIPTION
there was still a legacy commons-lang:3.17 on the classpath due to the surefire-proxy dependency. 
by importing the bom we get the dependency management for free.


<img width="1165" height="789" alt="Selection_105" src="https://github.com/user-attachments/assets/aae06ed5-f9dd-4a56-8a2b-5332db743961" />
<img width="1707" height="1038" alt="Selection_104" src="https://github.com/user-attachments/assets/dce9f79d-686f-4383-8768-d5f22091161e" />
