### PR TITLE
XIVY-17237 Fix SSL Test with new suggestAlias

### DIFF
--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestTlsTester.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestTlsTester.java
@@ -71,8 +71,8 @@ class WebTestTlsTester {
       $(By.id("connResult:connTestForm:closeConTesterDialog")).click();
       Navigation.toSSL();
       var table = new Table(By.id("sslTrustTable:storeTable:storeCertificates"));
-      table.firstColumnShouldBe(texts("ivy1"));
-      table.clickButtonForEntry("ivy1", "delete");
+      table.firstColumnShouldBe(texts("ivy"));
+      table.clickButtonForEntry("ivy", "delete");
       $(By.id("sslKeyTable:storeTable:deleteCertDialog")).shouldBe(visible);
       $(By.id("sslKeyTable:storeTable:deleteYesBtn")).shouldBe(visible).click();
       Navigation.toRestClientDetail(RESTCLIENT_NAME);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSSL.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSSL.java
@@ -181,8 +181,8 @@ class WebTestSSL {
       Files.copy(is, createTempFile, StandardCopyOption.REPLACE_EXISTING);
     }
     $(By.id("sslTrustTable:storeTable:certUpload_input")).sendKeys(createTempFile.toString());
-    table.firstColumnShouldBe(texts("ivy1"));
-    table.clickButtonForEntry("ivy1", "delete");
+    table.firstColumnShouldBe(texts("ivy"));
+    table.clickButtonForEntry("ivy", "delete");
     $(By.id("sslTrustTable:storeTable:deleteCertDialog")).shouldBe(visible);
     $(By.id("sslTrustTable:storeTable:deleteYesBtn")).shouldBe(visible).click();
     table.firstColumnShouldBe(empty);


### PR DESCRIPTION
By changing the SuggestAlias method, we fixed the problem of it always starting with ivy1 and not with ivy.