### PR TITLE
deflake `WebTestNotificationChannelDetail#saveChanges`

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
@@ -121,15 +121,26 @@ public class WebTestNotificationChannelDetail {
     firstEventCheckbox.shouldBeDisabled(true);
 
     $(By.id("save")).click();
-    refresh();
 
-    enabledCheckbox.shouldBeChecked(false);
+    var maxAttempts = 3;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        refresh();
 
-    allEventsCheckbox.shouldBeDisabled(true);
-    allEventsCheckbox.shouldBeChecked(false);
+        enabledCheckbox.shouldBeChecked(false);
 
-    firstEventCheckbox.shouldBeDisabled(true);
-    firstEventCheckbox.shouldBeChecked(true);
+        allEventsCheckbox.shouldBeDisabled(true);
+        allEventsCheckbox.shouldBeChecked(false);
+
+        firstEventCheckbox.shouldBeDisabled(true);
+        firstEventCheckbox.shouldBeChecked(true);
+        break;
+      } catch (AssertionError e) {
+        if (attempt == maxAttempts) {
+          throw e;
+        }
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Rarely, updating the config after saving takes longer than refreshing the page so the changes are not represented correctly. Adding a simple retry logic should deflake the test.