### PR TITLE
Remove no longer needed build parameter

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -9,10 +9,6 @@ pipeline {
     cron '@midnight'
   }
 
-  parameters {
-    string(name: 'engineSource', defaultValue: 'https://product.ivyteam.io', description: 'Engine page url')
-  }
-
   stages {
     stage('check editorconfig') {
       steps {

--- a/build/build.groovy
+++ b/build/build.groovy
@@ -46,7 +46,7 @@ def buildIntegration(def mvnBuildArgs) {
 
 def build() {
   docker.build('maven', '-f build/Dockerfile.maven .').inside("") {
-    mvnBuild("-Pcockpit -Dengine.page.url=${params.engineSource}");
+    mvnBuild("-Pcockpit");
   }
 }
 


### PR DESCRIPTION
project-build-plugin validate no longer needs to download an engine. since this build is only validating, compiling and not executing any integration-test this param is now useless.