### PR TITLE
Fix all unit tests which uses a bean with Ivy.cm access

### DIFF
--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/health/TestHealthBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/health/TestHealthBean.java
@@ -5,19 +5,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import ch.ivyteam.enginecockpit.monitor.health.HealthBean.Check;
 import ch.ivyteam.ivy.environment.IvyTest;
 import ch.ivyteam.ivy.health.check.HealthChecker;
 import ch.ivyteam.ivy.health.check.HealthSeverity;
-import ch.ivyteam.ivy.manager.IManager;
+import ch.ivyteam.ivy.health.check.impl.HealthCheckImpl;
 
-@IvyTest
+@IvyTest(enableWebServer = false)
 class TestHealthBean {
 
   HealthBean testee = new HealthBean();
 
+  @SuppressWarnings("restriction")
   @AfterEach
   void after() {
-    ((IManager) HealthChecker.instance()).stop();
+    HealthChecker.instance().checks().stream().map(HealthCheckImpl.class::cast).forEach(HealthCheckImpl::stop);
   }
 
   @Test
@@ -71,8 +73,7 @@ class TestHealthBean {
     assertThat(testee.getMessage()).isEqualTo("No problems detected. Engine is healthy.");
     assertThat(testee.getMessages()).isEmpty();
 
-    ((IManager) HealthChecker.instance()).start();
-    testee.refresh();
+    runCheck();
 
     assertThat(testee.getMessageCount()).isEqualTo(1);
     assertThat(testee.getMessage()).isEqualTo("Release Candidate");
@@ -81,8 +82,7 @@ class TestHealthBean {
 
   @Test
   void message() {
-    ((IManager) HealthChecker.instance()).start();
-    testee.refresh();
+    runCheck();
 
     var msg = testee.getMessages().get(0);
     assertThat(msg.getMessage()).isEqualTo("Release Candidate");
@@ -100,21 +100,19 @@ class TestHealthBean {
     assertThat(testee.getSeverityIcon()).isEqualTo("si si-check-1");
     assertThat(testee.getSeverityName()).isEqualTo("HEALTHY");
 
-    ((IManager) HealthChecker.instance()).start();
-    testee.refresh();
+    runCheck();
 
     assertThat(testee.getSeverityClass()).isEqualTo("health-high");
     assertThat(testee.getSeverityIcon()).isEqualTo("si si-alert-circle");
     assertThat(testee.getSeverityName()).isEqualTo("HIGH");
   }
 
-  @Test
-  void checkNow() {
-    assertThat(testee.getMessageCount()).isEqualTo(0);
+  private Check getCheck() {
+    return testee.getChecks().stream().filter(c -> "Release Candidate".equals(c.getName())).findAny().orElseThrow();
+  }
 
-    ((IManager) HealthChecker.instance()).start();
-    testee.checkNow();
-
-    assertThat(testee.getMessageCount()).isEqualTo(1);
+  private void runCheck() {
+    getCheck().checkNow();
+    testee.refresh();
   }
 }

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestSystemDatabaseMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/TestSystemDatabaseMonitorBean.java
@@ -10,10 +10,7 @@ import com.axonivy.jmx.MAttribute;
 import com.axonivy.jmx.MBean;
 import com.axonivy.jmx.MBeans;
 
-import ch.ivyteam.ivy.environment.IvyTest;
-
 @SuppressWarnings("restriction")
-@IvyTest
 public class TestSystemDatabaseMonitorBean {
   @AfterEach
   public void afterEach() {

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/TestSessionMonitorBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/TestSessionMonitorBean.java
@@ -11,10 +11,7 @@ import com.axonivy.jmx.MAttribute;
 import com.axonivy.jmx.MBean;
 import com.axonivy.jmx.MBeans;
 
-import ch.ivyteam.ivy.environment.IvyTest;
-
 @SuppressWarnings("restriction")
-@IvyTest
 public class TestSessionMonitorBean {
   @BeforeEach
   public void beforeEach() {

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TestProcessExecutionBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/performance/TestProcessExecutionBean.java
@@ -15,10 +15,8 @@ import ch.ivyteam.di.restricted.DiCore;
 import ch.ivyteam.ivy.bpm.engine.restricted.IBpmEngineManager;
 import ch.ivyteam.ivy.bpm.engine.restricted.statistic.IProcessElementExecutionStatistic;
 import ch.ivyteam.ivy.configuration.restricted.IConfiguration;
-import ch.ivyteam.ivy.environment.IvyTest;
 
 @SuppressWarnings("restriction")
-@IvyTest
 class TestProcessExecutionBean {
 
   private static final double ONE_MILLION = 1_000_000.0f;
@@ -31,6 +29,7 @@ class TestProcessExecutionBean {
       @Override
       protected void configure() {
         super.configure();
+
         bind(IBpmEngineManager.class).to(TstBpmEngineManager.class);
       }
     });

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/AbstractDatabase.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/AbstractDatabase.java
@@ -9,6 +9,7 @@ import javax.management.ObjectName;
 import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
 import ch.ivyteam.enginecockpit.monitor.monitor.Series;
 import ch.ivyteam.enginecockpit.monitor.unit.Unit;
+import ch.ivyteam.enginecockpit.util.CmsUtil;
 import ch.ivyteam.ivy.environment.Ivy;
 
 abstract class AbstractDatabase {
@@ -46,27 +47,27 @@ abstract class AbstractDatabase {
     var maxConnections = attribute(canonicalName, "maxConnections", Unit.ONE);
     var transactions = new ExecutionCounter(canonicalName, "transactions");
 
-    connectionsMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/ConnectionsMonitorUsedValue"), usedConnections));
-    connectionsMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/ConnectionsMonitorOpenValue"), openConnections));
-    connectionsMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/ConnectionsMonitorMaxValue"), maxConnections));
-    connectionsMonitor.addSeries(Series.build(openConnections, Ivy.cm().co("/liveStats/ConnectionsMonitorOpen")).toSeries());
-    connectionsMonitor.addSeries(Series.build(usedConnections, Ivy.cm().co("/liveStats/ConnectionsMonitorUsed")).toSeries());
+    connectionsMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/ConnectionsMonitorUsedValue", "Used %5d"), usedConnections));
+    connectionsMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/ConnectionsMonitorOpenValue", "Open %5d"), openConnections));
+    connectionsMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/ConnectionsMonitorMaxValue", "Max %5d"), maxConnections));
+    connectionsMonitor.addSeries(Series.build(openConnections, CmsUtil.coWithDefault("/liveStats/ConnectionsMonitorOpen", "Open")).toSeries());
+    connectionsMonitor.addSeries(Series.build(usedConnections, CmsUtil.coWithDefault("/liveStats/ConnectionsMonitorUsed", "Used")).toSeries());
 
     queriesMonitor.addInfoValue(format("%5d", transactions.deltaExecutions()));
-    queriesMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/QueriesMonitorTotalValue"), transactions.executions()));
-    queriesMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/QueriesMonitorErrorsValue"), transactions.deltaErrors()));
-    queriesMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/QueriesMonitorErrorsTotalValue"), transactions.errors()));
+    queriesMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/QueriesMonitorTotalValue", "Total %5d"), transactions.executions()));
+    queriesMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/QueriesMonitorErrorsValue", "Errors %5d"), transactions.deltaErrors()));
+    queriesMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/QueriesMonitorErrorsTotalValue", "Errors Total %5d"), transactions.errors()));
 
     queriesMonitor.addSeries(Series.build(transactions.deltaExecutions(), queries).toSeries());
-    queriesMonitor.addSeries(Series.build(transactions.deltaErrors(), Ivy.cm().co("/liveStats/QueriesMonitorErrors")).toSeries());
+    queriesMonitor.addSeries(Series.build(transactions.deltaErrors(), CmsUtil.coWithDefault("/liveStats/QueriesMonitorErrors", "Errors")).toSeries());
 
-    executionTimeMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/ExecutionTimeMonitorMinValue"), transactions.deltaMinExecutionTime()));
-    executionTimeMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/ExecutionTimeMonitorAvgValue"), transactions.deltaAvgExecutionTime()));
-    executionTimeMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/ExecutionTimeMonitorMaxValue"), transactions.deltaMaxExecutionTime()));
-    executionTimeMonitor.addInfoValue(format(Ivy.cm().co("/liveStats/ExecutionTimeMonitorTotalValue"), transactions.executionTime()));
-    executionTimeMonitor.addSeries(Series.build(transactions.deltaMinExecutionTime(), Ivy.cm().co("/liveStats/ExecutionTimeMonitorMin")).toSeries());
-    executionTimeMonitor.addSeries(Series.build(transactions.deltaAvgExecutionTime(), Ivy.cm().co("/liveStats/ExecutionTimeMonitorAvg")).toSeries());
-    executionTimeMonitor.addSeries(Series.build(transactions.deltaMaxExecutionTime(), Ivy.cm().co("/liveStats/ExecutionTimeMonitorMax")).toSeries());
+    executionTimeMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/ExecutionTimeMonitorMinValue", "Min %t"), transactions.deltaMinExecutionTime()));
+    executionTimeMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/ExecutionTimeMonitorAvgValue", "Avg %t"), transactions.deltaAvgExecutionTime()));
+    executionTimeMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/ExecutionTimeMonitorMaxValue", "Max %t"), transactions.deltaMaxExecutionTime()));
+    executionTimeMonitor.addInfoValue(format(CmsUtil.coWithDefault("/liveStats/ExecutionTimeMonitorTotalValue", "Total %t"), transactions.executionTime()));
+    executionTimeMonitor.addSeries(Series.build(transactions.deltaMinExecutionTime(), CmsUtil.coWithDefault("/liveStats/ExecutionTimeMonitorMin", "Min")).toSeries());
+    executionTimeMonitor.addSeries(Series.build(transactions.deltaAvgExecutionTime(), CmsUtil.coWithDefault("/liveStats/ExecutionTimeMonitorAvg", "Avg")).toSeries());
+    executionTimeMonitor.addSeries(Series.build(transactions.deltaMaxExecutionTime(), CmsUtil.coWithDefault("/liveStats/ExecutionTimeMonitorMax", "Max")).toSeries());
   }
 
   public String name() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/SystemDatabase.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/ivy/SystemDatabase.java
@@ -4,6 +4,7 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
+import ch.ivyteam.enginecockpit.util.CmsUtil;
 import ch.ivyteam.ivy.environment.Ivy;
 
 public final class SystemDatabase extends AbstractDatabase {
@@ -20,9 +21,9 @@ public final class SystemDatabase extends AbstractDatabase {
   SystemDatabase() {
     super(
         DATABASE_PERSISTENCY_SERVICE,
-        Ivy.cm().co("/liveStats/Transactions"),
-        Monitor.build().name(Ivy.cm().co("/common/Connections")).icon("insert_link").toMonitor(),
-        Monitor.build().name(Ivy.cm().co("/liveStats/Transactions")).icon("dns").toMonitor(),
-        Monitor.build().name(Ivy.cm().co("/liveStats/ProcessingTime")).icon("timer").yAxisLabel(Ivy.cm().co("/common/Time")).toMonitor());
+        CmsUtil.coWithDefault("/liveStats/Transactions", "Transactions"),
+        Monitor.build().name(CmsUtil.coWithDefault("/common/Connections", "Connections")).icon("insert_link").toMonitor(),
+        Monitor.build().name(CmsUtil.coWithDefault("/liveStats/Transactions", "Transactions")).icon("dns").toMonitor(),
+        Monitor.build().name(CmsUtil.coWithDefault("/liveStats/ProcessingTime", "Processing Time")).icon("timer").yAxisLabel(Ivy.cm().co("/common/Time")).toMonitor());
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/SessionMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/SessionMonitorBean.java
@@ -2,7 +2,6 @@ package ch.ivyteam.enginecockpit.monitor.mbeans.tomcat;
 
 import static ch.ivyteam.enginecockpit.monitor.value.ValueProvider.attribute;
 import static ch.ivyteam.enginecockpit.monitor.value.ValueProvider.format;
-import static ch.ivyteam.ivy.environment.Ivy.cm;
 import static java.lang.String.join;
 import static org.apache.commons.lang3.StringUtils.SPACE;
 
@@ -13,31 +12,32 @@ import ch.ivyteam.enginecockpit.monitor.monitor.Monitor;
 import ch.ivyteam.enginecockpit.monitor.monitor.Series;
 import ch.ivyteam.enginecockpit.monitor.unit.Unit;
 import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
+import ch.ivyteam.enginecockpit.util.CmsUtil;
 
 @ManagedBean
 @ViewScoped
 public class SessionMonitorBean {
   private static final String SECURITY_MANAGER = "ivy Engine:type=Security Manager";
   private static final String TOMCAT_MANAGER = "ivy:type=Manager,host=*,context=*";
-  private final Monitor sessionsMonitor = Monitor.build().name(cm().co("/common/Sessions")).icon("person").toMonitor();
+  private final Monitor sessionsMonitor = Monitor.build().name(CmsUtil.coWithDefault("/common/Sessions", "Sessions")).icon("person").toMonitor();
 
   public SessionMonitorBean() {
     setupSessionMonitor();
   }
 
   private void setupSessionMonitor() {
-    var licensedSession = join(SPACE, cm().co("/monitor/session/LicensedSessions"), "%5d");
-    var session = join(SPACE, cm().co("/common/Sessions"), "%5d");
-    var httpSession = join(SPACE, cm().co("/monitor/session/HTTPSessions"), "%5d");
-    var licensedUser = join(SPACE, cm().co("/monitor/session/LicensedUsers"), "%5d");
+    var licensedSession = join(SPACE, CmsUtil.coWithDefault("/monitor/session/LicensedSessions", "Licensed Sessions"), "%5d");
+    var session = join(SPACE, CmsUtil.coWithDefault("/common/Sessions", "Sessions"), "%5d");
+    var httpSession = join(SPACE, CmsUtil.coWithDefault("/monitor/session/HTTPSessions", "Http Sessions"), "%5d");
+    var licensedUser = join(SPACE, CmsUtil.coWithDefault("/monitor/session/LicensedUsers", "Licensed Users"), "%5d");
     sessionsMonitor.addInfoValue(format(licensedSession, licensedSessions()));
     sessionsMonitor.addInfoValue(format(session, sessions()));
     sessionsMonitor.addInfoValue(format(httpSession, httpSessions()));
     sessionsMonitor.addInfoValue(format(licensedUser, licensedUsers()));
 
-    sessionsMonitor.addSeries(Series.build(licensedSessions(), cm().co("/monitor/session/LicensedSessions")).toSeries());
-    sessionsMonitor.addSeries(Series.build(sessions(), cm().co("/common/Sessions")).toSeries());
-    sessionsMonitor.addSeries(Series.build(httpSessions(), cm().co("/monitor/session/HTTPSessions")).toSeries());
+    sessionsMonitor.addSeries(Series.build(licensedSessions(), CmsUtil.coWithDefault("/monitor/session/LicensedSessions", "Licensed Sessions")).toSeries());
+    sessionsMonitor.addSeries(Series.build(sessions(), CmsUtil.coWithDefault("/common/Sessions", "Sessions")).toSeries());
+    sessionsMonitor.addSeries(Series.build(httpSessions(), CmsUtil.coWithDefault("/monitor/session/HTTPSessions", "Http Sessions")).toSeries());
   }
 
   public Monitor getSessionsMonitor() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ProcessExecutionBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/performance/ProcessExecutionBean.java
@@ -18,6 +18,7 @@ import javax.faces.context.FacesContext;
 import org.ocpsoft.prettytime.PrettyTime;
 import org.primefaces.util.ComponentUtils;
 
+import ch.ivyteam.enginecockpit.util.CmsUtil;
 import ch.ivyteam.ivy.bpm.engine.restricted.IBpmEngineManager;
 import ch.ivyteam.ivy.bpm.engine.restricted.statistic.IExecutionStatistic;
 import ch.ivyteam.ivy.configuration.restricted.IConfiguration;
@@ -105,10 +106,10 @@ public final class ProcessExecutionBean {
   public String getLoggingInterval() {
     var seconds = IConfiguration.instance().getOrDefault("ProcessEngine.FiringStatistic.Interval", long.class);
     if (seconds == 1) {
-      return Ivy.cm().co("/monitor/execution/OneSecond");
+      return CmsUtil.coWithDefault("/monitor/execution/OneSecond", "1 second");
     }
     if (seconds < 60) {
-      return seconds + " " + Ivy.cm().co("/monitor/execution/Seconds");
+      return seconds + " " + CmsUtil.coWithDefault("/monitor/execution/Seconds", "seconds");
     }
     Instant now = Instant.now();
     var then = now.plus(Duration.ofSeconds(seconds));

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/WebServerConnectorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/WebServerConnectorBean.java
@@ -1,7 +1,5 @@
 package ch.ivyteam.enginecockpit.setup;
 
-import java.util.Arrays;
-
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.context.FacesContext;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/util/CmsUtil.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/util/CmsUtil.java
@@ -1,0 +1,13 @@
+package ch.ivyteam.enginecockpit.util;
+
+import ch.ivyteam.ivy.environment.Ivy;
+
+public class CmsUtil {
+  public static String coWithDefault(String uri, String defaultValue) {
+    var value = Ivy.cm().co(uri);
+    if (value.isEmpty()) {
+      return defaultValue;
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
- Fix TestHealthBean, by change tests because the Health job is not started in a `@IvyTest` environment
- Add default labels for tests which are not compatible with `@IvyTest`, because they are do some special stuff
- Fix warning about unused import