### PR TITLE
XIVY-10163 Only require password when creating a new admin

### DIFF
--- a/engine-cockpit/webContent/resources/composite/Administrators.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Administrators.xhtml
@@ -91,7 +91,7 @@
         <p:outputLabel for="password1" value="Password" />
         <h:panelGroup styleClass="md-inputfield">
           <p:password id="password1" validatorMessage="Password didn't match" feedback="true" inline="true"
-            match="password2" autocomplete="new-password" value="#{administratorBean.admin.password}" required="true"
+            match="password2" autocomplete="new-password" value="#{administratorBean.admin.password}" required="#{empty administratorBean.admin.name}"
             requiredMessage="Value is required" redisplay="true" />
           <p:message for="password1" id="passwordMessage">
             <p:autoUpdate />
@@ -101,7 +101,7 @@
         <p:outputLabel for="password2" value="Confirm Password" />
         <h:panelGroup styleClass="md-inputfield">
           <p:password id="password2" feedback="true" inline="true" value="#{administratorBean.admin.password}"
-            required="true" requiredMessage="Value is required" redisplay="true" />
+            required="#{empty administratorBean.admin.name}" requiredMessage="Value is required" redisplay="true" />
           <p:message for="password2" id="password2Message" />
         </h:panelGroup>
       </p:panelGrid>


### PR DESCRIPTION
if password is not set on update, it won't be overwritten.
because the admins comes now from db and i don't have there the clear text password.
it's now anyway a bit "more safe" and the same behavior as for users.