### PR TITLE
deflake `WebTestNotificationChannelDetail#saveChanges`

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
@@ -208,6 +208,7 @@ class WebTestUserDetail {
     var allEventsCheckbox = PrimeUi.selectBooleanCheckbox(By.id("form:allEvents"));
     allEventsCheckbox.removeChecked();
     $(By.id("save")).click();
+    $(".ui-growl-message").shouldHave(text("Successfully saved"));
 
     Navigation.toUserDetail(USER_FOO);
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotification.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotification.java
@@ -223,5 +223,6 @@ class WebTestNotification {
     var enabledCheckbox = PrimeUi.selectBooleanCheckbox(By.id("form:enabled"));
     enabledCheckbox.setChecked();
     $(By.id("save")).click();
+    $(".ui-growl-message").shouldHave(text("Successfully saved"));
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestNotificationChannelDetail.java
@@ -121,6 +121,7 @@ public class WebTestNotificationChannelDetail {
     firstEventCheckbox.shouldBeDisabled(true);
 
     $(By.id("save")).click();
+    $(".ui-growl-message").shouldHave(text("Successfully saved"));
     refresh();
 
     enabledCheckbox.shouldBeChecked(false);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestPushNotificationChannel.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestPushNotificationChannel.java
@@ -103,6 +103,7 @@ public class WebTestPushNotificationChannel {
   private void enable() {
     enabledCheckbox.setChecked();
     $(By.id("save")).click();
+    $(".ui-growl-message").shouldHave(text("Successfully saved"));
   }
 
   private void assertDefault() {


### PR DESCRIPTION
Rarely, updating the config after saving takes longer than refreshing the page so the changes are not represented correctly.
Waiting for the "Successfully saved" growl message should resolve this.

Also added this check to other places that save notification channel changes.
