### PR TITLE
XIVY-18408-replace-icons-tabler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ classes/
 **/lib/mvn-deps/*
 .flattened-pom.xml
 /workspace
+
+# TODO: Remove
+icon-replacement/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ classes/
 **/lib/mvn-deps/*
 .flattened-pom.xml
 /workspace
-
-# TODO: Remove
-icon-replacement/

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -30,7 +30,8 @@ pipeline {
 
 def getTestFilter() {
   if (isReleasingBranch()) {
-    return 'WebTest*.java'
+    // return 'WebTest*.java'
+    return 'WebTestRoleDetail.java'
   }
   return params.testFilter
 }

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
 
   parameters {
     string(name: 'engineSource', defaultValue: 'https://product.ivyteam.io', description: 'Engine page url')
-    string(name: 'testFilter', defaultValue: 'WebTest*.java', description: 'Change to only run tests of the matching classes (flag will be gnored on master)')
+    string(name: 'testFilter', defaultValue: 'WebTestRoleDetail.java', description: 'Change to only run tests of the matching classes (flag will be gnored on master)')
   }
 
   stages {
@@ -30,8 +30,7 @@ pipeline {
 
 def getTestFilter() {
   if (isReleasingBranch()) {
-    // return 'WebTest*.java'
-    return 'WebTestRoleDetail.java'
+    return 'WebTest*.java'
   }
   return params.testFilter
 }

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
 
   parameters {
     string(name: 'engineSource', defaultValue: 'https://product.ivyteam.io', description: 'Engine page url')
-    string(name: 'testFilter', defaultValue: 'WebTestRoleDetail.java', description: 'Change to only run tests of the matching classes (flag will be gnored on master)')
+    string(name: 'testFilter', defaultValue: 'WebTest*.java', description: 'Change to only run tests of the matching classes (flag will be gnored on master)')
   }
 
   stages {
@@ -30,8 +30,7 @@ pipeline {
 
 def getTestFilter() {
   if (isReleasingBranch()) {
-    // return 'WebTest*.java'
-    'WebTestRoleDetail.java'
+    return 'WebTest*.java'
   }
   return params.testFilter
 }

--- a/build/integration/Jenkinsfile
+++ b/build/integration/Jenkinsfile
@@ -30,7 +30,8 @@ pipeline {
 
 def getTestFilter() {
   if (isReleasingBranch()) {
-    return 'WebTest*.java'
+    // return 'WebTest*.java'
+    'WebTestRoleDetail.java'
   }
   return params.testFilter
 }

--- a/engine-cockpit-selenium-test/pom.xml
+++ b/engine-cockpit-selenium-test/pom.xml
@@ -208,7 +208,8 @@
     <profile>
       <id>integration</id>
       <properties>
-        <test.filter>WebTest*.java</test.filter>
+        <!-- <test.filter>WebTest*.java</test.filter> -->
+        <test.filter>WebTestRoleDetail.java</test.filter>
       </properties>
 
       <build>

--- a/engine-cockpit-selenium-test/pom.xml
+++ b/engine-cockpit-selenium-test/pom.xml
@@ -208,8 +208,7 @@
     <profile>
       <id>integration</id>
       <properties>
-        <!-- <test.filter>WebTest*.java</test.filter> -->
-        <test.filter>WebTestRoleDetail.java</test.filter>
+        <test.filter>WebTest*.java</test.filter>
       </properties>
 
       <build>

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
@@ -98,11 +98,11 @@ class WebTestApplication {
     expandAppTree();
     // project of app test has override configured
     $$(".activity-name").find(exactText("portal-components")).parent().find(".table-icon")
-        .shouldHave(cssClass("ti-arrow-big-down-lines"))
+        .shouldHave(cssClass("ti ti-arrow-big-down-lines"))
         .shouldHave(attribute("title", "This PM is configured as strict override project"));
     // project of app test-ad has no override configured
     $$(".activity-name").find(exactText("portal-user-examples")).parent().find(".table-icon")
-        .shouldHave(cssClass("ti-packages"))
+        .shouldHave(cssClass("ti ti-packages"))
         .shouldHave(attribute("title", "PM"));
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
@@ -102,7 +102,7 @@ class WebTestApplication {
         .shouldHave(attribute("title", "This PM is configured as strict override project"));
     // project of app test-ad has no override configured
     $$(".activity-name").find(exactText("portal-user-examples")).parent().find(".table-icon")
-        .shouldHave(cssClass("si-module-three-2"))
+        .shouldHave(cssClass("ti-packages"))
         .shouldHave(attribute("title", "PM"));
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
@@ -98,11 +98,11 @@ class WebTestApplication {
     expandAppTree();
     // project of app test has override configured
     $$(".activity-name").find(exactText("portal-components")).parent().find(".table-icon")
-        .shouldHave(cssClass("ti ti-arrow-big-down-lines"))
+        .shouldHave(cssClass("ti-arrow-big-down-lines"))
         .shouldHave(attribute("title", "This PM is configured as strict override project"));
     // project of app test-ad has no override configured
     $$(".activity-name").find(exactText("portal-user-examples")).parent().find(".table-icon")
-        .shouldHave(cssClass("ti ti-packages"))
+        .shouldHave(cssClass("ti-packages"))
         .shouldHave(attribute("title", "PM"));
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplication.java
@@ -98,7 +98,7 @@ class WebTestApplication {
     expandAppTree();
     // project of app test has override configured
     $$(".activity-name").find(exactText("portal-components")).parent().find(".table-icon")
-        .shouldHave(cssClass("si-move-to-bottom"))
+        .shouldHave(cssClass("ti-arrow-big-down-lines"))
         .shouldHave(attribute("title", "This PM is configured as strict override project"));
     // project of app test-ad has no override configured
     $$(".activity-name").find(exactText("portal-user-examples")).parent().find(".table-icon")

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplicationDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/application/WebTestApplicationDetail.java
@@ -79,9 +79,9 @@ class WebTestApplicationDetail {
     waitUntilAjaxIsFinished();
     $("#appDetailSecurityForm\\:showAdSyncLogBtn").should(exist);
     $("#appDetailSecurityForm\\:synchronizeSecurity").shouldBe(visible, enabled).click();
-    $$("#appDetailSecurityForm\\:synchronizeSecurity span").first().shouldHave(cssClass("si-is-spinning"));
+    $$("#appDetailSecurityForm\\:synchronizeSecurity span").first().shouldHave(cssClass("spinning"));
     $$("#appDetailSecurityForm\\:synchronizeSecurity span").first()
-        .shouldHave(not(cssClass("si-is-spinning")), Duration.ofSeconds(20));
+        .shouldHave(not(cssClass("spinning")), Duration.ofSeconds(20));
 
     $("#appDetailSecurityForm\\:showAdSyncLogBtn").click();
     $$(".ui-panel-titlebar").find(text("usersynch.log")).parent()

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoleDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoleDetail.java
@@ -40,7 +40,7 @@ class WebTestRoleDetail {
   private static final String DIRECTORY_BROWSER_FORM = "#directoryBrowser\\:directoryBrowserForm\\:";
   private static final String DIRECTORY_BROWSER_DIALOG = "directoryBrowser:directoryBrowserDialog";
   private static final String ROLE_USERS_TABLE = "usersOfRoleForm:roleUserTable";
-  private static final String DETAIL_ROLE_NAME = "boss";
+  private static final String DETAIL_ROLE_NAME = "Boss";
 
   @BeforeEach
   void beforeEach() {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoleDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoleDetail.java
@@ -40,7 +40,7 @@ class WebTestRoleDetail {
   private static final String DIRECTORY_BROWSER_FORM = "#directoryBrowser\\:directoryBrowserForm\\:";
   private static final String DIRECTORY_BROWSER_DIALOG = "directoryBrowser:directoryBrowserDialog";
   private static final String ROLE_USERS_TABLE = "usersOfRoleForm:roleUserTable";
-  private static final String DETAIL_ROLE_NAME = "Boss";
+  private static final String DETAIL_ROLE_NAME = "boss";
 
   @BeforeEach
   void beforeEach() {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoles.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestRoles.java
@@ -88,7 +88,7 @@ class WebTestRoles {
     Tab.SECURITY_SYSTEM.switchToTab("test-ad");
     var syncBtnId = "#form\\:syncMoreBtn_button";
     $(syncBtnId).shouldBe(visible).click();
-    $(syncBtnId).findAll("span").first().shouldHave(cssClass("si-is-spinning"));
-    $(syncBtnId).findAll("span").first().shouldHave(not(cssClass("si-is-spinning")), Duration.ofSeconds(20));
+    $(syncBtnId).findAll("span").first().shouldHave(cssClass("spinning"));
+    $(syncBtnId).findAll("span").first().shouldHave(not(cssClass("spinning")), Duration.ofSeconds(20));
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
@@ -42,7 +42,7 @@ import ch.ivyteam.enginecockpit.util.Table;
 class WebTestUserDetail {
 
   private static final String CSS_MEMBER_INHERIT = "light";
-  private static final String CSS_MEMBER = "ti-circle-check";
+  private static final String CSS_MEMBER = "ti ti-circle-check";
   private static final String CSS_DISABLED = "ui-state-disabled";
   private static final String ROLE_REMOVE_BUTTON = "button:nth-child(2)";
   private static final String ROLE_ADD_BUTTON = "button:nth-child(1)";
@@ -270,9 +270,9 @@ class WebTestUserDetail {
 
   private void iconShouldHaveSubscribedState(SelenideElement icon, boolean subscribed) {
     if (subscribed) {
-      icon.shouldHave(cssClass("ti-circle-check"));
+      icon.shouldHave(cssClass("ti ti-circle-check"));
     } else {
-      icon.shouldHave(cssClass("ti-circle-minus"));
+      icon.shouldHave(cssClass("ti ti-circle-minus"));
     }
   }
 
@@ -310,7 +310,7 @@ class WebTestUserDetail {
   @Test
   void absences_isWorking() {
     Navigation.toUserDetail(USER_FOO);
-    $(By.id("working")).shouldHave(cssClass("ti-circle-check"));
+    $(By.id("working")).shouldHave(cssClass("ti ti-circle-check"));
   }
 
   @Test
@@ -319,7 +319,7 @@ class WebTestUserDetail {
     beforeEach();
     Navigation.toUserDetail(USER_FOO);
 
-    $(By.id("working")).shouldHave(cssClass("ti-circle-minus"));
+    $(By.id("working")).shouldHave(cssClass("ti ti-circle-minus"));
 
     Table table = new Table(By.id("absencesForm:absencesTable"));
     table.firstColumnShouldBe(size(2));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
@@ -272,7 +272,7 @@ class WebTestUserDetail {
     if (subscribed) {
       icon.shouldHave(cssClass("ti ti-circle-check"));
     } else {
-      icon.shouldHave(cssClass("ti ti-circle-minus"));
+      icon.shouldHave(cssClass("ti-circle-minus"), cssClass("ti"));
     }
   }
 

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
@@ -42,7 +42,7 @@ import ch.ivyteam.enginecockpit.util.Table;
 class WebTestUserDetail {
 
   private static final String CSS_MEMBER_INHERIT = "light";
-  private static final String CSS_MEMBER = "ti ti-circle-check";
+  private static final String CSS_MEMBER = "ti-circle-check";
   private static final String CSS_DISABLED = "ui-state-disabled";
   private static final String ROLE_REMOVE_BUTTON = "button:nth-child(2)";
   private static final String ROLE_ADD_BUTTON = "button:nth-child(1)";
@@ -270,9 +270,9 @@ class WebTestUserDetail {
 
   private void iconShouldHaveSubscribedState(SelenideElement icon, boolean subscribed) {
     if (subscribed) {
-      icon.shouldHave(cssClass("ti ti-circle-check"));
+      icon.shouldHave(cssClass("ti-circle-check"));
     } else {
-      icon.shouldHave(cssClass("ti-circle-minus"), cssClass("ti"));
+      icon.shouldHave(cssClass("ti-circle-minus"));
     }
   }
 
@@ -310,7 +310,7 @@ class WebTestUserDetail {
   @Test
   void absences_isWorking() {
     Navigation.toUserDetail(USER_FOO);
-    $(By.id("working")).shouldHave(cssClass("ti ti-circle-check"));
+    $(By.id("working")).shouldHave(cssClass("ti-circle-check"));
   }
 
   @Test
@@ -319,7 +319,7 @@ class WebTestUserDetail {
     beforeEach();
     Navigation.toUserDetail(USER_FOO);
 
-    $(By.id("working")).shouldHave(cssClass("ti ti-circle-minus"));
+    $(By.id("working")).shouldHave(cssClass("ti-circle-minus"));
 
     Table table = new Table(By.id("absencesForm:absencesTable"));
     table.firstColumnShouldBe(size(2));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUserDetail.java
@@ -42,7 +42,7 @@ import ch.ivyteam.enginecockpit.util.Table;
 class WebTestUserDetail {
 
   private static final String CSS_MEMBER_INHERIT = "light";
-  private static final String CSS_MEMBER = "si-check-circle";
+  private static final String CSS_MEMBER = "ti-circle-check";
   private static final String CSS_DISABLED = "ui-state-disabled";
   private static final String ROLE_REMOVE_BUTTON = "button:nth-child(2)";
   private static final String ROLE_ADD_BUTTON = "button:nth-child(1)";
@@ -270,9 +270,9 @@ class WebTestUserDetail {
 
   private void iconShouldHaveSubscribedState(SelenideElement icon, boolean subscribed) {
     if (subscribed) {
-      icon.shouldHave(cssClass("si-check-circle-1"));
+      icon.shouldHave(cssClass("ti-circle-check"));
     } else {
-      icon.shouldHave(cssClass("si-remove-circle"));
+      icon.shouldHave(cssClass("ti-circle-minus"));
     }
   }
 
@@ -310,7 +310,7 @@ class WebTestUserDetail {
   @Test
   void absences_isWorking() {
     Navigation.toUserDetail(USER_FOO);
-    $(By.id("working")).shouldHave(cssClass("si-check-circle-1"));
+    $(By.id("working")).shouldHave(cssClass("ti-circle-check"));
   }
 
   @Test
@@ -319,7 +319,7 @@ class WebTestUserDetail {
     beforeEach();
     Navigation.toUserDetail(USER_FOO);
 
-    $(By.id("working")).shouldHave(cssClass("si-remove-circle"));
+    $(By.id("working")).shouldHave(cssClass("ti-circle-minus"));
 
     Table table = new Table(By.id("absencesForm:absencesTable"));
     table.firstColumnShouldBe(size(2));

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUsers.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/security/WebTestUsers.java
@@ -246,7 +246,7 @@ class WebTestUsers {
     Tab.SECURITY_SYSTEM.switchToTab("test-ad");
     String syncBtnId = "#form\\:syncMoreBtn_button";
     $(syncBtnId).shouldBe(visible).click();
-    $(syncBtnId).findAll("span").first().shouldHave(cssClass("si-is-spinning"));
-    $(syncBtnId).findAll("span").first().shouldHave(not(cssClass("si-is-spinning")), Duration.ofSeconds(20));
+    $(syncBtnId).findAll("span").first().shouldHave(cssClass("spinning"));
+    $(syncBtnId).findAll("span").first().shouldHave(not(cssClass("spinning")), Duration.ofSeconds(20));
   }
 }

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseHistory.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestDatabaseHistory.java
@@ -44,7 +44,7 @@ class WebTestDatabaseHistory {
     new Table(By.id("databaseExecHistoryForm:databaseExecHistoryTable"))
         .firstColumnShouldBe(sizeGreaterThan(0));
 
-    $(".si-copy-paste").shouldBe(visible).click();
+    $(".ti-copy").shouldBe(visible).click();
     var copyPasteAlert = switchTo().alert();
     assertThat(copyPasteAlert.getText()).contains("Person");
     copyPasteAlert.accept();

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestPushNotificationChannel.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestPushNotificationChannel.java
@@ -55,15 +55,15 @@ public class WebTestPushNotificationChannel {
     login();
     Navigation.toNotificationChannelDetail("mail");
 
-    $(By.id("form:state")).$("i.si-remove-circle").shouldBe(Condition.visible);
-    $(By.id("form:state")).$("i.si-synchronize-arrow-clock").shouldBe(Condition.visible);
+    $(By.id("form:state")).$("i.ti-circle-minus").shouldBe(Condition.visible);
+    $(By.id("form:state")).$("i.ti-clock-play").shouldBe(Condition.visible);
     $(By.id("form:state")).click();
     var lockDetails = $(By.cssSelector("[id*='lockDetails']"));
     assertLockDetails(lockDetails);
 
     $(By.id("open")).click();
 
-    $(By.id("form:state")).$("i.si-check-circle-1").shouldBe(Condition.visible);
+    $(By.id("form:state")).$("i.ti-circle-check").shouldBe(Condition.visible);
   }
 
   @Test
@@ -74,8 +74,8 @@ public class WebTestPushNotificationChannel {
     Navigation.toNotificationChannels();
     Table table = new Table(By.id("securitySystems:securitySystemTabView:" + Tab.SECURITY_SYSTEM.getSelectedTabIndex() + ":tableForm:" + WebTestNotificationChannels.TABLE_ID), true);
 
-    table.tableEntry("Email", 4, 2).$("i.si-remove-circle").shouldBe(Condition.visible);
-    table.tableEntry("Email", 4, 2).$("i.si-synchronize-arrow-clock").shouldBe(Condition.visible);
+    table.tableEntry("Email", 4, 2).$("i.ti-circle-minus").shouldBe(Condition.visible);
+    table.tableEntry("Email", 4, 2).$("i.ti-clock-play").shouldBe(Condition.visible);
     table.tableEntry("Email", 4, 2).click();
     var lockDetails = $(By.id("securitySystems:securitySystemTabView:" + Tab.SECURITY_SYSTEM.getSelectedTabIndex() + ":tableForm:channelsTable:2:state:lockDetails"));
     assertLockDetails(lockDetails);
@@ -84,7 +84,7 @@ public class WebTestPushNotificationChannel {
     $(By.id("open")).click();
     Navigation.toNotificationChannels();
 
-    table.tableEntry("Email", 4, 2).$("i.si-check-circle-1").shouldBe(Condition.visible);
+    table.tableEntry("Email", 4, 2).$("i.ti-circle-check").shouldBe(Condition.visible);
   }
 
   @Test

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
@@ -49,8 +49,8 @@ class WebTestSearchEngine {
     $(By.id("searchEngineInfoForm:name")).shouldBe(text("ivy-opensearch"));
     $(By.id("searchEngineInfoForm:url")).shouldBe(exactText("http://localhost:19200"));
     $(By.id("searchEngineInfoForm:version")).shouldNotBe(empty);
-    $("#searchEngineInfoForm\\:state > i").shouldHave(cssClass("ti ti-circle-check"));
-    $("#searchEngineInfoForm\\:health > i").shouldHave(cssClass("ti ti-circle-check"));
+    $("#searchEngineInfoForm\\:state > i").shouldHave(cssClass("ti-circle-check"));
+    $("#searchEngineInfoForm\\:health > i").shouldHave(cssClass("ti-circle-check"));
     $(By.id("searchEngineInfoForm:diskThreshold")).shouldHave(text("true"));
     $(By.id("searchEngineInfoForm:watermarkLow")).shouldNotBe(empty);
     $(By.id("searchEngineInfoForm:watermarkHigh")).shouldNotBe(empty);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
@@ -49,8 +49,8 @@ class WebTestSearchEngine {
     $(By.id("searchEngineInfoForm:name")).shouldBe(text("ivy-opensearch"));
     $(By.id("searchEngineInfoForm:url")).shouldBe(exactText("http://localhost:19200"));
     $(By.id("searchEngineInfoForm:version")).shouldNotBe(empty);
-    $("#searchEngineInfoForm\\:state > i").shouldHave(cssClass("ti-circle-check"));
-    $("#searchEngineInfoForm\\:health > i").shouldHave(cssClass("ti-circle-check"));
+    $("#searchEngineInfoForm\\:state > i").shouldHave(cssClass("ti ti-circle-check"));
+    $("#searchEngineInfoForm\\:health > i").shouldHave(cssClass("ti ti-circle-check"));
     $(By.id("searchEngineInfoForm:diskThreshold")).shouldHave(text("true"));
     $(By.id("searchEngineInfoForm:watermarkLow")).shouldNotBe(empty);
     $(By.id("searchEngineInfoForm:watermarkHigh")).shouldNotBe(empty);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/services/WebTestSearchEngine.java
@@ -49,8 +49,8 @@ class WebTestSearchEngine {
     $(By.id("searchEngineInfoForm:name")).shouldBe(text("ivy-opensearch"));
     $(By.id("searchEngineInfoForm:url")).shouldBe(exactText("http://localhost:19200"));
     $(By.id("searchEngineInfoForm:version")).shouldNotBe(empty);
-    $("#searchEngineInfoForm\\:state > i").shouldHave(cssClass("si-check-circle-1"));
-    $("#searchEngineInfoForm\\:health > i").shouldHave(cssClass("si-check-circle-1"));
+    $("#searchEngineInfoForm\\:state > i").shouldHave(cssClass("ti-circle-check"));
+    $("#searchEngineInfoForm\\:health > i").shouldHave(cssClass("ti-circle-check"));
     $(By.id("searchEngineInfoForm:diskThreshold")).shouldHave(text("true"));
     $(By.id("searchEngineInfoForm:watermarkLow")).shouldNotBe(empty);
     $(By.id("searchEngineInfoForm:watermarkHigh")).shouldNotBe(empty);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/system/WebTestSystemDb.java
@@ -160,7 +160,7 @@ public class WebTestSystemDb {
     $(By.id("systemDb:createDatabaseForm:confirmCreateButton")).click();
     $(By.id("systemDb:createDatabaseForm:confirmCreateButton")).shouldNotBe(enabled);
     $("#systemDb\\:createDatabaseForm\\:confirmCreateButton > .ui-icon")
-        .shouldHave(cssClass("si-is-spinning"));
+        .shouldHave(cssClass("spinning"));
     $("#systemDb\\:createDatabaseForm\\:closeCreationButton")
         .shouldBe(and("wait until db created", appear, enabled), Duration.ofSeconds(20));
     $("#systemDb\\:createDatabaseForm\\:creationError").shouldNot(exist);

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -170,7 +170,7 @@ public class Navigation {
   }
 
   public static void toUserDetail(String userName) {
-    toUserDetail("~Developer-engine-cockpit", userName);
+    toUserDetail("default", userName);
   }
 
   public static void toUserDetail(String system, String userName) {
@@ -189,7 +189,7 @@ public class Navigation {
   }
 
   public static void toRoleDetail(String roleName) {
-    toRoleDetail("~Developer-engine-cockpit", roleName);
+    toRoleDetail("default", roleName);
   }
 
   public static void toRoleDetail(String system, String roleName) {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Navigation.java
@@ -170,7 +170,7 @@ public class Navigation {
   }
 
   public static void toUserDetail(String userName) {
-    toUserDetail("default", userName);
+    toUserDetail("~Developer-engine-cockpit", userName);
   }
 
   public static void toUserDetail(String system, String userName) {
@@ -189,7 +189,7 @@ public class Navigation {
   }
 
   public static void toRoleDetail(String roleName) {
-    toRoleDetail("default", roleName);
+    toRoleDetail("~Developer-engine-cockpit", roleName);
   }
 
   public static void toRoleDetail(String system, String roleName) {

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
@@ -23,7 +23,7 @@ public class Tab {
       "li.security-system-tab",
       "li.security-system-tab.ui-state-active",
       ".ui-tabs-panel:not(.ui-helper-hidden)",
-      tab -> tab.switchToTab("default"));
+      tab -> tab.switchToTab("~Developer-engine-cockpit"));
 
   public static final Tab APP = new Tab(
       "li.application-tab > a",

--- a/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
+++ b/engine-cockpit-selenium-test/test/ch/ivyteam/enginecockpit/util/Tab.java
@@ -23,7 +23,7 @@ public class Tab {
       "li.security-system-tab",
       "li.security-system-tab.ui-state-active",
       ".ui-tabs-panel:not(.ui-helper-hidden)",
-      tab -> tab.switchToTab("~Developer-engine-cockpit"));
+      tab -> tab.switchToTab("default"));
 
   public static final Tab APP = new Tab(
       "li.application-tab > a",

--- a/engine-cockpit-test-data/src_hd/engine/cockpit/test/data/DummyHtmlDialog/DummyHtmlDialog.xhtml
+++ b/engine-cockpit-test-data/src_hd/engine/cockpit/test/data/DummyHtmlDialog/DummyHtmlDialog.xhtml
@@ -13,7 +13,7 @@
         <br />
         <div class="command-btns">
           <p:commandLink id="cancel" actionListener="#{ivyWorkflowView.cancel()}" value="Cancel" />
-          <p:commandButton id="proceed" actionListener="#{logic.close}" value="Proceed" update="form" icon="pi pi-check" />
+          <p:commandButton id="proceed" actionListener="#{logic.close}" value="Proceed" update="form" icon="ti ti-check" />
         </div>
       </h:form>
 </h:body>

--- a/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/health/TestHealthBean.java
+++ b/engine-cockpit-test/src_test/ch/ivyteam/enginecockpit/monitor/health/TestHealthBean.java
@@ -42,7 +42,7 @@ class TestHealthBean {
     assertThat(check.getDescription()).isEqualTo("Checks if this is a release candidate version");
     assertThat(check.getSeverity()).isEqualTo(HealthSeverity.HEALTHY);
     assertThat(check.getSeverityClass()).isEqualTo("health-healthy");
-    assertThat(check.getSeverityIcon()).isEqualTo("si si-check-1");
+    assertThat(check.getSeverityIcon()).isEqualTo("ti ti-check");
     assertThat(check.getNextExecution()).isEqualTo("n.a.");
     assertThat(check.getTimeUntilNextExecution()).isEqualTo("n.a.");
 
@@ -50,7 +50,7 @@ class TestHealthBean {
 
     assertThat(check.getSeverity()).isEqualTo(HealthSeverity.HIGH);
     assertThat(check.getSeverityClass()).isEqualTo("health-high");
-    assertThat(check.getSeverityIcon()).isEqualTo("si si-alert-circle");
+    assertThat(check.getSeverityIcon()).isEqualTo("ti ti-alert-circle");
   }
 
   @Test
@@ -88,7 +88,7 @@ class TestHealthBean {
     assertThat(msg.getDescription()).isEqualTo("Don't use this version in production it is a release candidate");
     assertThat(msg.getSeverity()).isEqualTo(HealthSeverity.HIGH);
     assertThat(msg.getSeverityClass()).isEqualTo("health-high");
-    assertThat(msg.getSeverityIcon()).isEqualTo("si si-alert-circle");
+    assertThat(msg.getSeverityIcon()).isEqualTo("ti ti-alert-circle");
     assertThat(msg.getActionLink()).isEqualTo("https://developer.axonivy.com/download");
     assertThat(msg.getCheck()).isEqualTo("Release Candidate");
   }
@@ -96,13 +96,13 @@ class TestHealthBean {
   @Test
   void severity() {
     assertThat(testee.getSeverityClass()).isEqualTo("health-healthy");
-    assertThat(testee.getSeverityIcon()).isEqualTo("si si-check-1");
+    assertThat(testee.getSeverityIcon()).isEqualTo("ti ti-check");
     assertThat(testee.getSeverityName()).isEqualTo("HEALTHY");
 
     runCheck();
 
     assertThat(testee.getSeverityClass()).isEqualTo("health-high");
-    assertThat(testee.getSeverityIcon()).isEqualTo("si si-alert-circle");
+    assertThat(testee.getSeverityIcon()).isEqualTo("ti ti-alert-circle");
     assertThat(testee.getSeverityName()).isEqualTo("HIGH");
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/Application.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/Application.java
@@ -87,7 +87,7 @@ public class Application extends AppTreeItem {
   }
 
   public String getIcon() {
-    return "module";
+    return "ti ti-cube";
   }
 
   @Override
@@ -138,11 +138,11 @@ public class Application extends AppTreeItem {
   @Override
   public String getReleaseStateIcon() {
     return switch (getReleaseState()) {
-      case RELEASED -> "check-circle-1";
-      case DEPRECATED -> "delete";
-      case ARCHIVED -> "archive";
-      case CREATED, PREPARED -> "advertising-megaphone-2";
-      default -> "question-circle";
+      case RELEASED -> "ti ti-circle-check";
+      case DEPRECATED -> "ti ti-circle-half-vertical";
+      case ARCHIVED -> "ti ti-archive";
+      case CREATED, PREPARED -> "ti ti-speakerphone";
+      default -> "ti ti-help-circle";
     };
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModelVersion.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/ProcessModelVersion.java
@@ -57,7 +57,7 @@ public class ProcessModelVersion extends AppTreeItem {
   }
 
   public String getIcon() {
-    return "module-three-1";
+    return "ti ti-packages";
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/StateOfActivity.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/StateOfActivity.java
@@ -115,7 +115,7 @@ public class StateOfActivity {
         this.operationIcon = "remove-circle";
         break;
       default:
-        this.operationIcon = "button-refresh-arrows si-is-spinning";
+        this.operationIcon = "button-refresh-arrows spinning";
         this.processing = true;
     }
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/StateOfActivity.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/application/model/StateOfActivity.java
@@ -90,10 +90,10 @@ public class StateOfActivity {
     this.activityState = update.name();
     switch (update) {
       case ACTIVE:
-        this.activityStateIcon = "check-circle-1";
+        this.activityStateIcon = "ti ti-circle-check";
         break;
       default:
-        this.activityStateIcon = "button-pause";
+        this.activityStateIcon = "ti ti-player-pause";
     }
   }
 
@@ -106,16 +106,16 @@ public class StateOfActivity {
     switch (update) {
       case ACTIVE:
       case LOCKED:
-        this.operationIcon = "check-circle-1";
+        this.operationIcon = "ti ti-circle-check";
         break;
       case INACTIVE:
-        this.operationIcon = "button-pause";
+        this.operationIcon = "ti ti-player-pause";
         break;
       case ERROR:
-        this.operationIcon = "remove-circle";
+        this.operationIcon = "ti ti-circle-minus";
         break;
       default:
-        this.operationIcon = "button-refresh-arrows spinning";
+        this.operationIcon = "ti ti-refresh spinning";
         this.processing = true;
     }
   }
@@ -127,20 +127,20 @@ public class StateOfActivity {
     this.releaseState = update.name();
     switch (update) {
       case RELEASED:
-        this.releaseStateIcon = "check-circle-1";
+        this.releaseStateIcon = "ti ti-circle-check";
         break;
       case DEPRECATED:
-        this.releaseStateIcon = "delete";
+        this.releaseStateIcon = "ti ti-circle-half-vertical";
         break;
       case ARCHIVED:
-        this.releaseStateIcon = "archive";
+        this.releaseStateIcon = "ti ti-archive";
         break;
       case CREATED:
       case PREPARED:
-        this.releaseStateIcon = "advertising-megaphone-2";
+        this.releaseStateIcon = "ti ti-speakerphone";
         break;
       default:
-        this.releaseStateIcon = "question-circle";
+        this.releaseStateIcon = "ti ti-help-circle";
     }
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/BusinessCalendar.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/BusinessCalendar.java
@@ -108,28 +108,28 @@ public class BusinessCalendar {
     public TimeDayConfig(FreeDayOfYear freeDay, String calendarName) {
       this(freeDay);
       this.calendarName = calendarName;
-      this.icon = "synchronize-arrow-clock";
+      this.icon = "ti ti-clock-play";
       this.tooltip = Ivy.cm().co("/freeDays/FreeDayOfYearTooltip");
     }
 
     public TimeDayConfig(FreeEasterRelativeDay freeDay, String calendarName) {
       this(freeDay);
       this.calendarName = calendarName;
-      this.icon = "synchronize-arrow-clock";
+      this.icon = "ti ti-clock-play";
       this.tooltip = Ivy.cm().co("/freeDays/FreeEasterRelativeDayTooltip");
     }
 
     public TimeDayConfig(FreeDate freeDay, String calendarName) {
       this(freeDay);
       this.calendarName = calendarName;
-      this.icon = "time-clock-circle";
+      this.icon = "ti ti-clock";
       this.tooltip = Ivy.cm().co("/freeDays/FreeDateTooltip");
     }
 
     public TimeDayConfig(WorkingTime time, String calendarName) {
       this(time);
       this.calendarName = calendarName;
-      this.icon = "hourglass";
+      this.icon = "ti ti-hourglass-low";
       this.tooltip = Ivy.cm().co("/weekConfiguration/DefinedWorkingTime");
     }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
@@ -142,12 +142,12 @@ public class ConfigProperty {
       return "password-lock-2";
     }
     if (configValueFormat == ConfigValueFormat.FILE) {
-      return "common-file-text";
+      return "file-text";
     }
     if (configValueFormat == ConfigValueFormat.EXPRESSION) {
-      return "archive-folder";
+      return "archive";
     }
-    return "cog";
+    return "settings";
   }
 
   public String getConfigValueFormat() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/configuration/model/ConfigProperty.java
@@ -139,15 +139,15 @@ public class ConfigProperty {
 
   public String getIcon() {
     if (isPassword()) {
-      return "password-lock-2";
+      return "ti ti-password-lock-2";
     }
     if (configValueFormat == ConfigValueFormat.FILE) {
-      return "file-text";
+      return "ti ti-file-text";
     }
     if (configValueFormat == ConfigValueFormat.EXPRESSION) {
-      return "archive";
+      return "ti ti-archive";
     }
-    return "settings";
+    return "ti ti-settings";
   }
 
   public String getConfigValueFormat() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/deployment/DeploymentStatus.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/deployment/DeploymentStatus.java
@@ -44,9 +44,9 @@ public class DeploymentStatus {
 
   public String getIconClass() {
     return switch (state) {
-      case RUNNING -> "si-button-refresh-arrows si-is-spinning";
-      case SUCCESS -> "si-check-circle-1";
-      case ERROR -> "si-alert-circle";
+      case RUNNING -> "ti-refresh spinning";
+      case SUCCESS -> "ti-circle-check";
+      case ERROR -> "ti-alert-circle";
       default -> "";
     };
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/deployment/DeploymentStatus.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/deployment/DeploymentStatus.java
@@ -44,9 +44,9 @@ public class DeploymentStatus {
 
   public String getIconClass() {
     return switch (state) {
-      case RUNNING -> "ti-refresh spinning";
-      case SUCCESS -> "ti-circle-check";
-      case ERROR -> "ti-alert-circle";
+      case RUNNING -> "ti ti-refresh spinning";
+      case SUCCESS -> "ti ti-circle-check";
+      case ERROR -> "ti ti-alert-circle";
       default -> "";
     };
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/OsBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/OsBean.java
@@ -25,20 +25,20 @@ import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
 @ViewScoped
 public class OsBean {
   private final Monitor memoryMonitor = Monitor.build().name(cm().co("/monitor/Memory"))
-      .icon("analytics-board-graph-line")
+      .icon("ti ti-chart-line")
       .yAxisLabel(cm().co("/monitor/Memory"))
       .reverseColors()
       .toMonitor();
   private final Monitor cpuMonitor = Monitor.build().name(cm().co("/monitor/CPULoad"))
-      .icon("computer-chip")
+      .icon("ti ti-cpu")
       .yAxisLabel(cm().co("/monitor/Load"))
       .toMonitor();
   private final Monitor networkMonitor = Monitor.build().name(cm().co("/monitor/Network"))
-      .icon("network-signal")
+      .icon("ti ti-building-broadcast-tower")
       .yAxisLabel(cm().co("/monitor/SendRecv"))
       .toMonitor();
   private final Monitor ioMonitor = Monitor.build().name(cm().co("/monitor/IO"))
-      .icon("cd")
+      .icon("ti ti-device-floppy")
       .yAxisLabel(cm().co("/monitor/ReadWrite"))
       .toMonitor();
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/health/HealthBean.java
@@ -47,10 +47,10 @@ public class HealthBean {
 
   private static String severityIcon(HealthSeverity severity) {
     return switch (severity) {
-      case HEALTHY -> "si si-check-1";
-      case LOW -> "si si-road-sign-warning";
-      case HIGH -> "si si-alert-circle";
-      case CRITICAL -> "si si-alarm-bell";
+      case HEALTHY -> "ti ti-check";
+      case LOW -> "ti ti-alert-triangle";
+      case HIGH -> "ti ti-alert-circle";
+      case CRITICAL -> "ti ti-bell";
     };
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/JvmMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/JvmMonitorBean.java
@@ -22,14 +22,14 @@ import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
 @ViewScoped
 public class JvmMonitorBean {
   private final Monitor cpuMonitor = Monitor.build().name(cm().co("/monitor/CPULoad"))
-      .icon("computer-chip")
+      .icon("ti ti-cpu")
       .yAxisLabel(cm().co("/monitor/Load"))
       .toMonitor();
   private final Monitor classesMonitor = Monitor.build().name(cm().co("/monitor/Classes"))
-      .icon("coffee-cup")
+      .icon("ti ti-coffee")
       .toMonitor();
   private final Monitor threadsMonitor = Monitor.build().name(cm().co("/common/Threads"))
-      .icon("analytics-graph")
+      .icon("ti ti-chart-dots")
       .toMonitor();
 
   public JvmMonitorBean() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/MemoryMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/jvm/MemoryMonitorBean.java
@@ -24,15 +24,15 @@ import ch.ivyteam.enginecockpit.monitor.value.ValueProvider;
 @ViewScoped
 public class MemoryMonitorBean {
   private final Monitor heapMemoryMonitor = Monitor.build().name(cm().co("/monitor/HeapMemory"))
-      .icon("analytics-board-graph-line")
+      .icon("ti ti-chart-line")
       .yAxisLabel(cm().co("/monitor/Memory"))
       .toMonitor();
   private final Monitor nonHeapMemoryMonitor = Monitor.build().name(cm().co("/monitor/NonHeapMemory"))
-      .icon("analytics-board-graph-line")
+      .icon("ti ti-chart-line")
       .yAxisLabel(cm().co("/monitor/Memory"))
       .toMonitor();
   private final Monitor gcMonitor = Monitor.build().name(cm().co("/monitor/GarbageCollection"))
-      .icon("recycling-trash-bin-2")
+      .icon("ti ti-recycle")
       .yAxisLabel(cm().co("/monitor/Time"))
       .toMonitor();
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/RequestMonitorBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/monitor/mbeans/tomcat/RequestMonitorBean.java
@@ -26,10 +26,10 @@ import ch.ivyteam.ivy.environment.Ivy;
 @ViewScoped
 public class RequestMonitorBean {
   private final Monitor requestsMonitor =
-      Monitor.build().name(Ivy.cm().co("/liveStats/Requests")).icon("network-signal").toMonitor();
+      Monitor.build().name(Ivy.cm().co("/liveStats/Requests")).icon("ti ti-building-broadcast-tower").toMonitor();
   private final Monitor errorsMonitor =
-      Monitor.build().name(Ivy.cm().co("/common/Errors")).icon("global-warming-globe-fire").toMonitor();
-  private final Monitor bytesMonitor = Monitor.build().name(Ivy.cm().co("/liveStats/Bytes")).icon("cd")
+      Monitor.build().name(Ivy.cm().co("/common/Errors")).icon("ti ti-world-exclamation").toMonitor();
+  private final Monitor bytesMonitor = Monitor.build().name(Ivy.cm().co("/liveStats/Bytes")).icon("ti ti-device-floppy")
       .yAxisLabel(Ivy.cm().co("/liveStats/Bytes")).toMonitor();
   private final Monitor processingTimeMonitor = Monitor.build().name(Ivy.cm().co("/liveStats/ProcessingTime"))
       .icon("optimization-timer").yAxisLabel(Ivy.cm().co("/common/Time")).toMonitor();

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/directory/DirectoryBrowserBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/directory/DirectoryBrowserBean.java
@@ -45,11 +45,11 @@ public class DirectoryBrowserBean {
 
   public String icon(DirectoryNode node) {
     return switch (node.type()) {
-      case DEFAULT -> "folder-empty";
-      case DOMAIN -> "buildings-1";
-      case GROUP -> "multiple-neutral-1";
-      case ORGANIZATION -> "folder-share";
-      case USER -> "single-neutral-actions";
+      case DEFAULT -> "ti ti-folder-open";
+      case DOMAIN -> "ti ti-buildings";
+      case GROUP -> "ti ti-users";
+      case ORGANIZATION -> "ti ti-folder-share";
+      case USER -> "ti ti-user";
     };
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/NotificationChannelDto.java
@@ -66,10 +66,10 @@ public class NotificationChannelDto {
     var iconTitle = new StringBuilder();
 
     if (subscribedByUser || (useDefault && subscription.isSubscribedByDefault())) {
-      icon.append("check-circle-1 state-active");
+      icon.append("ti ti-circle-check state-active");
       iconTitle.append(Ivy.cm().co("/userDetailNotifications/Subscribed"));
     } else {
-      icon.append("remove-circle state-inactive");
+      icon.append("ti ti-circle-minus state-inactive");
       iconTitle.append(Ivy.cm().co("/userDetailNotifications/NotSubscribed"));
     }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/Role.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/Role.java
@@ -58,7 +58,7 @@ public class Role implements SecurityMember {
 
   @Override
   public String getCssIconClass() {
-    return "si si-multiple-neutral-1";
+    return "ti ti-users";
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
@@ -81,7 +81,7 @@ public class User implements SecurityMember {
 
   @Override
   public String getCssIconClass() {
-    return "si si-single-neutral-actions";
+    return "ti ti-user-check";
   }
 
   @Override

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/security/model/User.java
@@ -311,16 +311,16 @@ public class User implements SecurityMember {
       String memberIcon;
       String memberTitle;
       if (substitutionRole == null) {
-        memberIcon = "single-neutral-actions";
+        memberIcon = "ti ti-user";
         memberTitle = Ivy.cm().co("/userDetailSubstitutes/Personal");
       } else {
         role = substitutionRole.getName();
-        memberIcon = "multiple-neutral-1";
+        memberIcon = "ti ti-users";
         memberTitle = Ivy.cm().co("/common/Role");
       }
 
       boolean onAbsence = SubstitutionType.ON_ABSENCE.equals(substitute.getSubstitutionType());
-      String typeIcon = onAbsence ? "time-clock-circle" : "pin";
+      String typeIcon = onAbsence ? "ti ti-clock" : "ti ti-pin";
       String typeTitle =
           onAbsence ? Ivy.cm().co("/userDetailSubstitutes/OnAbsence") : Ivy.cm().co("/userDetailSubstitutes/Permanent");
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/SearchEngine.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/model/SearchEngine.java
@@ -63,10 +63,10 @@ public class SearchEngine {
 
   public enum SearchEngineHealth {
 
-    GREEN("green", "check-circle-1", Ivy.cm().co("/searchEngine/SearchEngineHealthGreenHint")),
-    YELLOW("yellow", "check-circle-1", Ivy.cm().co("/searchEngine/SearchEngineHealthYellowHint")),
-    RED("red", "remove-circle", Ivy.cm().co("/searchEngine/SearchEngineHealthRedHint")),
-    UNKNOWN("unknown", "question-circle", Ivy.cm().co("/searchEngine/SearchEngineHealthUnknownHint"));
+    GREEN("green", "ti ti-circle-check", Ivy.cm().co("/searchEngine/SearchEngineHealthGreenHint")),
+    YELLOW("yellow", "ti ti-circle-check", Ivy.cm().co("/searchEngine/SearchEngineHealthYellowHint")),
+    RED("red", "ti ti-circle-minus", Ivy.cm().co("/searchEngine/SearchEngineHealthRedHint")),
+    UNKNOWN("unknown", "ti ti-help-circle", Ivy.cm().co("/searchEngine/SearchEngineHealthUnknownHint"));
 
     private final String state;
     private final String icon;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDto.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/notification/NotificationChannelDto.java
@@ -116,8 +116,8 @@ public class NotificationChannelDto {
 
   public String getStateIcon() {
     return switch (getStateText()) {
-      case "Open" -> "si si-check-circle-1 state-active";
-      case "Locked" -> "si si-remove-circle state-inactive";
+      case "Open" -> "ti ti-circle-check state-active";
+      case "Locked" -> "ti ti-circle-minus state-inactive";
       default -> "";
     };
   }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
@@ -72,7 +72,7 @@ public class SearchEngineIndex {
   public enum IndexStatus {
     OPEN("open", "pi pi-lock-open state-active", Ivy.cm().co("/indices/OpenIndexHint")),
     CLOSED("closed", "pi pi-lock-closed state-inactive",  Ivy.cm().co("/indices/ClosedIndexHint")),
-    UNKNOWN("unknown", "si si-question-circle", "");
+    UNKNOWN("unknown", "ti ti-help-circle", "");
 
     private final String state;
     private final String icon;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
@@ -71,7 +71,7 @@ public class SearchEngineIndex {
 
   public enum IndexStatus {
     OPEN("open", "pi pi-lock-open state-active", Ivy.cm().co("/indices/OpenIndexHint")),
-    CLOSED("closed", "pi pi-lock-closed state-inactive",  Ivy.cm().co("/indices/ClosedIndexHint")),
+    CLOSED("closed", "pi pi-lock state-inactive",  Ivy.cm().co("/indices/ClosedIndexHint")),
     UNKNOWN("unknown", "ti ti-help-circle", "");
 
     private final String state;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/services/search/SearchEngineIndex.java
@@ -70,8 +70,8 @@ public class SearchEngineIndex {
   }
 
   public enum IndexStatus {
-    OPEN("open", "pi pi-lock-open state-active", Ivy.cm().co("/indices/OpenIndexHint")),
-    CLOSED("closed", "pi pi-lock state-inactive",  Ivy.cm().co("/indices/ClosedIndexHint")),
+    OPEN("open", "ti ti-lock-open-2 state-active", Ivy.cm().co("/indices/OpenIndexHint")),
+    CLOSED("closed", "ti ti-lock state-inactive",  Ivy.cm().co("/indices/ClosedIndexHint")),
     UNKNOWN("unknown", "ti ti-help-circle", "");
 
     private final String state;

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/MigrationBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/MigrationBean.java
@@ -126,9 +126,9 @@ public class MigrationBean {
 
   public String getStartMigrationButtonIcon() {
     return switch (running) {
-      case START -> "si si-controls-play";
-      case RUNNING -> "si si-button-refresh-arrows si-is-spinning";
-      case FINISHED -> "si si-check-1";
+      case START -> "ti ti-player-play";
+      case RUNNING -> "ti ti-refresh spinning";
+      case FINISHED -> "ti ti-check";
     };
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
@@ -31,7 +31,7 @@ public class Task {
 
   public void run() {
     state = "running";
-    stateIcon = "button-refresh-arrows spinning";
+    stateIcon = "ti ti-refresh spinning";
   }
 
   public String getScript() {
@@ -40,7 +40,7 @@ public class Task {
 
   public void done() {
     state = DONE;
-    stateIcon = "check-circle-1 state-active";
+    stateIcon = "ti ti-circle-check state-active";
   }
 
   public boolean isDone() {
@@ -49,7 +49,7 @@ public class Task {
 
   public void fail() {
     state = "fail";
-    stateIcon = "remove-circle state-inactive";
+    stateIcon = "ti ti-circle-minus state-inactive";
   }
 
   public String getName() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
@@ -31,7 +31,7 @@ public class Task {
 
   public void run() {
     state = "running";
-    stateIcon = "button-refresh-arrows si-is-spinning";
+    stateIcon = "button-refresh-arrows spinning";
   }
 
   public String getScript() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/setup/migration/Task.java
@@ -21,7 +21,7 @@ public class Task {
     this.version = task.version();
     this.name = task.name();
     this.description = task.description();
-    this.stateIcon = "time-clock-circle";
+    this.stateIcon = "ti ti-clock";
     this.script = task.script();
   }
 

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ClusterNode.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ClusterNode.java
@@ -99,7 +99,7 @@ public class ClusterNode {
     if (isLicensed()) {
       return "";
     }
-    return "si si-real-estate-action-house-key table-icon state-inactive";
+    return "ti ti-home-up table-icon state-inactive";
   }
 
   public Version getIvyVersion() {

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ConnectionInfo.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/model/ConnectionInfo.java
@@ -17,7 +17,7 @@ public class ConnectionInfo {
     label = Ivy.cm().co("/systemDb/ConnectionInfoLabel");
     advise = Ivy.cm().co("/systemDb/ConnectionInfoAdvise");
     messageLevel = "ui-message-info";
-    icon = "si si-question-circle";
+    icon = "ti ti-help-circle";
   }
 
   public ConnectionInfo(ConnectionTestResult result) {
@@ -82,11 +82,11 @@ public class ConnectionInfo {
 
   private static String getIcon(ConnectionTestResult result) {
     if (result.isSuccessful()) {
-      return "si si-check-circle";
+      return "ti ti-circle-check";
     } else if (result.isFailed()) {
-      return "si si-delete-1";
+      return "ti ti-trash";
     }
-    return "si si-question-circle";
+    return "ti ti-help-circle";
   }
 
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
@@ -98,11 +98,11 @@ public class TlsTesterBean {
 
   public String icon(String result) {
     if (result.contains("0")) {
-      return "circle-minus state-inactive";
+      return "ti ti-circle-minus state-inactive";
     }
     if (result.contains("1")) {
-      return "circle-check-1 state-active";
+      return "ti ti-circle-check-1 state-active";
     }
-    return "help-circle state-unused";
+    return "ti ti-help-circle state-unused";
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
@@ -98,11 +98,11 @@ public class TlsTesterBean {
 
   public String icon(String result) {
     if (result.contains("0")) {
-      return "remove-circle state-inactive";
+      return "circle-minus state-inactive";
     }
     if (result.contains("1")) {
-      return "check-circle-1 state-active";
+      return "circle-check-1 state-active";
     }
-    return "question-circle state-unused";
+    return "help-circle state-unused";
   }
 }

--- a/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
+++ b/engine-cockpit/src/ch/ivyteam/enginecockpit/system/ssl/TlsTesterBean.java
@@ -101,7 +101,7 @@ public class TlsTesterBean {
       return "ti ti-circle-minus state-inactive";
     }
     if (result.contains("1")) {
-      return "ti ti-circle-check-1 state-active";
+      return "ti ti-circle-check state-active";
     }
     return "ti ti-help-circle state-unused";
   }

--- a/engine-cockpit/webContent/includes/components/application/configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/configuration.xhtml
@@ -7,10 +7,10 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-cog"></i>
+      <i class="pr-3 ti ti-settings"></i>
       <h6 class="m-0">#{ivy.cm.co('/configuration/ApplicationConfiguration')}</h6>
 
-      <p:commandButton id="reloadConfig" title="#{ivy.cm.co('/configuration/ReloadApplicationConfiguration')}" icon="si si-button-refresh-arrows"
+      <p:commandButton id="reloadConfig" title="#{ivy.cm.co('/configuration/ReloadApplicationConfiguration')}" icon="ti ti-refresh"
           actionListener="#{applicationDetailBean.reloadConfig()}" disabled="#{applicationDetailBean.application.disabled}"
           styleClass="flex-shrink-0 ml-auto rounded-button"/>
     </div>

--- a/engine-cockpit/webContent/includes/components/application/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/information.xhtml
@@ -7,12 +7,12 @@
   <h:form id="appDetailInfoForm">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/information/ApplicationInformation')}</h6>
-        <p:linkButton id="home" title="#{ivy.cm.co('/information/ApplicationHome')}" icon="si si-house-chimney-2"
+        <p:linkButton id="home" title="#{ivy.cm.co('/information/ApplicationHome')}" icon="ti ti-home"
           href="#{applicationDetailBean.application.homeUrl}" disabled="#{applicationDetailBean.application.disabled}"
           styleClass="flex-shrink-0 ml-auto rounded-button"/>
-        <p:linkButton id="workflow" title="#{ivy.cm.co('/information/WorkflowUI')}" icon="si si-layout-bullets" 
+        <p:linkButton id="workflow" title="#{ivy.cm.co('/information/WorkflowUI')}" icon="ti ti-list" 
           href="#{applicationDetailBean.application.devWorkflowUrl}" disabled="#{applicationDetailBean.application.disabled}"
           styleClass="flex-shrink-0 ml-1 rounded-button"/>
       </div>

--- a/engine-cockpit/webContent/includes/components/application/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/information.xhtml
@@ -30,7 +30,7 @@
     <p:panelGrid columns="1" layout="flex">
       <h:panelGroup id="deployBtnHint">
         <p:commandButton id="showDeployment" title="#{ivy.cm.co('/common/Deployment')}" value="#{ivy.cm.co('/common/Deployment')}"
-          style="margin-top: 20px; min-width: 150px;" icon="si si-upload-bottom"
+          style="margin-top: 20px; min-width: 150px;" icon="ti ti-upload"
           onclick="PF('fileUploadModal').show()" 
           actionListener="#{deploymentBean.setAppNameAndVersion(applicationDetailBean.application.name, applicationDetailBean.appVersion)}"/>
       </h:panelGroup>

--- a/engine-cockpit/webContent/includes/components/application/security.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/security.xhtml
@@ -7,21 +7,21 @@
   <h:form id="appDetailSecurityForm">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-lock-1"></i>
+        <i class="pr-3 ti ti-lock"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/SecuritySystem')}</h6>
-        <p:commandButton id="moveApplication" title="#{ivy.cm.co('/security/ChangeSecuritySystem')}" type="button" icon="si si-pencil" onclick="PF('moveApplicationModal').show();"
+        <p:commandButton id="moveApplication" title="#{ivy.cm.co('/security/ChangeSecuritySystem')}" type="button" icon="ti ti-pencil" onclick="PF('moveApplicationModal').show();"
           styleClass="flex-shrink-0 ml-auto rounded-button">
             <p:ajax listener="#{moveApplicationBean.setApp(applicationDetailBean.application)}" update="moveApplicationForm" />
         </p:commandButton>
         <p:commandButton id="synchronizeSecurity"
           rendered="#{applicationDetailBean.securitySystem.securitySystemProvider ne 'ivy Security System'}"
           title="#{ivy.cm.co('/common/Synchronize')}" type="button"
-          icon="si si-button-refresh-arrows #{securityBean.syncRunningForSelectedApp ? 'si-is-spinning' : ''}"
+          icon="ti ti-refresh #{securityBean.syncRunningForSelectedApp ? 'spinning' : ''}"
           styleClass="ml-1 ui-button-secondary rounded-button spin-icon" onclick="PF('logPoller').start()">
           <p:ajax listener="#{securityBean.triggerSyncForSelectedApp}" update="@this" />
         </p:commandButton>
         <p:poll widgetVar="logPoller" autoStart="#{securityBean.syncRunningForSelectedApp}" interval="5" update="@form" />
-        <p:linkButton id="showAdSyncLogBtn" icon="si si-common-file-text" styleClass="ml-1 ui-button-secondary rounded-button"
+        <p:linkButton id="showAdSyncLogBtn" icon="ti ti-file-text" styleClass="ml-1 ui-button-secondary rounded-button"
           href="#{securityBean.synchLogUri}" rendered="#{!securityBean.ivySecurityForSelectedApp}" />
       </div>
     </div>
@@ -30,7 +30,7 @@
       <h:outputLink value="#{applicationDetailBean.securitySystem.link}">
         <h:outputText value="#{applicationDetailBean.securitySystem.securitySystemName}"
           rendered="#{not empty applicationDetailBean.securitySystem.link}">
-          <i class="si si-lock-1 link-icon"></i>
+          <i class="ti ti-lock link-icon"></i>
         </h:outputText>
       </h:outputLink>
       <label>#{ivy.cm.co('/common/Provider')}</label>
@@ -38,13 +38,13 @@
       <label>#{ivy.cm.co('/common/Users')}</label>
       <h:outputLink value="users.xhtml">
         <h:outputText value="#{applicationDetailBean.securitySystem.usersCount}">
-          <i class="si si-single-neutral-actions link-icon"></i>
+          <i class="ti ti-user-check link-icon"></i>
         </h:outputText>
       </h:outputLink>
       <label>#{ivy.cm.co('/common/Roles')}</label>
       <h:outputLink value="roles.xhtml">
         <h:outputText value="#{applicationDetailBean.securitySystem.rolesCount}">
-          <i class="si si-multiple-neutral-1 link-icon"></i>
+          <i class="ti ti-users link-icon"></i>
         </h:outputText>
       </h:outputLink>
     </p:panelGrid>

--- a/engine-cockpit/webContent/includes/components/application/state.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/state.xhtml
@@ -7,14 +7,14 @@
   <h:form id="appDetailStateForm">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-cog-play"></i>
+        <i class="pr-3 ti ti-settings-automation"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Activity')}</h6>
         
         <p:commandButton id="activateApplication" title="#{ivy.cm.co('/common/Activate')}" type="button" icon="ti ti-player-play"
           disabled="#{applicationDetailBean.application.notStartable}" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.activate}" update="@form" />
         </p:commandButton>
-        <p:commandButton id="deActivateApplication" title="#{ivy.cm.co('/common/Deactivate')}" type="button" icon="si si-controls-stop"
+        <p:commandButton id="deActivateApplication" title="#{ivy.cm.co('/common/Deactivate')}" type="button" icon="ti ti-player-stop"
           disabled="#{applicationDetailBean.application.notStopable}" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.deactivate}" update="@form" />
         </p:commandButton>

--- a/engine-cockpit/webContent/includes/components/application/state.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/state.xhtml
@@ -10,7 +10,7 @@
         <i class="pr-3 si si-cog-play"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Activity')}</h6>
         
-        <p:commandButton id="activateApplication" title="#{ivy.cm.co('/common/Activate')}" type="button" icon="si si-controls-play"
+        <p:commandButton id="activateApplication" title="#{ivy.cm.co('/common/Activate')}" type="button" icon="ti ti-player-play"
           disabled="#{applicationDetailBean.application.notStartable}" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.activate}" update="@form" />
         </p:commandButton>
@@ -18,7 +18,7 @@
           disabled="#{applicationDetailBean.application.notStopable}" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.deactivate}" update="@form" />
         </p:commandButton>
-        <p:commandButton id="lockApplication" title="#{ivy.cm.co('/common/Lock')}" type="button" icon="si si-lock-1"
+        <p:commandButton id="lockApplication" title="#{ivy.cm.co('/common/Lock')}" type="button" icon="ti ti-lock"
           disabled="#{applicationDetailBean.application.notLockable}" styleClass="flex-shrink-0 ml-1 ui-button-warning rounded-button">
           <p:ajax listener="#{applicationDetailBean.application.lock}" update="@form" />
         </p:commandButton>

--- a/engine-cockpit/webContent/includes/components/application/state.xhtml
+++ b/engine-cockpit/webContent/includes/components/application/state.xhtml
@@ -27,12 +27,12 @@
     <p:panelGrid columns="2" columnClasses="col-12 md:col-4 lg:col-4, col-12 md:col-8 lg:col-8" layout="flex" styleClass="grey-label-panel">
       <label>#{ivy.cm.co('/common/State')}</label>
       <h:outputText>
-        <i class="si si-#{applicationDetailBean.application.state.operationIcon} icon-bold activity-state-#{applicationDetailBean.application.state.operationCssClass}"
+        <i class="#{applicationDetailBean.application.state.operationIcon} icon-bold activity-state-#{applicationDetailBean.application.state.operationCssClass}"
           title="#{applicationDetailBean.application.state.operation}" />
       </h:outputText>
       <label>#{ivy.cm.co('/common/ConfiguredState')}</label>
       <h:outputText>
-        <i class="si si-#{applicationDetailBean.application.state.stateIcon} icon-bold activity-state-#{applicationDetailBean.application.state.stateCssClass}"
+        <i class="#{applicationDetailBean.application.state.stateIcon} icon-bold activity-state-#{applicationDetailBean.application.state.stateCssClass}"
           title="#{applicationDetailBean.application.state.state}" />
       </h:outputText>
     </p:panelGrid>

--- a/engine-cockpit/webContent/includes/components/configuration/branding-colors.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/branding-colors.xhtml
@@ -8,7 +8,7 @@
     filteredValue="#{brandingBean.filteredCssColors}" widgetVar="colorsTable" id="colorsTable" emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
     <f:facet name="header">
       <div class="ui-input-icon-left filter-container">
-        <i class="pi pi-search"/>
+        <i class="ti ti-search"/>
         <p:inputText id="globalFilter" onkeyup="PF('colorsTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{brandingBean.filter}" />
       </div>
     </f:facet>
@@ -21,10 +21,10 @@
       <h:outputText value="#{color.value}" />
     </p:column>
     <p:column styleClass="table-btn-2">
-      <p:commandButton id="setColor" icon="si si-pencil" styleClass="ui-button-secondary rounded-button" 
+      <p:commandButton id="setColor" icon="ti ti-pencil" styleClass="ui-button-secondary rounded-button" 
         actionListener="#{brandingBean.setSelectedCssColor(color.color)}" 
         update="cssColorPickerForm:editCssColorModal" oncomplete="PF('editCssColorModal').show();" process="@this"/>
-      <p:commandButton id="resetColor" icon="si si-undo" styleClass="ml-1 ui-button-danger rounded-button"
+      <p:commandButton id="resetColor" icon="ti ti-arrow-back-up" styleClass="ml-1 ui-button-danger rounded-button"
         actionListener="#{brandingBean.setSelectedCssColor(color.color)}" disabled="#{color.default}"
         update="resetColorConfirmDialog" oncomplete="PF('resetColorConfirmDialog').show();" process="@this"/>
     </p:column>

--- a/engine-cockpit/webContent/includes/components/configuration/branding-resources.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/branding-resources.xhtml
@@ -9,7 +9,7 @@
       <div class="col-12 md:col-3 lg:col-1 align-self-center">
         <p:outputLabel value="#{res.label}" />
         <h:panelGroup id="img_#{res.label}" styleClass="label-help-icon">
-          <i class="si si-question-circle"></i>
+          <i class="ti ti-help-circle"></i>
           <p:tooltip for="@parent" value="#{res.description}" position="right" />
         </h:panelGroup>
       </div>
@@ -19,7 +19,7 @@
       <div class="col-12 md:col-4 lg:col-2 align-self-center">
         <p:splitButton id="uploadBtn" value="#{ivy.cm.co('/common/Upload')}" title="#{ivy.cm.co('/common/Upload')} #{res.label}" icon="si si-upload-bottom" styleClass="branding-btn"
           actionListener="#{brandingBean.setCurrentRes(res.name)}" update="@this fileUpload" oncomplete="PF('fileUploadModal').show()" process="@this">
-          <p:menuitem id="resetBtn" value="#{ivy.cm.co('/common/Reset')}" icon="si si-undo" styleClass="ui-button-secondary" oncomplete="PF('resetBrandingConfirmDialog').show()"
+          <p:menuitem id="resetBtn" value="#{ivy.cm.co('/common/Reset')}" icon="ti ti-arrow-back-up" styleClass="ui-button-secondary" oncomplete="PF('resetBrandingConfirmDialog').show()"
             actionListener="#{brandingBean.setCurrentRes(res.name)}" update="resetBrandingConfirmDialog" process="@this"/>
         </p:splitButton>
       </div>
@@ -30,7 +30,7 @@
     <div class="col-12 md:col-5 lg:col-3 align-self-center"></div>
     <div class="col-12 md:col-4 lg:col-2 align-self-center">
       <p:splitButton id="editCustomCssBtn" value="#{ivy.cm.co('/common/Edit')}" icon="si si-common-file-text-edit" update="editCustomCssModal" oncomplete="PF('editCustomCssModal').show();" process="@this">
-        <p:menuitem id="resetCustomCssBtn" value="#{ivy.cm.co('/common/Reset')}" icon="si si-undo" styleClass="ui-button-secondary" oncomplete="PF('resetBrandingConfirmDialog').show()"
+        <p:menuitem id="resetCustomCssBtn" value="#{ivy.cm.co('/common/Reset')}" icon="ti ti-arrow-back-up" styleClass="ui-button-secondary" oncomplete="PF('resetBrandingConfirmDialog').show()"
           actionListener="#{brandingBean.setCurrentRes('custom.css')}" update="resetBrandingConfirmDialog" process="@this"/>
       </p:splitButton>
     </div>

--- a/engine-cockpit/webContent/includes/components/configuration/branding-resources.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/branding-resources.xhtml
@@ -17,7 +17,7 @@
         <p:graphicImage url="#{res.url}" alt="#{res.name}" styleClass="branding-img #{res.label}" />
       </div>
       <div class="col-12 md:col-4 lg:col-2 align-self-center">
-        <p:splitButton id="uploadBtn" value="#{ivy.cm.co('/common/Upload')}" title="#{ivy.cm.co('/common/Upload')} #{res.label}" icon="si si-upload-bottom" styleClass="branding-btn"
+        <p:splitButton id="uploadBtn" value="#{ivy.cm.co('/common/Upload')}" title="#{ivy.cm.co('/common/Upload')} #{res.label}" icon="ti ti-upload" styleClass="branding-btn"
           actionListener="#{brandingBean.setCurrentRes(res.name)}" update="@this fileUpload" oncomplete="PF('fileUploadModal').show()" process="@this">
           <p:menuitem id="resetBtn" value="#{ivy.cm.co('/common/Reset')}" icon="ti ti-arrow-back-up" styleClass="ui-button-secondary" oncomplete="PF('resetBrandingConfirmDialog').show()"
             actionListener="#{brandingBean.setCurrentRes(res.name)}" update="resetBrandingConfirmDialog" process="@this"/>
@@ -29,7 +29,7 @@
     </div>
     <div class="col-12 md:col-5 lg:col-3 align-self-center"></div>
     <div class="col-12 md:col-4 lg:col-2 align-self-center">
-      <p:splitButton id="editCustomCssBtn" value="#{ivy.cm.co('/common/Edit')}" icon="si si-common-file-text-edit" update="editCustomCssModal" oncomplete="PF('editCustomCssModal').show();" process="@this">
+      <p:splitButton id="editCustomCssBtn" value="#{ivy.cm.co('/common/Edit')}" icon="ti ti-file-pencil" update="editCustomCssModal" oncomplete="PF('editCustomCssModal').show();" process="@this">
         <p:menuitem id="resetCustomCssBtn" value="#{ivy.cm.co('/common/Reset')}" icon="ti ti-arrow-back-up" styleClass="ui-button-secondary" oncomplete="PF('resetBrandingConfirmDialog').show()"
           actionListener="#{brandingBean.setCurrentRes('custom.css')}" update="resetBrandingConfirmDialog" process="@this"/>
       </p:splitButton>

--- a/engine-cockpit/webContent/includes/components/configuration/freeDays.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/freeDays.xhtml
@@ -25,7 +25,7 @@
     <p:column headerText="#{ivy.cm.co('/common/DefinedBy')}">
       <a href="businesscalendar-detail.xhtml?calendarName=#{day.calendarName}">
         <h:outputText value="#{day.calendarName}">
-          <i class="si si-calendar table-icon"></i>
+          <i class="ti ti-calendar-event table-icon"></i>
         </h:outputText>
       </a>
     </p:column>

--- a/engine-cockpit/webContent/includes/components/configuration/freeDays.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/freeDays.xhtml
@@ -18,7 +18,7 @@
 
     <p:column headerText="#{ivy.cm.co('/common/Date')}">
       <h:outputText value="#{day.value}" title="#{day.tooltip}">
-        <i class="si si-#{day.icon} table-icon"></i>
+        <i class="#{day.icon} table-icon"></i>
       </h:outputText>
     </p:column>
 

--- a/engine-cockpit/webContent/includes/components/configuration/freeDays.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/freeDays.xhtml
@@ -6,7 +6,7 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-calendar-date"></i>
+      <i class="pr-3 ti ti-calendar-event"></i>
       <h6 class="m-0">#{ivy.cm.co('/freeDays/FreeDays')}</h6>
     </div>
   </div>

--- a/engine-cockpit/webContent/includes/components/configuration/ssl-keystore.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/ssl-keystore.xhtml
@@ -15,9 +15,9 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/sslKeyStore/KeyStoreConfigurations')}</h6>
-        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" id="save"
+        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" id="save"
           styleClass="flex-shrink-0 ml-auto ml-1 ui-button-success rounded-button"
           actionListener="#{keyStoreBean.saveKeyStore}"
           update="@form, sslKeyTable:storeTable"/>

--- a/engine-cockpit/webContent/includes/components/configuration/ssl-truststore.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/ssl-truststore.xhtml
@@ -16,9 +16,9 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/sslTrustStore/TrustStoreConfigurations')}</h6>
-        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" id="save"
+        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" id="save"
           styleClass="flex-shrink-0 ml-auto ml-1 ui-button-success rounded-button"
           actionListener="#{trustStoreBean.saveTrustStore}"
           update="@form, sslTrustTable:storeTable" />

--- a/engine-cockpit/webContent/includes/components/configuration/weekConfiguration.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/weekConfiguration.xhtml
@@ -26,7 +26,7 @@
 
     <p:column headerText="#{ivy.cm.co('/weekConfiguration/FromTo')}">
       <h:outputText value="#{workingTime.value}" title="#{workingTime.tooltip}">
-        <i class="si si-#{workingTime.icon} table-icon"></i>
+        <i class="#{workingTime.icon} table-icon"></i>
       </h:outputText>
     </p:column>
 

--- a/engine-cockpit/webContent/includes/components/configuration/weekConfiguration.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/weekConfiguration.xhtml
@@ -6,7 +6,7 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-cog"></i>
+      <i class="pr-3 ti ti-settings"></i>
       <h6 class="m-0">#{ivy.cm.co('/weekConfiguration/WeekConfiguration')}</h6>
     </div>
   </div>

--- a/engine-cockpit/webContent/includes/components/configuration/weekConfiguration.xhtml
+++ b/engine-cockpit/webContent/includes/components/configuration/weekConfiguration.xhtml
@@ -33,7 +33,7 @@
     <p:column headerText="#{ivy.cm.co('/common/DefinedBy')}">
       <a href="businesscalendar-detail.xhtml?calendarName=#{workingTime.calendarName}">
         <h:outputText value="#{workingTime.calendarName}">
-          <i class="si si-calendar table-icon"></i>
+          <i class="ti ti-calendar-event table-icon"></i>
         </h:outputText>
       </a>
     </p:column>

--- a/engine-cockpit/webContent/includes/components/dashboard/axonivy.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/axonivy.xhtml
@@ -6,7 +6,7 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-tools-wench"></i>
+      <i class="pr-3 ti ti-tool"></i>
       <h6 class="m-0">#{ivy.cm.co('/common/AxonIvy')}</h6>
     </div>
   </div>

--- a/engine-cockpit/webContent/includes/components/dashboard/email.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/email.xhtml
@@ -9,11 +9,11 @@
   </p:growl>
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-email-action-unread"></i>
+      <i class="pr-3 ti ti-mail-opened"></i>
       <h6 class="m-0">#{ivy.cm.co('/common/Email')}</h6>
-      <p:commandButton id="openTestMailBtn" title="#{ivy.cm.co('/email/SendTestMail')}" icon="si si-send-email" type="button"
+      <p:commandButton id="openTestMailBtn" title="#{ivy.cm.co('/email/SendTestMail')}" icon="ti ti-mail" type="button"
         styleClass="ml-auto ui-button-secondary rounded-button" onclick="PF('sendTestMailModal').show()" />
-      <p:linkButton id="configureEmailBtn" title="#{ivy.cm.co('/email/ConfigureEmailServer')}" icon="si si-cog" type="button"
+      <p:linkButton id="configureEmailBtn" title="#{ivy.cm.co('/email/ConfigureEmailServer')}" icon="ti ti-settings" type="button"
         styleClass="ml-1 ui-button-secondary rounded-button" href="systemconfig.xhtml?filter=EMail" />
     </div>
   </div>

--- a/engine-cockpit/webContent/includes/components/dashboard/health.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/health.xhtml
@@ -7,12 +7,12 @@
   <h:form id="healthForm">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-road-sign-warning"></i>
+        <i class="pr-3 ti ti-alert-triangle"></i>
         <h6 class="m-0" style="margin: 0; padding-left: 0">#{ivy.cm.co('/common/Health')}</h6>
         <p:linkButton id="detail" title="#{ivy.cm.co('/health/HealthDetails')}" type="button" href="monitor-health.xhtml"
-           icon="si si-road-sign-warning" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
+           icon="ti ti-alert-triangle" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="runCheck" title="#{ivy.cm.co('/health/RunHealthChecks')}" action="#{healthBean.checkNow()}"
-            update="healthForm" icon="si si-controls-play" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
+            update="healthForm" icon="ti ti-player-play" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
       </div>
     </div>
     <p:panelGrid id="content" columns="2" layout="flex" columnClasses="col-12 md:col-4 lg:col-4, col-12 md:col-8 lg:col-8"

--- a/engine-cockpit/webContent/includes/components/dashboard/java.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/java.xhtml
@@ -6,10 +6,10 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-information-circle"></i>
+      <i class="pr-3 ti ti-info-circle"></i>
       <h6 class="m-0" style="margin: 0; padding-left: 0">#{ivy.cm.co('/java/Java')}</h6>
       <p:commandButton id="tasksButtonJavaDetail" onclick="PF('javaDetailDialog').show();" title="#{ivy.cm.co('/java/JavaDetails')}" type="button"
-        icon="si si-information-circle" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
+        icon="ti ti-info-circle" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
     </div>
   </div>
   <p:panelGrid columns="2" layout="flex" columnClasses="col-12 md:col-4 lg:col-4, col-12 md:col-8 lg:col-8"

--- a/engine-cockpit/webContent/includes/components/dashboard/licence.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/licence.xhtml
@@ -7,7 +7,7 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-real-estate-action-house-key"></i>
+      <i class="pr-3 ti ti-home-up"></i>
       <h6 class="m-0">#{ivy.cm.co('/common/Licence')}</h6>
       <p:linkButton id="tasksButtonLicenceDetail" href="licence.xhtml" title="#{ivy.cm.co('/licence/ConfigureLicence')}"
         type="button" icon="ti ti-settings" styleClass="ml-auto ui-button-secondary rounded-button" />
@@ -42,7 +42,7 @@
     <p:staticMessage rendered="#{licenceBean.installed and !licenceBean.valid}" severity="warn" detail="#{licenceBean.problemMessage}" />
     <p:staticMessage rendered="#{licenceBean.showExpiryWarning()}" severity="warn" detail="#{ivy.cm.co('/licence/ExpiredLicenceTouchYourSalesMessage')}" />
     <p:linkButton id="uploadLicenceBtn" type="button" value="#{ivy.cm.co('/licence/UploadLicence')}"
-      rendered="#{!licenceBean.installed or !licenceBean.valid}" icon="si si-upload-bottom"
+      rendered="#{!licenceBean.installed or !licenceBean.valid}" icon="ti ti-upload"
       href="licence.xhtml" />
   </p:panelGrid>
 </div>

--- a/engine-cockpit/webContent/includes/components/dashboard/licence.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/licence.xhtml
@@ -10,9 +10,9 @@
       <i class="pr-3 si si-real-estate-action-house-key"></i>
       <h6 class="m-0">#{ivy.cm.co('/common/Licence')}</h6>
       <p:linkButton id="tasksButtonLicenceDetail" href="licence.xhtml" title="#{ivy.cm.co('/licence/ConfigureLicence')}"
-        type="button" icon="si si-cog" styleClass="ml-auto ui-button-secondary rounded-button" />
+        type="button" icon="ti ti-settings" styleClass="ml-auto ui-button-secondary rounded-button" />
       <p:commandButton id="tasksButtonLicenceEvents" onclick="PF('licenceEventsDialog').show();" title="#{ivy.cm.co('/licence/LicenceEvents')}"
-        type="button" icon="si si-alarm-bell-timer" styleClass="ml-1 ui-button-secondary rounded-button"
+        type="button" icon="ti ti-bell-plus" styleClass="ml-1 ui-button-secondary rounded-button"
         rendered="#{not empty licenceBean.licenceEvents}" />
     </div>
   </div>

--- a/engine-cockpit/webContent/includes/components/dashboard/systemdatabase.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/systemdatabase.xhtml
@@ -8,10 +8,10 @@
     <div class="card-title flex align-items-center">
       <i class="pr-3 si si-database-settings"></i>
       <h6 class="m-0">#{ivy.cm.co('/systemDatabase/SystemDatabase')}</h6>
-      <p:linkButton id="helpSystemDbBtn" title="#{ivy.cm.co('/common/Help')}" icon="si si-question-circle" type="button"
+      <p:linkButton id="helpSystemDbBtn" title="#{ivy.cm.co('/common/Help')}" icon="ti ti-help-circle" type="button"
         href="#{advisorBean.engineGuideBaseUrl}/configuration/system-database/index.html"
         target="_blank" rel="noopener noreferrer" styleClass="ml-auto ui-button-secondary rounded-button" />
-      <p:linkButton id="configureSystemDbBtn" title="#{ivy.cm.co('/systemDatabase/ConfigureSystemDb')}" icon="si si-cog" type="button"
+      <p:linkButton id="configureSystemDbBtn" title="#{ivy.cm.co('/systemDatabase/ConfigureSystemDb')}" icon="ti ti-settings" type="button"
         styleClass="ml-1 ui-button-secondary rounded-button" href="systemdb.xhtml" />
     </div>
   </div>

--- a/engine-cockpit/webContent/includes/components/dashboard/systemdatabase.xhtml
+++ b/engine-cockpit/webContent/includes/components/dashboard/systemdatabase.xhtml
@@ -6,7 +6,7 @@
 <div class="card">
   <div class="card-header">
     <div class="card-title flex align-items-center">
-      <i class="pr-3 si si-database-settings"></i>
+      <i class="pr-3 ti ti-database-cog"></i>
       <h6 class="m-0">#{ivy.cm.co('/systemDatabase/SystemDatabase')}</h6>
       <p:linkButton id="helpSystemDbBtn" title="#{ivy.cm.co('/common/Help')}" icon="ti ti-help-circle" type="button"
         href="#{advisorBean.engineGuideBaseUrl}/configuration/system-database/index.html"

--- a/engine-cockpit/webContent/includes/components/searchengine/indices.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/indices.xhtml
@@ -10,7 +10,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-common-file-text"></i>
+        <i class="pr-3 ti ti-file-text"></i>
         <h6 class="m-0">#{ivy.cm.co('/indices/Indices')}</h6>
       </div>
     </div>
@@ -21,7 +21,7 @@
       <p:column id="indexName" headerText="#{ivy.cm.co('/common/Name')}" styleClass="index-name-column">
         <a href="#{index.viewUrl}" class="flex align-items-center">
           <h:outputText value="#{index.name}" styleClass="index-name" style="overflow: auto">
-            <i class="si si-common-file-text table-icon"></i>
+            <i class="ti ti-file-text table-icon"></i>
           </h:outputText>
           <h:outputText styleClass="ml-2 addition-row-info"
             value="[Reindexing: #{index.countIndexing} (#{index.percentIndexed}%)]"
@@ -50,7 +50,7 @@
           actionListener="#{searchEngineBean.setActiveIndex(index)}" update="searchEngineQueryToolModal"
           styleClass="rounded-button" oncomplete="PF('searchEngineQueryToolModal').show()" />
         <p:commandButton title="#{ivy.cm.co('/indices/Reindex')}"
-          icon="si si-button-refresh-arrows #{searchEngineBean.isReindexing(index) ? 'si-is-spinning' : ''} spin-icon"
+          icon="ti ti-refresh #{searchEngineBean.isReindexing(index) ? 'spinning' : ''} spin-icon"
           styleClass="ml-1 ui-button-secondary rounded-button" id="reindexBtn"
           oncomplete="PF('reindexSearchEngineModel').show();" actionListener="#{searchEngineBean.setActiveIndex(index)}"
           update="reindexSearchEngineModel" />
@@ -70,7 +70,7 @@
       type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
     <p:commandButton id="reindexSearchEngineBtn" update="searchEngineIndexForm"
       onclick="PF('reindexSearchEngineModel').hide();"
-      actionListener="#{searchEngineBean.reindex}" value="#{ivy.cm.co('/indices/Reindex')}" icon="si si-button-refresh-arrows"
+      actionListener="#{searchEngineBean.reindex}" value="#{ivy.cm.co('/indices/Reindex')}" icon="ti ti-refresh"
       styleClass="modal-input-button" />
   </f:facet>
 </p:dialog>

--- a/engine-cockpit/webContent/includes/components/searchengine/indices.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/indices.xhtml
@@ -35,7 +35,7 @@
         <h:outputText value="#{index.countStored}" />
       </p:column>
       <p:column headerText="#{ivy.cm.co('/common/Health')}" style="text-align: center; width: 65px; font-weight: bold;">
-        <i class="si si-#{index.health.icon} table-icon icon-bold search-machine-health-#{index.health.state}"
+        <i class="#{index.health.icon} table-icon icon-bold search-machine-health-#{index.health.state}"
           title="#{index.health.hint}"></i>
       </p:column>
       <p:column headerText="#{ivy.cm.co('/indices/Status')}" style="text-align: center; width: 65px; font-weight: bold;">

--- a/engine-cockpit/webContent/includes/components/searchengine/indices.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/indices.xhtml
@@ -46,7 +46,7 @@
         <h:outputText value="#{index.size}" />
       </p:column>
       <p:column styleClass="table-btn-2">
-        <p:commandButton id="queryToolBtn" title="#{ivy.cm.co('/common/RunSearchEngineQuery')}" icon="si si-monitor-heart-beat-search"
+        <p:commandButton id="queryToolBtn" title="#{ivy.cm.co('/common/RunSearchEngineQuery')}" icon="ti ti-device-desktop-search"
           actionListener="#{searchEngineBean.setActiveIndex(index)}" update="searchEngineQueryToolModal"
           styleClass="rounded-button" oncomplete="PF('searchEngineQueryToolModal').show()" />
         <p:commandButton title="#{ivy.cm.co('/indices/Reindex')}"

--- a/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
@@ -29,7 +29,7 @@
         <label>#{ivy.cm.co('/common/State')}</label>
         <h:panelGroup id="state">
           <i
-            class="#{searchEngineBean.state ? 'check-circle-1' : 'remove-circle'} icon-bold search-machine-state-#{searchEngineBean.state}"></i>
+            class="#{searchEngineBean.state ? 'ti ti-circle-check' : 'ti ti-circle-minus'} icon-bold search-machine-state-#{searchEngineBean.state}"></i>
         </h:panelGroup>
         <label>#{ivy.cm.co('/common/Health')}</label>
         <h:panelGroup id="health">

--- a/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
@@ -10,12 +10,12 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/SearchEngine')}</h6>
         <p:commandButton id="queryToolBtn" title="#{ivy.cm.co('/common/RunSearchEngineQuery')}" icon="si si-monitor-heart-beat-search"
           update="searchEngineQueryToolModal" actionListener="#{searchEngineBean.setActiveIndex(null)}"
           styleClass="ml-auto rounded-button" oncomplete="PF('searchEngineQueryToolModal').show()" />
-        <p:linkButton id="configSearchEngine" title="#{ivy.cm.co('/searchEngineInformation/ConfigureSearchEngineButtonTitle')}" icon="si si-cog" type="button"
+        <p:linkButton id="configSearchEngine" title="#{ivy.cm.co('/searchEngineInformation/ConfigureSearchEngineButtonTitle')}" icon="ti ti-settings" type="button"
           styleClass="ml-1 ui-button-secondary rounded-button" href="systemconfig.xhtml?filter=SearchEngine" />
       </div>
     </div>
@@ -44,7 +44,7 @@
           <h:panelGroup>
             <h:outputText id="version" value="#{searchEngineBean.searchEngine.version}" />
             <h:outputText rendered="#{searchEngineBean.searchEngine.notSupported}">
-              <i class="si si-lg si-road-sign-warning search-machine-health-yellow"
+              <i class="text-xl ti-alert-triangle search-machine-health-yellow"
               style="position: relative; top: 3px; font-weight: 700;"
               title="#{ivy.cm.co('/searchEngineInformation/NotSupportESVersionMessage')}"></i>
             </h:outputText>
@@ -53,7 +53,7 @@
           <h:panelGroup>
             <label>#{ivy.cm.co('/searchEngineInformation/DiskThresholdEnabled')}</label>
             <h:panelGroup id="diskThresholdHelp" styleClass="flex align-items-center ml-1">
-              <i class="si si-question-circle"></i>
+              <i class="ti ti-help-circle"></i>
               <p:tooltip for="@parent" value="#{ivy.cm.co('/searchEngineInformation/DiskThresholdEnabledInfo')}" position="top" />
             </h:panelGroup>
           </h:panelGroup>
@@ -62,7 +62,7 @@
           <h:panelGroup>
             <label>#{ivy.cm.co('/searchEngineInformation/WatermarkLow')}</label>
             <h:panelGroup id="watermarkLowHelp" styleClass="flex align-items-center ml-1">
-              <i class="si si-question-circle"></i>
+              <i class="ti ti-help-circle"></i>
               <p:tooltip for="@parent" value="#{ivy.cm.co('/searchEngineInformation/WatermarkLowInfo')}"
                position="top" />
             </h:panelGroup>
@@ -72,7 +72,7 @@
           <h:panelGroup>
             <label>#{ivy.cm.co('/searchEngineInformation/WatermarkHigh')}</label>
             <h:panelGroup id="watermarkHighHelp" styleClass="flex align-items-center ml-1">
-              <i class="si si-question-circle"></i>
+              <i class="ti ti-help-circle"></i>
               <p:tooltip for="@parent" value="#{ivy.cm.co('/searchEngineInformation/WatermarkHighInfo')}" 
                 position="top" />
             </h:panelGroup>
@@ -82,7 +82,7 @@
           <h:panelGroup>
             <label>#{ivy.cm.co('/searchEngineInformation/FloodStage')}</label>
             <h:panelGroup id="floodStageHelp" styleClass="flex align-items-center ml-1">
-              <i class="si si-question-circle"></i>
+              <i class="ti ti-help-circle"></i>
               <p:tooltip for="@parent" value="#{ivy.cm.co('/searchEngineInformation/FloodStageInfo')}" 
                 position="top" />
             </h:panelGroup>

--- a/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
@@ -12,7 +12,7 @@
       <div class="card-title flex align-items-center">
         <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/SearchEngine')}</h6>
-        <p:commandButton id="queryToolBtn" title="#{ivy.cm.co('/common/RunSearchEngineQuery')}" icon="si si-monitor-heart-beat-search"
+        <p:commandButton id="queryToolBtn" title="#{ivy.cm.co('/common/RunSearchEngineQuery')}" icon="ti ti-device-desktop-search"
           update="searchEngineQueryToolModal" actionListener="#{searchEngineBean.setActiveIndex(null)}"
           styleClass="ml-auto rounded-button" oncomplete="PF('searchEngineQueryToolModal').show()" />
         <p:linkButton id="configSearchEngine" title="#{ivy.cm.co('/searchEngineInformation/ConfigureSearchEngineButtonTitle')}" icon="ti ti-settings" type="button"

--- a/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
@@ -44,7 +44,7 @@
           <h:panelGroup>
             <h:outputText id="version" value="#{searchEngineBean.searchEngine.version}" />
             <h:outputText rendered="#{searchEngineBean.searchEngine.notSupported}">
-              <i class="text-xl ti-alert-triangle search-machine-health-yellow"
+              <i class="text-xl ti ti-alert-triangle search-machine-health-yellow"
               style="position: relative; top: 3px; font-weight: 700;"
               title="#{ivy.cm.co('/searchEngineInformation/NotSupportESVersionMessage')}"></i>
             </h:outputText>

--- a/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
+++ b/engine-cockpit/webContent/includes/components/searchengine/information.xhtml
@@ -29,11 +29,11 @@
         <label>#{ivy.cm.co('/common/State')}</label>
         <h:panelGroup id="state">
           <i
-            class="si si-#{searchEngineBean.state ? 'check-circle-1' : 'remove-circle'} icon-bold search-machine-state-#{searchEngineBean.state}"></i>
+            class="#{searchEngineBean.state ? 'check-circle-1' : 'remove-circle'} icon-bold search-machine-state-#{searchEngineBean.state}"></i>
         </h:panelGroup>
         <label>#{ivy.cm.co('/common/Health')}</label>
         <h:panelGroup id="health">
-          <i class="si si-#{searchEngineBean.searchEngine.health.icon} icon-bold search-machine-health-#{searchEngineBean.searchEngine.health.state}"
+          <i class="#{searchEngineBean.searchEngine.health.icon} icon-bold search-machine-health-#{searchEngineBean.searchEngine.health.state}"
             title="#{searchEngineBean.searchEngine.health.hint}"></i>
         </h:panelGroup>
         </p:panelGrid>

--- a/engine-cockpit/webContent/includes/components/security/member-properties.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/member-properties.xhtml
@@ -8,11 +8,11 @@
     <p:growl for="propertiesMessage" id="propertiesMessage" showDetail="true" />
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-cog"></i>
+        <i class="pr-3 ti ti-settings"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Properties')}</h6>
         <p:commandButton id="newPropertyBtn" oncomplete="PF('propertyModal').show();" process="@this"
           actionListener="#{memberProperty.setProperty(null)}" update="propertyModalForm:propertyModal" title="#{ivy.cm.co('/common/Add')}"
-          icon="si si-add" styleClass="flex-shrink-0 ml-auto rounded-button" />
+          icon="ti ti-plus" styleClass="flex-shrink-0 ml-auto rounded-button" />
       </div>
     </div>
 
@@ -22,21 +22,21 @@
       emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
       <f:facet name="header">
         <div class="ui-input-icon-left filter-container">
-          <i class="pi pi-search"/>
+          <i class="ti ti-search"/>
           <p:inputText id="globalFilter" onkeyup="PF('propertiesTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{memberProperty.filter}" />
         </div>
       </f:facet>
 
       <p:column headerText="#{ivy.cm.co('/common/Name')}" filterBy="#{property.key}" sortBy="#{property.value}">
         <h:outputText value="#{property.key}" styleClass="property-name">
-          <i class="si si-cog table-icon"></i>
+          <i class="ti ti-settings table-icon"></i>
         </h:outputText>
       </p:column>
   
       <p:column headerText="#{ivy.cm.co('/common/Value')}" filterBy="#{property.value}">
         <h:outputText value="#{property.value}" title="#{property.value}" styleClass="table-cell-autocut">
           <h:panelGroup rendered="#{property.managed}">
-            <i class="si si-button-refresh-arrows table-icon"
+            <i class="ti ti-refresh table-icon"
               title="#{ivy.cm.co('/memberProperties/PropertyInExternalSecuritySystem')}"></i>
           </h:panelGroup>
         </h:outputText>
@@ -45,10 +45,10 @@
       <p:column styleClass="table-btn-2">
         <p:outputLabel>
           <p:commandButton id="editPropertyBtn" actionListener="#{memberProperty.setProperty(property)}"
-            icon="si si-pencil" title="#{ivy.cm.co('/common/Edit')}" update="propertyModalForm:propertyModal" disabled="#{property.managed}"
+            icon="ti ti-pencil" title="#{ivy.cm.co('/common/Edit')}" update="propertyModalForm:propertyModal" disabled="#{property.managed}"
             styleClass="ui-button-secondary rounded-button" oncomplete="PF('propertyModal').show();"
             process="@this" />
-          <p:commandButton id="deletePropertyBtn" type="button" icon="si si-bin-1" title="#{ivy.cm.co('/common/Delete')}"
+          <p:commandButton id="deletePropertyBtn" type="button" icon="ti ti-trash" title="#{ivy.cm.co('/common/Delete')}"
             disabled="#{property.managed}" styleClass="ml-1 ui-button-danger rounded-button">
             <p:ajax listener="#{memberProperty.removeProperty(property.key)}" update="@form" />
           </p:commandButton>
@@ -82,7 +82,7 @@
       <p:commandButton id="cancelProperty" onclick="PF('propertyModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="saveProperty" validateClient="true" ajax="false" update=":propertiesForm"
-        actionListener="#{memberProperty.saveProperty}" value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk"
+        actionListener="#{memberProperty.saveProperty}" value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy"
         styleClass="modal-input-button" />
     </f:facet>
   </p:dialog>

--- a/engine-cockpit/webContent/includes/components/security/permissions.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/permissions.xhtml
@@ -10,19 +10,19 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-lock-1"></i>
+        <i class="pr-3 ti ti-lock"></i>
         <h6 class="m-0">#{ivy.cm.co('/permissions/Permissions')}</h6>
       </div>
     </div>
     
     <div class="table-search flex ui-fluid">
       <span class="ui-input-icon-left filter-container">
-        <i class="pi pi-search"/>
+        <i class="ti ti-search"/>
         <p:inputText id="globalFilter" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{permissionBean.filter}">
           <p:ajax event="keyup" delay="300" update="@form:permissionTable" />
         </p:inputText>
       </span>
-      <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
+      <p:commandButton id="collapseAll" icon="ti ti-arrows-minimize"
         actionListener="#{permissionBean.collapseAllNodes}" update="permissionTable" title="#{ivy.cm.co('/common/CollapseAll')}"
         styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
     </div>
@@ -38,19 +38,19 @@
   
       <p:column id="icons" styleClass="permission-icon table-btn-2">
         <h:outputText rendered="#{permission.grant}">
-          <i id="grant" class="si si-check-circle table-icon" title="#{ivy.cm.co('/permissions/PermissionGranted')}" />
+          <i id="grant" class="ti ti-circle-check table-icon" title="#{ivy.cm.co('/permissions/PermissionGranted')}" />
         </h:outputText>
         <h:outputText rendered="#{!permission.grant and permission.someGrant}">
-          <i id="someGrant" class="si si-check-circle table-icon light" title="#{ivy.cm.co('/permissions/SomePermissionGranted')}" />
+          <i id="someGrant" class="ti ti-circle-check table-icon light" title="#{ivy.cm.co('/permissions/SomePermissionGranted')}" />
         </h:outputText>
         <h:outputText rendered="#{permission.deny}">
-          <i id="deny" class="si si-subtract-circle table-icon" title="#{ivy.cm.co('/permissions/PermissionDenied')}" />
+          <i id="deny" class="ti ti-circle-minus table-icon" title="#{ivy.cm.co('/permissions/PermissionDenied')}" />
         </h:outputText>
         <h:outputText rendered="#{!permission.deny and permission.someDeny}">
-          <i id="someDeny" class="si si-subtract-circle table-icon light" title="#{ivy.cm.co('/permissions/SomePermissionDenied')}" />
+          <i id="someDeny" class="ti ti-circle-minus table-icon light" title="#{ivy.cm.co('/permissions/SomePermissionDenied')}" />
         </h:outputText>
         <h:outputText rendered="#{!permission.group and not empty permission.permissionHolder and !permission.explicit}">
-          <i id="everybody" class="si si-multiple-neutral-1 table-icon" title="#{permission.permissionHolder}"></i>
+          <i id="everybody" class="ti ti-users table-icon" title="#{permission.permissionHolder}"></i>
         </h:outputText>
       </p:column>
   

--- a/engine-cockpit/webContent/includes/components/security/permissions.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/permissions.xhtml
@@ -32,7 +32,7 @@
 
       <p:column headerText="#{ivy.cm.co('/permissions/AllPermissions')}">
         <h:outputText value="#{permission.name}">
-          <i class="si si-#{permission.group ? 'folder-empty' : 'lock-1'} table-icon"></i>
+          <i class="#{permission.group ? 'folder-empty' : 'lock-1'} table-icon"></i>
         </h:outputText>
       </p:column>
   

--- a/engine-cockpit/webContent/includes/components/security/permissions.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/permissions.xhtml
@@ -32,7 +32,7 @@
 
       <p:column headerText="#{ivy.cm.co('/permissions/AllPermissions')}">
         <h:outputText value="#{permission.name}">
-          <i class="#{permission.group ? 'folder-empty' : 'lock-1'} table-icon"></i>
+          <i class="#{permission.group ? 'ti ti-folder-open' : 'ti ti-lock'} table-icon"></i>
         </h:outputText>
       </p:column>
   

--- a/engine-cockpit/webContent/includes/components/security/roledetail-information.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-information.xhtml
@@ -10,12 +10,12 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/roleDetailInformation/RoleInformation')}</h6>
         <p:commandButton id="createNewChildRole" type="button" onclick="PF('newChildRoleModal').show()"
-          title="#{ivy.cm.co('/roleDetailInformation/AddNewChildRole')}" icon="si si-add" styleClass="flex-shrink-0 ml-auto rounded-button" />
+          title="#{ivy.cm.co('/roleDetailInformation/AddNewChildRole')}" icon="ti ti-plus" styleClass="flex-shrink-0 ml-auto rounded-button" />
         <p:commandButton id="deleteRole" rendered="#{roleDetailBean.canDeleteRole()}" type="button"
-          onclick="PF('deleteRoleConfirmDialog').show()" title="#{ivy.cm.co('/roleDetailInformation/DeleteRole')}" icon="si si-bin-1"
+          onclick="PF('deleteRoleConfirmDialog').show()" title="#{ivy.cm.co('/roleDetailInformation/DeleteRole')}" icon="ti ti-trash"
           styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
         <p:confirmDialog id="deleteRoleConfirmDialog"
           message="#{ivy.cm.content('/roleDetailInformation/DeleteRoleDialogConfirmMessage').replace('role', roleDetailBean.name).get()}" header="#{ivy.cm.co('/roleDetailInformation/DeleteRoleDialogHeader')}" severity="alert"
@@ -24,10 +24,10 @@
           <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('deleteRoleConfirmDialog').hide();" type="button"
             styleClass="ui-button-secondary ui-button-flat modal-input-button" />
           <p:commandButton id="deleteRoleConfirmDialogYesBtn" value="#{ivy.cm.co('/common/Delete')}" immediate="true"
-            action="#{roleDetailBean.deleteRole}" styleClass="modal-input-button" icon="si si-bin-1" />
+            action="#{roleDetailBean.deleteRole}" styleClass="modal-input-button" icon="ti ti-trash" />
         </p:confirmDialog>
         <p:commandButton id="saveRoleInformation" actionListener="#{roleDetailBean.saveRoleInfos}" title="#{ivy.cm.co('/common/SaveChanges')}"
-          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" update="usersOfRoleForm" />
+          icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" update="usersOfRoleForm" />
       </div>
     </div>
 
@@ -37,7 +37,7 @@
       <p:outputLabel for="name" value="#{ivy.cm.co('/common/Name')}" />
       <h:panelGroup layout="block" styleClass="ui-inputgroup">
         <p:inputText id="name" disabled="true" value="#{roleDetailBean.role.name}" />
-        <p:commandButton id="renameRole" icon="si si-pencil" title="#{ivy.cm.co('/roleDetailInformation/RenameRole')}"
+        <p:commandButton id="renameRole" icon="ti ti-pencil" title="#{ivy.cm.co('/roleDetailInformation/RenameRole')}"
           onclick="PF('renameRoleModal').show()"
           disabled="#{!roleDetailBean.canRenameRole()}" />
       </h:panelGroup>
@@ -51,7 +51,7 @@
       <p:outputLabel for="parentRole" value="#{ivy.cm.co('/roleDetailInformation/ParentRole')}" />
       <h:panelGroup layout="block" styleClass="ui-inputgroup">
         <p:inputText id="parentRole" disabled="true" value="#{roleDetailBean.role.parentRoleName}" />
-        <p:commandButton id="updateRoleParent" icon="si si-pencil" title="#{ivy.cm.co('/roleDetailInformation/UpdateRoleParentButtonTitle')}"
+        <p:commandButton id="updateRoleParent" icon="ti ti-pencil" title="#{ivy.cm.co('/roleDetailInformation/UpdateRoleParentButtonTitle')}"
           onclick="PF('updateRoleParentModal').show()"
           disabled="#{!roleDetailBean.canUpdateRoleParent()}" />
       </h:panelGroup>
@@ -59,7 +59,7 @@
       <p:outputLabel for="externalSecurityName" value="#{ivy.cm.co('/roleDetailInformation/ExternalName')}" />
       <h:panelGroup layout="block" styleClass="ui-inputgroup">
         <p:inputText id="externalSecurityName" value="#{roleDetailBean.role.externalName}" />
-        <p:commandButton id="browseExternalName" icon="si si-network-browser" title="#{ivy.cm.co('/common/Browse')}"
+        <p:commandButton id="browseExternalName" icon="ti ti-browser" title="#{ivy.cm.co('/common/Browse')}"
           actionListener="#{roleDetailBean.browseDirectory}" update="directoryBrowser:directoryBrowserDialog"
           oncomplete="PF('directoryBrowserDialog').show();"
           disabled="#{roleDetailBean.directoryBrowserDisabled}" />

--- a/engine-cockpit/webContent/includes/components/security/roledetail-members.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-members.xhtml
@@ -10,7 +10,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-multiple-neutral-1"></i>
+        <i class="pr-3 ti ti-users"></i>
         <h6 class="m-0">#{ivy.cm.co('/roleDetailMembers/RoleMembers')}</h6>
       </div>
     </div>
@@ -20,7 +20,7 @@
         completeMethod="#{roleDetailBean.searchMember}" style="width: 100%;" styleClass="card-autocomplete-search"
         placeholder="#{ivy.cm.co('/roleDetailMembers/SearchRoleToAddPlaceholder')}" />
       <p:commandButton id="addMemberToRoleBtn" update="membersOfRoleForm" actionListener="#{roleDetailBean.addMember}"
-        icon="si si-add" title="#{ivy.cm.co('/common/Add')}" 
+        icon="ti ti-plus" title="#{ivy.cm.co('/common/Add')}" 
         styleClass="ml-1 flex-shrink-0 rounded-button" />
     </div>
     <p:dataTable id="roleMemberTable" value="#{roleDetailBean.membersOfRole}" widgetVar="membersOfRoleTable" var="member"
@@ -28,7 +28,7 @@
       paginatorAlwaysVisible="false" styleClass="mt-2" emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
       <f:facet name="header">
         <div class="ui-input-icon-left filter-container">
-          <i class="pi pi-search"/>
+          <i class="ti ti-search"/>
           <p:inputText onkeyup="PF('membersOfRoleTable').filter()" placeholder="#{ivy.cm.co('/roleDetailMembers/SearchRolesPlaceholder')}" id="globalFilter" value="#{roleDetailBean.membersFitler}" />
         </div>
       </f:facet>
@@ -44,7 +44,7 @@
       </p:column>
       <p:column styleClass="table-btn-1">
         <p:commandButton id="removeMemberFromRoleBtn" update="membersOfRoleForm"
-          actionListener="#{roleDetailBean.removeMember(member.name)}" icon="si si-subtract" title="#{ivy.cm.co('/common/Remove')}"
+          actionListener="#{roleDetailBean.removeMember(member.name)}" icon="ti ti-minus" title="#{ivy.cm.co('/common/Remove')}"
           styleClass="ui-button-secondary rounded-button" />
       </p:column>
     </p:dataTable>

--- a/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
@@ -10,7 +10,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-single-neutral-actions"></i>
+        <i class="pr-3 ti ti-user-check"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Users')}</h6>
       </div>
     </div>
@@ -22,7 +22,7 @@
           var="user" itemLabel="#{user.displayName}" itemValue="#{user}" converter="userConverter"
           placeholder="#{ivy.cm.co('/roleDetailUsers/SearchUserToAddPlaceholder')}" disabled="#{roleDetailBean.managed}" />
         <p:commandButton id="addUserToRoleBtn" update="usersOfRoleForm" actionListener="#{roleDetailBean.addUser}"
-          icon="si si-add" title="#{ivy.cm.co('/common/Add')}" disabled="#{roleDetailBean.managed}" 
+          icon="ti ti-plus" title="#{ivy.cm.co('/common/Add')}" disabled="#{roleDetailBean.managed}" 
           styleClass="ml-1 flex-shrink-0 rounded-button" />
       </div>
       <p:dataTable id="roleUserTable" value="#{roleDetailBean.usersOfRole}" widgetVar="usersOfRoleTable" var="user"
@@ -31,11 +31,11 @@
         <f:facet name="header">
           <div class="flex">
             <span class="ui-input-icon-left filter-container ui-fluid" style="width: 100%;">
-              <i class="pi pi-search"/>
+              <i class="ti ti-search"/>
               <p:inputText id="globalFilter" onkeyup="PF('usersOfRoleTable').filter()" placeholder="#{ivy.cm.co('/roleDetailUsers/SearchUsersPlaceholder')}" value="#{roleDetailBean.usersOfRoleFilter}" />
             </span>
 
-            <p:commandButton id="filterBtn" title="#{ivy.cm.co('/roleDetailUsers/Filter')} #{roleDetailBean.usersOfRole.contentFilterText}" type="button" icon="si si-filter-1"
+            <p:commandButton id="filterBtn" title="#{ivy.cm.co('/roleDetailUsers/Filter')} #{roleDetailBean.usersOfRole.contentFilterText}" type="button" icon="ti ti-filter"
               styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button" onclick="PF('filterPanel').show();" />
             <p:overlayPanel id="filterPanel" for="filterBtn" widgetVar="filterPanel" styleClass="table-content-filter">
               <p:selectManyCheckbox id="filterCheckboxes" layout="grid" columns="1" value="#{roleDetailBean.usersOfRole.selectedContentFilters}">
@@ -47,7 +47,7 @@
                   onclick="PF('filterPanel').hide();" type="button" />
                 <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
                   update="@form" actionListener="#{roleDetailBean.usersOfRole.resetSelectedContentFilters()}" />
-                <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="si si-check-1"
+                <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
                   update="@form" />
               </h:panelGroup>
             </p:overlayPanel>
@@ -67,7 +67,7 @@
         <p:column styleClass="table-btn-1">
           <ui:param name="canBeRemoved" value="#{roleDetailBean.hasRoleAssigned(user)}" />
           <p:commandButton id="removeUserFromRoleBtn" update="usersOfRoleForm"
-            actionListener="#{roleDetailBean.removeUser(user.name)}" icon="si si-subtract" 
+            actionListener="#{roleDetailBean.removeUser(user.name)}" icon="ti ti-minus" 
             title="#{canBeRemoved ? ivy.cm.co('/common/Remove') : ivy.cm.co('/roleDetailUsers/InheritedUser')}"
             styleClass="ui-button-secondary rounded-button" 
             disabled="#{roleDetailBean.managed or !canBeRemoved}" />

--- a/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/roledetail-users.xhtml
@@ -45,7 +45,7 @@
               <h:panelGroup layout="block" styleClass="mt-1 flex justify-content-end">
                 <p:commandButton id="cancelFilter" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-flat ui-button-secondary modal-input-button"
                   onclick="PF('filterPanel').hide();" type="button" />
-                <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
+                <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="ti ti-circle-x"
                   update="@form" actionListener="#{roleDetailBean.usersOfRole.resetSelectedContentFilters()}" />
                 <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
                   update="@form" />

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-info.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-info.xhtml
@@ -11,19 +11,19 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/SecuritySystem')}</h6>
 
         <h:panelGroup rendered="#{securityConfigBean.showDetails}">
-          <p:commandButton id="downloadSecurityReport" title="#{ivy.cm.co('/securitySystemInfo/DownloadSecurityReport')}" icon="si si-office-file-xls-1"
+          <p:commandButton id="downloadSecurityReport" title="#{ivy.cm.co('/securitySystemInfo/DownloadSecurityReport')}" icon="ti ti-file-type-xls"
             styleClass="flex-shrink-0 ml-auto rounded-button" onclick="PF('securityReportDownloadModal').show();"/>
           <p:linkButton outcome="securitysystem-merge.xhtml" id="compareSecuritySystemBtn" type="button" 
-                  title="#{ivy.cm.co('/securitySystemInfo/MergeSecuritySystems')}" icon="si si-move-to-bottom" styleClass="flex-shrink-0 ml-1 rounded-button">
+                  title="#{ivy.cm.co('/securitySystemInfo/MergeSecuritySystems')}" icon="ti ti-arrow-big-down-lines" styleClass="flex-shrink-0 ml-1 rounded-button">
             <f:param name="source" value="#{securityConfigBean.name}"/>
           </p:linkButton>
 
           <p:commandButton id="deleteSecuritySystem" type="button" onclick="PF('deleteSecuritySystemConfirmDialog').show()"
-                title="#{ivy.cm.co('/securitySystemInfo/DeleteSecuritySystemButtonTitle')}" icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
+                title="#{ivy.cm.co('/securitySystemInfo/DeleteSecuritySystemButtonTitle')}" icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
           <p:confirmDialog id="deleteSecuritySystemConfirmDialog"
             message="#{securityConfigBean.notToDeleteReason}"
             header="#{ivy.cm.co('/securitySystemInfo/DeleteSecuritySystemDialogHeader')}" severity="alert" widgetVar="deleteSecuritySystemConfirmDialog">
@@ -31,7 +31,7 @@
             <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('deleteSecuritySystemConfirmDialog').hide();" type="button"
               styleClass="ui-button-secondary ui-button-flat modal-input-button" />
             <p:commandButton id="deleteSecuritySystemConfirmYesBtn" value="#{ivy.cm.co('/common/Delete')}" immediate="true"
-              action="#{securityConfigBean.deleteConfiguration}" icon="si si-bin-1" styleClass="modal-input-button"
+              action="#{securityConfigBean.deleteConfiguration}" icon="ti ti-trash" styleClass="modal-input-button"
               disabled="#{!securityConfigBean.deletable}" />
           </p:confirmDialog>
         </h:panelGroup>
@@ -46,13 +46,13 @@
       <h:panelGroup>
         <label>#{ivy.cm.co('/securitySystemInfo/UsedByApplications')}</label>
         <h:panelGroup id="usedByHelp" styleClass="label-help-icon">
-          <i class="si si-question-circle"></i>
+          <i class="ti ti-help-circle"></i>
           <p:tooltip for="@parent" value="#{ivy.cm.co('/securitySystemInfo/UsedByApplicationsTooltip')}" position="top" />
         </h:panelGroup>
       </h:panelGroup>
       <ui:repeat var="app" value="#{securityConfigBean.usedByApps}" varStatus="status">
         <a href="#{securityConfigBean.getApplicationDetailLink(app)}">
-          <i class="si si-module link-icon"></i>#{app.name()}
+          <i class="ti ti-layout-grid link-icon"></i>#{app.name()}
         </a>
         <h:outputText value="#{status.last ? '' : ' / '}" />
       </ui:repeat>

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-language.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-language.xhtml
@@ -10,7 +10,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-conversation-chat-2"></i>
+        <i class="pr-3 ti ti-messages"></i>
         <h6 class="m-0">#{ivy.cm.co('/securitySystemLanguage/Languages')}</h6>
         <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" id="saveLanguageConfigBtn"
               styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" actionListener="#{securityConfigBean.saveLanguages}"/>

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-language.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-language.xhtml
@@ -12,7 +12,7 @@
       <div class="card-title flex align-items-center">
         <i class="pr-3 si si-conversation-chat-2"></i>
         <h6 class="m-0">#{ivy.cm.co('/securitySystemLanguage/Languages')}</h6>
-        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" id="saveLanguageConfigBtn"
+        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" id="saveLanguageConfigBtn"
               styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" actionListener="#{securityConfigBean.saveLanguages}"/>
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-provider.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-provider.xhtml
@@ -11,15 +11,15 @@
 
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-single-neutral-actions"></i>
+        <i class="pr-3 ti ti-user-check"></i>
         <h6 class="m-0">#{ivy.cm.co('/securitySystemProvider/IdentityProvider')}</h6>
 
-        <p:linkButton title="#{ivy.cm.co('/common/Edit')}" icon="si si-pencil" id="editProviderBtn" rendered="#{securityProviderBean.notIvySecuritySystem}"
+        <p:linkButton title="#{ivy.cm.co('/common/Edit')}" icon="ti ti-pencil" id="editProviderBtn" rendered="#{securityProviderBean.notIvySecuritySystem}"
             styleClass="ml-auto rounded-button" outcome="identity-provider">
           <f:param name="securitySystemName" value="#{securityProviderBean.securitySystemName}"/>
         </p:linkButton>
 
-        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" id="saveProviderBtn" update="securityProviderForm" actionListener="#{securityProviderBean.saveProvider}" 
+        <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" id="saveProviderBtn" update="securityProviderForm" actionListener="#{securityProviderBean.saveProvider}" 
             styleClass="#{securityProviderBean.notIvySecuritySystem ? '' : 'ml-auto'} ml-1 ui-button-success rounded-button"/>
       </div>
     </div>
@@ -57,7 +57,7 @@
           <br/>
           <h:panelGroup layout="block" styleClass="flex align-items-center mt-1">  
             <h:outputText value="#{securityProviderBean.cronReadable}" style="opacity: 0.5;"/>
-            <h:outputText id="cronHelp" class="ml-1 si si-information-circle" style="opacity: 0.5;"/>
+            <h:outputText id="cronHelp" class="ml-1 ti ti-info-circle" style="opacity: 0.5;"/>
             <p:tooltip for="cronHelp" value="#{securityProviderBean.cronHelp}" position="bottom" escape="false"/> <!-- contains no user input, contains html-->
           </h:panelGroup>
         </h:panelGroup>

--- a/engine-cockpit/webContent/includes/components/security/securitysystem-workflow-language.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/securitysystem-workflow-language.xhtml
@@ -7,11 +7,11 @@
   <h:form id="securityWorkflowLanguageForm">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-cog"></i>
+        <i class="pr-3 ti ti-settings"></i>
         <h6 class="m-0">#{ivy.cm.co('/securitySystemWorkflowLanguage/WorkflowLanguages')}</h6>
         <p:commandButton id="addBtn" oncomplete="PF('addWorkflowLanguageModal').show();" process="@this"
           update="securityWorkflowLanguageForm" title="#{ivy.cm.co('/securitySystemWorkflowLanguage/AddNewLanguage')}"
-          icon="si si-add" styleClass="flex-shrink-0 ml-auto rounded-button" disabled="#{empty securityWorkflowLanguageBean.addable}"/>
+          icon="ti ti-plus" styleClass="flex-shrink-0 ml-auto rounded-button" disabled="#{empty securityWorkflowLanguageBean.addable}"/>
       </div>
     </div>
 
@@ -21,14 +21,14 @@
         <h:outputText value="#{language.displayName}" styleClass="language-displayname" />
       </p:column>
       <p:column headerText="#{ivy.cm.co('/common/Default')}" styleClass="language-default">
-        <i class="#{securityWorkflowLanguageBean.isDefault(language) ? 'si si-check-circle-1 table-icon activity-state-active' : ''}"></i>
+        <i class="#{securityWorkflowLanguageBean.isDefault(language) ? 'ti ti-circle-check table-icon activity-state-active' : ''}"></i>
       </p:column>
       <p:column styleClass="table-btn-2">
         <p:commandButton id="defaultBtn" actionListener="#{securityWorkflowLanguageBean.setDefault(language)}"
-          icon="si si-pencil" title="#{ivy.cm.co('/securitySystemWorkflowLanguage/MakeDefaultLanguage')}" update="@form"
+          icon="ti ti-pencil" title="#{ivy.cm.co('/securitySystemWorkflowLanguage/MakeDefaultLanguage')}" update="@form"
           styleClass="ui-button-secondary rounded-button" disabled="#{securityWorkflowLanguageBean.isDefault(language)}" />
         <p:commandButton id="deleteBtn" actionListener="#{securityWorkflowLanguageBean.setEditLanguage(language)}" oncomplete="PF('deleteWorkflowLanguageModal').show();"
-          icon="si si-bin-1" title="#{ivy.cm.co('/securitySystemWorkflowLanguage/DeleteLanguage')}" update="@form"
+          icon="ti ti-trash" title="#{ivy.cm.co('/securitySystemWorkflowLanguage/DeleteLanguage')}" update="@form"
           styleClass="ml-1 ui-button-danger rounded-button"  
           disabled="#{securityWorkflowLanguageBean.isDefault(language)}">
         </p:commandButton>
@@ -53,7 +53,7 @@
       <p:commandButton id="cancelBtn" onclick="PF('addWorkflowLanguageModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" immediate="true" />
       <p:commandButton id="addBtn" validateClient="true" ajax="false" update=":securityWorkflowLanguageForm"
-        actionListener="#{securityWorkflowLanguageBean.add(securityWorkflowLanguageBean.editLanguage)}" value="#{ivy.cm.co('/common/Add')}" icon="si si-add"
+        actionListener="#{securityWorkflowLanguageBean.add(securityWorkflowLanguageBean.editLanguage)}" value="#{ivy.cm.co('/common/Add')}" icon="ti ti-plus"
         styleClass="modal-input-button" />
     </div>
   </h:form>
@@ -66,7 +66,7 @@
     <p:commandButton id="cancelBtn" onclick="PF('deleteWorkflowLanguageModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
       styleClass="ui-button-secondary ui-button-flat modal-input-button" immediate="true" />
     <p:commandButton id="deleteBtn" validateClient="true" ajax="false" update=":securityWorkflowLanguageForm"
-      actionListener="#{securityWorkflowLanguageBean.delete(securityWorkflowLanguageBean.editLanguage)}" value="#{ivy.cm.co('/common/Delete')}" icon="si si-bin-1"
+      actionListener="#{securityWorkflowLanguageBean.delete(securityWorkflowLanguageBean.editLanguage)}" value="#{ivy.cm.co('/common/Delete')}" icon="ti ti-trash"
       styleClass="modal-input-button" />
   </h:form>
 </p:confirmDialog>

--- a/engine-cockpit/webContent/includes/components/security/userdetail-absences.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-absences.xhtml
@@ -14,7 +14,7 @@
         title="#{userDetailBean.user.working ? ivy.cm.co('/userDetailAbsences/UserIsCurrentlyNotAbsent') : ivy.cm.co('/userDetailAbsences/UserIsCurrentlyAbsent')}">
         <h:outputLabel for="working" value="#{ivy.cm.co('/userDetailAbsences/Working')}" />
         <i id="working"
-          class="pl-3 si si-#{userDetailBean.user.working ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+          class="pl-3 #{userDetailBean.user.working ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
       </div>
     </div>
 

--- a/engine-cockpit/webContent/includes/components/security/userdetail-absences.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-absences.xhtml
@@ -14,7 +14,7 @@
         title="#{userDetailBean.user.working ? ivy.cm.co('/userDetailAbsences/UserIsCurrentlyNotAbsent') : ivy.cm.co('/userDetailAbsences/UserIsCurrentlyAbsent')}">
         <h:outputLabel for="working" value="#{ivy.cm.co('/userDetailAbsences/Working')}" />
         <i id="working"
-          class="pl-3 #{userDetailBean.user.working ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+          class="pl-3 #{userDetailBean.user.working ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
       </div>
     </div>
 

--- a/engine-cockpit/webContent/includes/components/security/userdetail-absences.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-absences.xhtml
@@ -7,7 +7,7 @@
   <h:form id="absencesForm">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-beach-palm-sunbed"></i>
+        <i class="pr-3 ti ti-beach"></i>
         <h6 class="m-0">#{ivy.cm.co('/userDetailAbsences/Absences')}</h6>
       </div>
       <div class="flex align-items-center"

--- a/engine-cockpit/webContent/includes/components/security/userdetail-information.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-information.xhtml
@@ -10,33 +10,33 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/userDetailInformation/UserInformation')}</h6>
         <p:commandButton title="#{ivy.cm.co('/userDetailInformation/Synch')}" id="userSynchBtn" rendered="#{!userDetailBean.ivySecuritySystem}" type="button"
-          icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" onclick="PF('synchUserModal').show()" />
+          icon="ti ti-refresh" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" onclick="PF('synchUserModal').show()" />
 
         <h:panelGroup rendered="#{!userDetailBean.user.external or userDetailBean.ivySecuritySystem}">
           <p:commandButton id="disableUser" actionListener="#{userDetailBean.disableUser}" title="#{ivy.cm.co('/userDetailInformation/DisableUser')}"
             styleClass="p-flex-shrink-0 ml-#{!userDetailBean.ivySecuritySystem ? '1' : 'auto'} ui-button-warning rounded-button"
-            icon="si si-delete" update="userInformationForm"  rendered="#{userDetailBean.isUserEnabled()}" />
+            icon="ti ti-trash" update="userInformationForm"  rendered="#{userDetailBean.isUserEnabled()}" />
           <p:commandButton id="enableUser" actionListener="#{userDetailBean.enableUser}" title="#{ivy.cm.co('/userDetailInformation/EnableUser')}"
             styleClass="p-flex-shrink-0 ml-#{!userDetailBean.ivySecuritySystem ? '1' : 'auto'} rounded-button" 
-            icon="si si-check-circle-1" update="userInformationForm" rendered="#{userDetailBean.isUserDisabled()}" />
+            icon="ti ti-circle-check" update="userInformationForm" rendered="#{userDetailBean.isUserDisabled()}" />
           <p:commandButton id="deleteUser" type="button" onclick="PF('deleteUserConfirmDialog').show()"
-            title="#{ivy.cm.co('/userDetailInformation/DeleteUser')}" icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
+            title="#{ivy.cm.co('/userDetailInformation/DeleteUser')}" icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
           <p:confirmDialog id="deleteUserConfirmDialog" header="#{ivy.cm.co('/userDetailInformation/DeleteUserDialogHeader')}" severity="alert"
             widgetVar="deleteUserConfirmDialog" message="#{userDetailBean.userDeleteHint()}">
             <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('deleteUserConfirmDialog').hide();" type="button"
               styleClass="ui-button-secondary ui-button-flat modal-input-button" />
             <p:commandButton id="disableUserConfirmBtn" value="#{ivy.cm.co('/common/Disable')}" immediate="true"
-              actionListener="#{userDetailBean.disableUser}" icon="si si-delete" styleClass="modal-input-button"
+              actionListener="#{userDetailBean.disableUser}" icon="ti ti-trash" styleClass="modal-input-button"
               rendered="#{userDetailBean.isUserEnabled()}" update="userInformationForm" />
             <p:commandButton id="deleteUserConfirmYesBtn" value="#{ivy.cm.co('/common/Delete')}" immediate="true"
-              action="#{userDetailBean.deleteSelectedUser}" icon="si si-bin-1" styleClass="modal-input-button" />
+              action="#{userDetailBean.deleteSelectedUser}" icon="ti ti-trash" styleClass="modal-input-button" />
           </p:confirmDialog>
         </h:panelGroup>
         <p:commandButton id="saveUserInformation" actionListener="#{userDetailBean.saveUserInfos}" title="#{ivy.cm.co('/common/SaveChanges')}"
-          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" />
+          icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" />
       </div>
     </div>
 
@@ -50,7 +50,7 @@
         <span class="ui-message-info-summary">#{ivy.cm.co('/common/Info')}</span>
         <span class="ui-message-info-detail">#{ivy.cm.co('/userDetailInformation/UserInExternalSecuritySystemMessage')}
           <a href="security-detail.xhtml?securitySystemName=#{userDetailBean.securitySystemName}">
-            <i class="si si-lock-1 link-icon"></i>#{userDetailBean.securitySystemName}
+            <i class="ti ti-lock link-icon"></i>#{userDetailBean.securitySystemName}
           </a>
         </span>
       </h:panelGroup>

--- a/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
@@ -39,7 +39,7 @@
         </f:facet>
 
         <c:set var="subscription" value="#{channel.getSubscription(event)}"/>
-        <i class="si table-icon #{subscription.icon} subscription-icon" title="#{subscription.title}"
+        <i class="table-icon #{subscription.icon} subscription-icon" title="#{subscription.title}"
           style="padding-right: 10px; vertical-align: top" />
         <p:triStateCheckbox id="subscriptionCheckbox" value="#{subscription.stateAsString}">
           <p:ajax event="change" update="notificationsForm" listener="#{channel.setSubscriptionIconAndTitle(event)}" />

--- a/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
@@ -39,7 +39,7 @@
         </f:facet>
 
         <c:set var="subscription" value="#{channel.getSubscription(event)}"/>
-        <i class="si table-icon si-#{subscription.icon} subscription-icon" title="#{subscription.title}"
+        <i class="si table-icon #{subscription.icon} subscription-icon" title="#{subscription.title}"
           style="padding-right: 10px; vertical-align: top" />
         <p:triStateCheckbox id="subscriptionCheckbox" value="#{subscription.stateAsString}">
           <p:ajax event="change" update="notificationsForm" listener="#{channel.setSubscriptionIconAndTitle(event)}" />

--- a/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-notifications.xhtml
@@ -10,13 +10,13 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-advertising-megaphone-2"></i>
+        <i class="pr-3 ti ti-speakerphone"></i>
         <h6 class="m-0">#{ivy.cm.co('/userDetailNotifications/NotificationChannels')}</h6>
       </div>
       <p:commandButton id="reset" actionListener="#{userDetailBean.notificationChannels.reset}" title="#{ivy.cm.co('/userDetailNotifications/ResetToDefault')}"
-        icon="si si-undo" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" update="notificationsForm" />
+        icon="ti ti-arrow-back-up" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" update="notificationsForm" />
       <p:commandButton id="save" actionListener="#{userDetailBean.notificationChannels.save}" title="#{ivy.cm.co('/common/SaveChanges')}"
-        icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" />
+        icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" />
     </div>
 
     <p:dataTable paginator="true" rows="10" paginatorPosition="bottom" paginatorAlwaysVisible="false"
@@ -26,7 +26,7 @@
       <p:column headerText="#{ivy.cm.co('/userDetailNotifications/Event')}" sortBy="#{event.displayName}">
         <h:panelGroup id="event">
           <h:outputText value="#{event.displayName}" styleClass="event-kind" />
-          <i class="si si-question-circle"></i>
+          <i class="ti ti-help-circle"></i>
         </h:panelGroup>
         <p:tooltip for="notificationsForm:notificationChannelsTable:#{rowIndex}:event" value="#{event.description}" position="top" styleClass="pre-tooltip" />
       </p:column>

--- a/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
@@ -10,25 +10,25 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-multiple-neutral-1"></i>
+        <i class="pr-3 ti ti-users"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Roles')}</h6>
       </div>
     </div>
 
     <div class="table-search flex ui-fluid">
       <span class="ui-input-icon-left filter-container">
-        <i class="pi pi-search"/>
+        <i class="ti ti-search"/>
         <p:inputText id="globalFilter" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{userDetailBean.roles.filter}">
           <p:ajax event="keyup" delay="300" update="@form:rolesTree" />
         </p:inputText>
       </span>
-      <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
+      <p:commandButton id="expandAll" icon="ti ti-arrows-vertical"
         actionListener="#{userDetailBean.roles.expandAllNodes}" update="rolesTree" title="#{ivy.cm.co('/common/ExpandAll')}"
         styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
-      <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
+      <p:commandButton id="collapseAll" icon="ti ti-arrows-minimize"
         actionListener="#{userDetailBean.roles.collapseAllNodes}" update="rolesTree" title="#{ivy.cm.co('/common/CollapseAll')}"
         styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
-      <p:commandButton id="roleFilterBtn" title="#{ivy.cm.co('/usersTable/Filter')} #{userDetailBean.roles.contentFilterText}" type="button" icon="si si-filter-1"
+      <p:commandButton id="roleFilterBtn" title="#{ivy.cm.co('/usersTable/Filter')} #{userDetailBean.roles.contentFilterText}" type="button" icon="ti ti-filter"
         styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button" onclick="PF('roleFilterPanel').show();" />
       <p:overlayPanel id="roleFilterPanel" for="roleFilterBtn" widgetVar="roleFilterPanel" styleClass="table-content-filter">
         <p:selectManyCheckbox id="filterCheckboxes" layout="grid" columns="1" value="#{userDetailBean.roles.selectedContentFilters}">
@@ -40,7 +40,7 @@
             onclick="PF('roleFilterPanel').hide();" type="button" />
           <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
             update="@form" actionListener="#{userDetailBean.roles.resetSelectedContentFilters()}" />
-          <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="si si-check-1"
+          <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
             update="@form" />
         </h:panelGroup>
       </p:overlayPanel>
@@ -57,7 +57,7 @@
             </h:outputText>
             <h:outputText value=" (#{role.displayName})" styleClass="addition-row-info" />
             <h:panelGroup rendered="#{userDetailBean.isRoleManaged(role)}">
-              <i class="si si-button-refresh-arrows table-icon" title="#{ivy.cm.co('/userDetailRoles/RoleInExternalSecuritySystemMessage')}"></i>
+              <i class="ti ti-refresh table-icon" title="#{ivy.cm.co('/userDetailRoles/RoleInExternalSecuritySystemMessage')}"></i>
             </h:panelGroup>
           </a>
         </p:treeNode>
@@ -68,7 +68,7 @@
         <p:treeNode type="searchDummy" rendered="#{node.type == 'searchDummy'}">
           <h:outputText value="#{role.name}"
             title="#{ivy.cm.co('/userDetailRoles/RoleSearchPerformanceReasonsMessage')}">
-            <i class="si si-navigation-menu-horizontal table-icon"></i>
+            <i class="ti ti-dots table-icon"></i>
           </h:outputText>
         </p:treeNode>
       </p:column>
@@ -76,10 +76,10 @@
       <p:column styleClass="table-btn-1">
         <h:panelGroup rendered="#{node.type == 'role'}">
           <h:outputText rendered="#{userDetailBean.isUserMemberOfButNotDirect(role)}">
-            <i class="si si-check-circle table-icon light" title="#{ivy.cm.co('/userDetailRoles/Inherited')}" />
+            <i class="ti ti-circle-check table-icon light" title="#{ivy.cm.co('/userDetailRoles/Inherited')}" />
           </h:outputText>
           <h:outputText rendered="#{userDetailBean.isUserDirectMemberOf(role)}">
-            <i class="si si-check-circle table-icon" />
+            <i class="ti ti-circle-check table-icon" />
           </h:outputText>
         </h:panelGroup>
       </p:column>
@@ -87,10 +87,10 @@
       <p:column styleClass="table-btn-2">
         <h:panelGroup rendered="#{node.type == 'role'}">
           <p:commandButton id="addRoleToUserBtn" update="@form" actionListener="#{userDetailBean.addRole(role.name)}"
-            icon="si si-add" title="#{ivy.cm.co('/common/Add')}" styleClass="rounded-button"
+            icon="ti ti-plus" title="#{ivy.cm.co('/common/Add')}" styleClass="rounded-button"
             disabled="#{userDetailBean.isAddRoleButtonDisabled(role)}" />
           <p:commandButton id="removeRoleFromUserBtn" update="@form"
-            actionListener="#{userDetailBean.removeRole(role.name)}" icon="si si-subtract" title="#{ivy.cm.co('/common/Remove')}"
+            actionListener="#{userDetailBean.removeRole(role.name)}" icon="ti ti-minus" title="#{ivy.cm.co('/common/Remove')}"
             styleClass="ml-1 ui-button-secondary rounded-button"
             disabled="#{userDetailBean.isRemoveRoleButtonDisabled(role)}" />
         </h:panelGroup>

--- a/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-roles.xhtml
@@ -38,7 +38,7 @@
         <h:panelGroup layout="block" styleClass="mt-1 flex justify-content-end">
           <p:commandButton id="cancelFilter" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-flat ui-button-secondary modal-input-button"
             onclick="PF('roleFilterPanel').hide();" type="button" />
-          <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
+          <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="ti ti-circle-x"
             update="@form" actionListener="#{userDetailBean.roles.resetSelectedContentFilters()}" />
           <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
             update="@form" />

--- a/engine-cockpit/webContent/includes/components/security/userdetail-substitutes.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-substitutes.xhtml
@@ -26,20 +26,20 @@
 
       <p:column headerText="#{ivy.cm.co('/userDetailSubstitutes/Type')}" sortBy="#{substitute.typeTitle}">
         <h:outputText value="#{substitute.typeTitle}">
-          <i class="si si-#{substitute.typeIcon} table-icon" />
+          <i class="#{substitute.typeIcon} table-icon" />
         </h:outputText>
       </p:column>
 
       <p:column headerText="#{ivy.cm.co('/userDetailSubstitutes/For')}" sortBy="#{substitute.memberTitle}">
         <h:outputText value="#{substitute.memberTitle}">
-          <i class="si si-#{substitute.memberIcon} table-icon" />
+          <i class="#{substitute.memberIcon} table-icon" />
         </h:outputText>
       </p:column>
 
       <p:column headerText="#{ivy.cm.co('/common/Role')}" sortBy="#{substitute.role}">
         <a href="#{substitute.roleViewUrl}">
           <h:outputText value="#{substitute.role}" styleClass="substitute-name" rendered="#{!substitute.role.blank}">
-            <i class="si si-#{substitute.memberIcon} table-icon" />
+            <i class="#{substitute.memberIcon} table-icon" />
           </h:outputText>
         </a>
       </p:column>

--- a/engine-cockpit/webContent/includes/components/security/userdetail-substitutes.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/userdetail-substitutes.xhtml
@@ -7,7 +7,7 @@
   <h:form id="substitutesForm">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-single-neutral-actions"></i>
+        <i class="pr-3 ti ti-user-check"></i>
         <h6 class="m-0">#{ivy.cm.co('/userDetailSubstitutes/Substitutes')}</h6>
       </div>
     </div>
@@ -19,7 +19,7 @@
       <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{substitute.name}">
         <a href="#{substitute.substituteViewUrl}">
           <h:outputText value="#{substitute.name}" styleClass="substitute-name">
-            <i class="si si-single-neutral-actions table-icon" />
+            <i class="ti ti-user-check table-icon" />
           </h:outputText>
         </a>
       </p:column>

--- a/engine-cockpit/webContent/includes/components/security/users-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/users-table.xhtml
@@ -11,10 +11,10 @@
     <f:facet name="header">
       <div class="flex">
         <span class="ui-input-icon-left filter-container ui-fluid" style="width: 100%;">
-          <i class="pi pi-search"/>
+          <i class="ti ti-search"/>
           <p:inputText id="globalFilter" onkeyup="PF('usersTable_#{app.id}').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{userBean.userDataModel.filter}" />
         </span>
-        <p:commandButton id="filterBtn" title="#{ivy.cm.co('/usersTable/Filter')} #{userBean.userDataModel.contentFilterText}" type="button" icon="si si-filter-1"
+        <p:commandButton id="filterBtn" title="#{ivy.cm.co('/usersTable/Filter')} #{userBean.userDataModel.contentFilterText}" type="button" icon="ti ti-filter"
           styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button" onclick="PF('filterPanel_#{securitySystem.id}').show();" />
         <p:overlayPanel id="filterPanel" for="filterBtn" widgetVar="filterPanel_#{securitySystem.id}" styleClass="table-content-filter">
           <p:selectManyCheckbox id="filterCheckboxes" layout="grid" columns="1" value="#{userBean.userDataModel.selectedContentFilters}">
@@ -26,7 +26,7 @@
               onclick="PF('filterPanel_#{securitySystem.id}').hide();" type="button" />
             <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
               update="@form" actionListener="#{userBean.userDataModel.resetSelectedContentFilters()}" />
-            <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="si si-check-1"
+            <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
               update="@form" />
           </h:panelGroup>
         </p:overlayPanel>

--- a/engine-cockpit/webContent/includes/components/security/users-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/users-table.xhtml
@@ -57,10 +57,10 @@
       </h:outputText>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/usersTable/Working')}" style="width: 100px; text-align: center">
-      <i class="si table-icon #{user.working ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}"></i>
+      <i class="table-icon #{user.working ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}"></i>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/usersTable/LoggedIn')}" style="width: 100px; text-align: center">
-      <i class="si table-icon #{user.loggedIn ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}"></i>
+      <i class="table-icon #{user.loggedIn ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}"></i>
     </p:column>
   </p:dataTable>
 </h:form>

--- a/engine-cockpit/webContent/includes/components/security/users-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/users-table.xhtml
@@ -24,7 +24,7 @@
           <h:panelGroup layout="block" styleClass="mt-1 flex justify-content-end">
             <p:commandButton id="cancelFilter" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-flat ui-button-secondary modal-input-button"
               onclick="PF('filterPanel_#{securitySystem.id}').hide();" type="button" />
-            <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
+            <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="ti ti-circle-x"
               update="@form" actionListener="#{userBean.userDataModel.resetSelectedContentFilters()}" />
             <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
               update="@form" />

--- a/engine-cockpit/webContent/includes/components/security/users-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/users-table.xhtml
@@ -57,10 +57,10 @@
       </h:outputText>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/usersTable/Working')}" style="width: 100px; text-align: center">
-      <i class="si table-icon #{user.working ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}"></i>
+      <i class="si table-icon #{user.working ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}"></i>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/usersTable/LoggedIn')}" style="width: 100px; text-align: center">
-      <i class="si table-icon #{user.loggedIn ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}"></i>
+      <i class="si table-icon #{user.loggedIn ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}"></i>
     </p:column>
   </p:dataTable>
 </h:form>

--- a/engine-cockpit/webContent/includes/components/security/users-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/security/users-table.xhtml
@@ -57,10 +57,10 @@
       </h:outputText>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/usersTable/Working')}" style="width: 100px; text-align: center">
-      <i class="si table-icon si-#{user.working ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}"></i>
+      <i class="si table-icon #{user.working ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}"></i>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/usersTable/LoggedIn')}" style="width: 100px; text-align: center">
-      <i class="si table-icon si-#{user.loggedIn ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}"></i>
+      <i class="si table-icon #{user.loggedIn ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}"></i>
     </p:column>
   </p:dataTable>
 </h:form>

--- a/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
@@ -11,24 +11,24 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/databaseConfiguration/DatabaseConfigurations')}</h6>
         <p:commandButton id="testDatabaseBtn" title="#{ivy.cm.co('/databaseConfiguration/TestDatabaseConnection')}" update="connResult:connectionTestModel"
           oncomplete="PF('connectionTestModel').show()" icon="si si-phone-actions-call"
           actionListener="#{tlsTesterBean.setTlsTestRendered(false)}"
           styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetDbConfirmDialog').show()"
-          title="#{ivy.cm.co('/databaseConfiguration/ResetConfiguration')}" icon="si si-undo" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
+          title="#{ivy.cm.co('/databaseConfiguration/ResetConfiguration')}" icon="ti ti-arrow-back-up" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
         <p:confirmDialog id="resetDbConfirmDialog" message="#{ivy.cm.co('/databaseConfiguration/ResetDatabaseConfirmDialogMessage')}"
           header="#{ivy.cm.co('/databaseConfiguration/ResetDatabaseConfirmDialogHeader')}" severity="alert" widgetVar="resetDbConfirmDialog">
           <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('resetDbConfirmDialog').hide();" type="button"
             styleClass="ui-button-secondary ui-button-flat modal-input-button" />
           <p:commandButton id="resetDbConfirmYesBtn" value="#{ivy.cm.co('/common/Reset')}"
-            actionListener="#{databaseDetailBean.resetDbConfig}" icon="si si-undo" update="@form"
+            actionListener="#{databaseDetailBean.resetDbConfig}" icon="ti ti-arrow-back-up" update="@form"
             styleClass="modal-input-button" />
         </p:confirmDialog>
         <p:commandButton id="saveDatabaseConfig" actionListener="#{databaseDetailBean.saveDbConfig}"
-          title="#{ivy.cm.co('/common/SaveChanges')}" icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"
+          title="#{ivy.cm.co('/common/SaveChanges')}" icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"
           update="@form, connResult:connectionTestModel" />
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-configuration.xhtml
@@ -14,7 +14,7 @@
         <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/databaseConfiguration/DatabaseConfigurations')}</h6>
         <p:commandButton id="testDatabaseBtn" title="#{ivy.cm.co('/databaseConfiguration/TestDatabaseConnection')}" update="connResult:connectionTestModel"
-          oncomplete="PF('connectionTestModel').show()" icon="si si-phone-actions-call"
+          oncomplete="PF('connectionTestModel').show()" icon="ti ti-phone-outgoing"
           actionListener="#{tlsTesterBean.setTlsTestRendered(false)}"
           styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetDbConfirmDialog').show()"

--- a/engine-cockpit/webContent/includes/components/services/database-connections.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-connections.xhtml
@@ -19,7 +19,7 @@
       id="databaseConnectionsTable" paginator="true" rows="10" paginatorPosition="bottom" paginatorAlwaysVisible="false">
       <p:column headerText="#{ivy.cm.co('/databaseConnections/InUse')}" sortBy="#{conn.inUse}">
         <h:outputText styleClass="connection">
-          <i class="#{conn.inUse ? 'check-circle-1' : 'remove-circle'} table-icon"></i>
+          <i class="#{conn.inUse ? 'ti ti-circle-check' : 'ti ti-circle-minus'} table-icon"></i>
         </h:outputText>
       </p:column>
       <p:column headerText="#{ivy.cm.co('/databaseConnections/LastUsed')}" sortBy="#{conn.lastUsed}">

--- a/engine-cockpit/webContent/includes/components/services/database-connections.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-connections.xhtml
@@ -10,7 +10,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-hyperlink-3"></i>
+        <i class="pr-3 ti ti-link"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Connections')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/database-connections.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-connections.xhtml
@@ -19,7 +19,7 @@
       id="databaseConnectionsTable" paginator="true" rows="10" paginatorPosition="bottom" paginatorAlwaysVisible="false">
       <p:column headerText="#{ivy.cm.co('/databaseConnections/InUse')}" sortBy="#{conn.inUse}">
         <h:outputText styleClass="connection">
-          <i class="si si-#{conn.inUse ? 'check-circle-1' : 'remove-circle'} table-icon"></i>
+          <i class="#{conn.inUse ? 'check-circle-1' : 'remove-circle'} table-icon"></i>
         </h:outputText>
       </p:column>
       <p:column headerText="#{ivy.cm.co('/databaseConnections/LastUsed')}" sortBy="#{conn.lastUsed}">

--- a/engine-cockpit/webContent/includes/components/services/database-history.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-history.xhtml
@@ -10,7 +10,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-optimization-timer"></i>
+        <i class="pr-3 ti ti-calendar-clock"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/ExecutionHistory')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/database-history.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-history.xhtml
@@ -29,7 +29,7 @@
       </p:column>
       <p:column headerText="#{ivy.cm.co('/databaseHistory/SQLHeader')}" sortBy="#{exec.sql}">
         <h:outputText value="#{exec.sql}" title="#{exec.sql}" styleClass="table-cell-autocut" style="width: calc(100% - 3rem);"/>
-        <p:commandButton icon="si si-copy-paste" type="button" title="#{ivy.cm.co('/databaseHistory/CopyToClipboardButtonTitle')}" onclick="var button=this; copyToClipboard($(this).siblings('.table-cell-autocut').text(), button)"
+        <p:commandButton icon="ti ti-copy" type="button" title="#{ivy.cm.co('/databaseHistory/CopyToClipboardButtonTitle')}" onclick="var button=this; copyToClipboard($(this).siblings('.table-cell-autocut').text(), button)"
           styleClass="ui-button-flat rounded-button"/>
       </p:column>
       <p:column headerText="#{ivy.cm.co('/databaseHistory/ProcessElementHeader')}" style="width: 75px; word-wrap: anywhere;" sortBy="#{exec.element}">

--- a/engine-cockpit/webContent/includes/components/services/database-properties.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/database-properties.xhtml
@@ -14,7 +14,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-cog"></i>
+        <i class="pr-3 ti ti-settings"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Properties')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
@@ -22,10 +22,10 @@
       </a>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/Enabled')}" sortBy="#{channel.enabled}" style="text-align: center">
-      <i class="si table-icon si-#{channel.enabled ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+      <i class="si table-icon #{channel.enabled ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/AllEvents')}" sortBy="#{channel.allEventsEnabled}" style="text-align: center">
-      <i class="si table-icon si-#{channel.allEventsEnabled ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+      <i class="si table-icon #{channel.allEventsEnabled ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/State')}" sortBy="#{channel.stateText}" style="text-align: center">
       <cc:ChannelState id="state" channel="#{channel}"/>

--- a/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
@@ -22,10 +22,10 @@
       </a>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/Enabled')}" sortBy="#{channel.enabled}" style="text-align: center">
-      <i class="si table-icon #{channel.enabled ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
+      <i class="table-icon #{channel.enabled ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/AllEvents')}" sortBy="#{channel.allEventsEnabled}" style="text-align: center">
-      <i class="si table-icon #{channel.allEventsEnabled ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
+      <i class="table-icon #{channel.allEventsEnabled ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/State')}" sortBy="#{channel.stateText}" style="text-align: center">
       <cc:ChannelState id="state" channel="#{channel}"/>

--- a/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
@@ -22,10 +22,10 @@
       </a>
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/Enabled')}" sortBy="#{channel.enabled}" style="text-align: center">
-      <i class="si table-icon #{channel.enabled ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+      <i class="si table-icon #{channel.enabled ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/AllEvents')}" sortBy="#{channel.allEventsEnabled}" style="text-align: center">
-      <i class="si table-icon #{channel.allEventsEnabled ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+      <i class="si table-icon #{channel.allEventsEnabled ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
     </p:column>
     <p:column headerText="#{ivy.cm.co('/common/State')}" sortBy="#{channel.stateText}" style="text-align: center">
       <cc:ChannelState id="state" channel="#{channel}"/>

--- a/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/notification-channels-table.xhtml
@@ -10,7 +10,7 @@
     filteredValue="#{notificationChannelsBean.filteredChannels}" lazy="false" id="channelsTable" emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
     <f:facet name="header">
       <div class="ui-input-icon-left filter-container">
-        <i class="pi pi-search"/>
+        <i class="ti ti-search"/>
         <p:inputText id="globalFilter" onkeyup="PF('channelsTable_#{app.id}').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{notificationChannelsBean.filter}" />
       </div>
     </f:facet>

--- a/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
@@ -14,7 +14,7 @@
         <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/restClientConfiguration/RestClientConfigurations')}</h6>
         <p:commandButton id="testRestBtn" title="#{ivy.cm.co('/restClientConfiguration/TestRestConnection')}" oncomplete="PF('connectionTestModel').show()"
-          icon="si si-phone-actions-call" update="restClientAdditionalConfigForm, connResult:connectionTestModel"
+          icon="ti ti-phone-outgoing" update="restClientAdditionalConfigForm, connResult:connectionTestModel"
           actionListener="#{tlsTesterBean.setTlsTestRendered(false)}"
           styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetRestConfirmDialog').show()"

--- a/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/restclient-configuration.xhtml
@@ -11,23 +11,23 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/restClientConfiguration/RestClientConfigurations')}</h6>
         <p:commandButton id="testRestBtn" title="#{ivy.cm.co('/restClientConfiguration/TestRestConnection')}" oncomplete="PF('connectionTestModel').show()"
           icon="si si-phone-actions-call" update="restClientAdditionalConfigForm, connResult:connectionTestModel"
           actionListener="#{tlsTesterBean.setTlsTestRendered(false)}"
           styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button" />
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetRestConfirmDialog').show()"
-          title="#{ivy.cm.co('/restClientConfiguration/ResetConfiguration')}" icon="si si-undo" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
+          title="#{ivy.cm.co('/restClientConfiguration/ResetConfiguration')}" icon="ti ti-arrow-back-up" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
         <p:confirmDialog id="resetRestConfirmDialog" message="#{ivy.cm.co('/restClientConfiguration/ResetRestClientDialogMessage')}"
           header="#{ivy.cm.co('/restClientConfiguration/ResetRestClientDialogHeader')}" severity="alert" widgetVar="resetRestConfirmDialog">
           <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('resetRestConfirmDialog').hide();" type="button"
             styleClass="ui-button-secondary ui-button-flat modal-input-button" />
           <p:commandButton id="resetRestConfirmYesBtn" value="#{ivy.cm.co('/common/Reset')}" actionListener="#{restClientDetailBean.resetConfig}"
-            icon="si si-undo" update="@form, restClientAdditionalConfigForm" styleClass="modal-input-button" />
+            icon="ti ti-arrow-back-up" update="@form, restClientAdditionalConfigForm" styleClass="modal-input-button" />
         </p:confirmDialog>
         <p:commandButton id="saveRestConfig" actionListener="#{restClientDetailBean.saveConfig}" title="#{ivy.cm.co('/common/SaveChanges')}"
-          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"
+          icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"
           update="@form, restClientAdditionalConfigForm, connResult:connectionTestModel" />
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/restclient-properties.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/restclient-properties.xhtml
@@ -11,7 +11,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-cog"></i>
+        <i class="pr-3 ti ti-settings"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/FeaturesAndProperties')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/services/webservice-configuration.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/webservice-configuration.xhtml
@@ -11,19 +11,19 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-information-circle"></i>
+        <i class="pr-3 ti ti-info-circle"></i>
         <h6 class="m-0">#{ivy.cm.co('/webServiceConfiguration/WebServiceConfigurations')}</h6>
         <p:commandButton id="resetConfig" type="button" onclick="PF('resetWsConfirmDialog').show()"
-          title="#{ivy.cm.co('/webServiceConfiguration/ResetConfiguration')}" icon="si si-undo" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" />
+          title="#{ivy.cm.co('/webServiceConfiguration/ResetConfiguration')}" icon="ti ti-arrow-back-up" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" />
         <p:confirmDialog id="resetWsConfirmDialog" message="#{ivy.cm.co('/webServiceConfiguration/ResetWSConfirmDialogMessage')}"
           header="#{ivy.cm.co('/webServiceConfiguration/ResetWSConfirmDialogHeader')}" severity="alert" widgetVar="resetWsConfirmDialog">
           <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('resetWsConfirmDialog').hide();" type="button"
             styleClass="ui-button-secondary ui-button-flat modal-input-button" />
           <p:commandButton id="resetWsConfirmYesBtn" value="#{ivy.cm.co('/common/Reset')}" actionListener="#{webserviceDetailBean.resetConfig}"
-            icon="si si-undo" update="@form, webserviceAdditionalConfigForm, webservcieEndPointForm" styleClass="modal-input-button" />
+            icon="ti ti-arrow-back-up" update="@form, webserviceAdditionalConfigForm, webservcieEndPointForm" styleClass="modal-input-button" />
         </p:confirmDialog>
         <p:commandButton id="saveWsConfig" actionListener="#{webserviceDetailBean.saveConfig}" title="#{ivy.cm.co('/common/SaveChanges')}"
-          icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" update="@form, webserviceAdditionalConfigForm, webservcieEndPointForm" />
+          icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" update="@form, webserviceAdditionalConfigForm, webservcieEndPointForm" />
       </div>
     </div>
     

--- a/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
@@ -11,7 +11,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-network-arrow"></i>
+        <i class="pr-3 ti ti-network"></i>
         <h6 class="m-0">#{ivy.cm.co('/webServiceEndpoints/Endpoints')}</h6>
       </div>
     </div>
@@ -23,7 +23,7 @@
         <h:outputText value="#{endpoint.name}" styleClass="endpoint-entry" />
       </p:column>
       <p:column styleClass="table-btn-2">
-        <p:commandButton id="editEndpointBtn" icon="si si-pencil" title="#{ivy.cm.co('/common/Edit')}"
+        <p:commandButton id="editEndpointBtn" icon="ti ti-pencil" title="#{ivy.cm.co('/common/Edit')}"
           styleClass="ui-button-secondary rounded-button" process="@this"
           actionListener="#{webserviceDetailBean.setActivePortType(endpoint.name)}" update="editEndpointModal"
           oncomplete="PF('editEndpointModal').show()" rendered="#{endpoint.type eq 'port'}" />
@@ -58,7 +58,7 @@
         <p:commandButton id="cancelEndpoint" onclick="PF('editEndpointModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
           styleClass="ui-button-secondary ui-button-flat modal-input-button" />
         <p:commandButton id="saveEndpoint" update="@form webservcieEndPointForm" onsuccess="PF('editEndpointModal').hide()" validateClient="true"
-          actionListener="#{webserviceDetailBean.savePortType}" value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk"
+          actionListener="#{webserviceDetailBean.savePortType}" value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy"
           process="@form" styleClass="modal-input-button" />
       </div>
     </h:form>

--- a/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
@@ -28,7 +28,7 @@
           actionListener="#{webserviceDetailBean.setActivePortType(endpoint.name)}" update="editEndpointModal"
           oncomplete="PF('editEndpointModal').show()" rendered="#{endpoint.type eq 'port'}" />
         <p:commandButton id="testWsEndpointBtn" title="#{ivy.cm.co('/webServiceEndpoints/TestWsEndpointButtonTitle')}"
-          update="connResult:connectionTestModel" icon="si si-phone-actions-call"
+          update="connResult:connectionTestModel" icon="ti ti-phone-outgoing"
           styleClass="ui-button-secondary rounded-button" process="@this"
           actionListener="#{webserviceDetailBean.setActiveEndpoint(endpoint.name)}"
           rendered="#{endpoint.type eq 'link'}" oncomplete="PF('connectionTestModel').show()" async="true" />

--- a/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
@@ -19,7 +19,7 @@
     <p:treeTable value="#{webserviceDetailBean.webservice.portTypes}" var="endpoint" id="webserviceEndpointTable"
       emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
       <p:column headerText="#{ivy.cm.co('/webServiceEndpoints/Endpoints')}">
-        <i class="si si-#{endpoint.type eq 'port' ? 'network-arrow' : 'hyperlink-3'} table-icon"></i>
+        <i class="#{endpoint.type eq 'port' ? 'network-arrow' : 'hyperlink-3'} table-icon"></i>
         <h:outputText value="#{endpoint.name}" styleClass="endpoint-entry" />
       </p:column>
       <p:column styleClass="table-btn-2">

--- a/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/webservice-endpoints.xhtml
@@ -19,7 +19,7 @@
     <p:treeTable value="#{webserviceDetailBean.webservice.portTypes}" var="endpoint" id="webserviceEndpointTable"
       emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
       <p:column headerText="#{ivy.cm.co('/webServiceEndpoints/Endpoints')}">
-        <i class="#{endpoint.type eq 'port' ? 'network-arrow' : 'hyperlink-3'} table-icon"></i>
+        <i class="#{endpoint.type eq 'port' ? 'ti ti-world-up' : 'ti ti-link'} table-icon"></i>
         <h:outputText value="#{endpoint.name}" styleClass="endpoint-entry" />
       </p:column>
       <p:column styleClass="table-btn-2">

--- a/engine-cockpit/webContent/includes/components/services/webservice-properties.xhtml
+++ b/engine-cockpit/webContent/includes/components/services/webservice-properties.xhtml
@@ -11,7 +11,7 @@
     </p:growl>
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-cog"></i>
+        <i class="pr-3 ti ti-settings"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/FeaturesAndProperties')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/includes/components/setup/setup-admins.xhtml
+++ b/engine-cockpit/webContent/includes/components/setup/setup-admins.xhtml
@@ -10,7 +10,7 @@
   </h:panelGroup>
   <div class="flex">
     <p:commandButton id="newAdminBtn"
-      actionListener="#{administratorBean.addAdmin()}" icon="si si-add"
+      actionListener="#{administratorBean.addAdmin()}" icon="ti ti-plus"
       title="#{ivy.cm.co('/setupAdmins/AddAdministratorButtonTitle')}"
       update="admins:editAdminDialog"
       value="#{ivy.cm.co('/setupAdmins/AddAdministratorButton')}"

--- a/engine-cockpit/webContent/includes/components/setup/setup-storage.xhtml
+++ b/engine-cockpit/webContent/includes/components/setup/setup-storage.xhtml
@@ -14,7 +14,7 @@
       <h:panelGroup>
         <label for="appDir">#{ivy.cm.co('/setupStorage/AppDirectory')}</label>
         <h:panelGroup id="appDirHelp" styleClass="label-help-icon">
-          <i class="si si-question-circle"></i>
+          <i class="ti ti-help-circle"></i>
           <p:tooltip for="@parent" value="#{storageBean.appDirHelp}" escape="false" position="right" /> <!-- contains no user input, contains html -->
         </h:panelGroup>
       </h:panelGroup>
@@ -23,7 +23,7 @@
       <h:panelGroup>
         <label for="dataDir">#{ivy.cm.co('/setupStorage/DataDirectory')}</label>
         <h:panelGroup id="dataDirHelp" styleClass="label-help-icon">
-          <i class="si si-question-circle"></i>
+          <i class="ti ti-help-circle"></i>
           <p:tooltip for="@parent" value="#{storageBean.dataDirHelp}" escape="false" position="right" /> <!-- contains no user input, contains html -->
         </h:panelGroup>
       </h:panelGroup>
@@ -33,7 +33,7 @@
     <h:panelGroup styleClass="storage-ctrls flex justify-content-end" layout="block">
       <p:commandButton value="#{ivy.cm.co('/common/Reset')}" id="reset" actionListener="#{storageBean.reset()}" update="@form, storageWarnMessage" 
         styleClass="ui-button-secondary ui-button-flat storage-reset-link" />
-      <p:commandButton value="#{ivy.cm.co('/common/Save')}" id="save" actionListener="#{storageBean.save()}" update="@form, storageWarnMessage" icon="si si-floppy-disk" 
+      <p:commandButton value="#{ivy.cm.co('/common/Save')}" id="save" actionListener="#{storageBean.save()}" update="@form, storageWarnMessage" icon="ti ti-device-floppy" 
         styleClass="storage-save-btn" />
     </h:panelGroup>
   </h:form>

--- a/engine-cockpit/webContent/includes/components/systemdb/indexes.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/indexes.xhtml
@@ -5,7 +5,7 @@
   <div class="col-12 md:col-12 xl:col-12">
     <div class="card">
       <div class="flex align-items-center mb-3">
-        <i class="pr-3 si si-archive-folder"></i>
+        <i class="pr-3 ti ti-archive"></i>
         <h6 id="indexes" class="m-0">#{ivy.cm.co('/indexes/Indexes')}</h6>
       </div>
       <h:form>

--- a/engine-cockpit/webContent/includes/components/systemdb/indexes.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/indexes.xhtml
@@ -14,7 +14,7 @@
           lazy="false" styleClass="userTable ui-fluid" id="systemDbIndexesTable" filteredValue="#{systemDatabaseInfoBean.filteredIndexes}">
           <f:facet name="header">
             <div class="ui-input-icon-left filter-container">
-              <i class="pi pi-search"/>
+              <i class="ti ti-search"/>
               <p:inputText id="globalFilter" onkeyup="PF('systemDbIndexesTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{systemDatabaseInfoBean.filterIndex}" />
             </div>
           </f:facet>

--- a/engine-cockpit/webContent/includes/components/systemdb/info.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/info.xhtml
@@ -6,7 +6,7 @@
     <div class="card">
       <div class="card-header">
         <div class="card-title flex align-items-center">
-          <i class="pr-3 si si-information-circle"></i>
+          <i class="pr-3 ti ti-info-circle"></i>
           <h6 id="overview" class="m-0">#{ivy.cm.co('/common/SystemDatabase')}</h6>
         </div>
       </div>

--- a/engine-cockpit/webContent/includes/components/systemdb/jdbc-driver.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/jdbc-driver.xhtml
@@ -6,7 +6,7 @@
     <div class="card">
       <div class="card-header">
         <div class="card-title flex align-items-center">
-          <i class="pr-3 si si-charger"></i>
+          <i class="pr-3 ti ti-plug"></i>
           <h6 id="jdbc-driver" class="m-0">#{ivy.cm.co('/jdbcDriver/JDBCDriver')}</h6>
         </div>
       </div>

--- a/engine-cockpit/webContent/includes/components/systemdb/tables.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/tables.xhtml
@@ -5,7 +5,7 @@
   <div class="col-12 md:col-12 xl:col-6">
     <div class="card">
       <div class="flex align-items-center mb-3">
-        <i class="pr-3 si si-layers-grid-settings"/>
+        <i class="pr-3 ti ti-layout-grid"/>
         <h6 id="tables" class="m-0">#{ivy.cm.co('/common/Tables')}</h6>
       </div>
       <h:form>
@@ -14,7 +14,7 @@
           lazy="false" styleClass="userTable ui-fluid" id="systemDbTablesTable" filteredValue="#{systemDatabaseInfoBean.filteredTables}">
           <f:facet name="header">
             <div class="ui-input-icon-left filter-container">
-              <i class="pi pi-search"/>
+              <i class="ti ti-search"/>
               <p:inputText id="globalFilter" onkeyup="PF('systemDbTablesTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{systemDatabaseInfoBean.filterTable}" />
             </div>
           </f:facet>

--- a/engine-cockpit/webContent/includes/components/systemdb/triggers.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/triggers.xhtml
@@ -5,7 +5,7 @@
   <div class="col-12 md:col-12 xl:col-6">
     <div class="card">
       <div class="flex align-items-center mb-3">
-        <i class="pr-3 si si-recycling-hand-trash"/>
+        <i class="pr-3 ti ti-trash"/>
         <h6 id="triggers" class="m-0">#{ivy.cm.co('/triggers/Triggers')}</h6>
       </div>
       <h:form>

--- a/engine-cockpit/webContent/includes/components/systemdb/triggers.xhtml
+++ b/engine-cockpit/webContent/includes/components/systemdb/triggers.xhtml
@@ -14,7 +14,7 @@
           lazy="false" styleClass="userTable ui-fluid" id="systemDbTriggersTable" filteredValue="#{systemDatabaseInfoBean.filteredTriggers}">
           <f:facet name="header">
             <div class="ui-input-icon-left filter-container">
-              <i class="pi pi-search"/>
+              <i class="ti ti-search"/>
               <p:inputText id="globalFilter" onkeyup="PF('systemDbTriggersTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{systemDatabaseInfoBean.filterTrigger}" />
             </div>
           </f:facet>

--- a/engine-cockpit/webContent/includes/dialogs/deployment.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/deployment.xhtml
@@ -15,7 +15,7 @@
           <p:fileUpload id="fileUpload" value="#{deploymentBean.file}" dropZone="drop_zone" style="display: none" mode="simple" 
             widgetVar="deployUpload" update="@form" accept="#{deploymentBean.allowedExtensionsText}"/>
           <p:panelGrid columns="2" columnClasses="col-4, col-8" layout="flex">
-            <p:button id="chooseFileBtn" icon="si si-add" onclick="PF('deployUpload').show(); return false" value="#{ivy.cm.co('/fileUpload/ChooseFileButton')}"/>
+            <p:button id="chooseFileBtn" icon="ti ti-plus" onclick="PF('deployUpload').show(); return false" value="#{ivy.cm.co('/fileUpload/ChooseFileButton')}"/>
             <h:panelGroup id="drop_zone" styleClass="drop-zone flex">
               <h:outputText value="#{deploymentBean.dropZoneText}"/>
             </h:panelGroup>
@@ -26,18 +26,18 @@
           <p:commandLink styleClass="flex justify-content-between mb-2 p-2 border-solid border-1 border-round no-underline hover:bg-primary"
             id="showDeployOptionsBtn" action="#{deploymentBean.toggleDeployOptions}" update="@form">
             <div class="flex align-items-center">
-              <i class="si si-cog mr-2"/>
+              <i class="ti ti-settings mr-2"/>
               <span>#{ivy.cm.co('/deployment/Options')}</span>
             </div>
             <span class="flex align-items-center">
-              <i class="si #{deploymentBean.showDeployOptions ? 'si-arrow-up-1' : 'si-arrow-down-1'}"/>
+              <i class="si #{deploymentBean.showDeployOptions ? 'si-arrow-up-1' : 'ti-chevron-down'}"/>
             </span>
           </p:commandLink>
           <p:panelGrid id="deployOptionsPanel" columns="2" columnClasses="col-4, col-8" layout="flex" contentStyleClass="align-items-center"
             styleClass="grey-label-panel mt-1 p-2 w-full" rendered="#{deploymentBean.showDeployOptions}">
             <span>#{ivy.cm.co('/common/Configuration')}</span>
             <p:linkButton href="#{advisorBean.engineGuideBaseUrl}/deployment/prepare/deployment-options/index.html" target="_blank" rel="noopener noreferrer" 
-              styleClass="ui-button-secondary ui-button-flat rounded-button ml-2 pt-1" style="float: right" icon="si si-question-circle"/>
+              styleClass="ui-button-secondary ui-button-flat rounded-button ml-2 pt-1" style="float: right" icon="ti ti-help-circle"/>
             
             <p:outputLabel value="#{ivy.cm.co('/deployment/DeployTestUsers')}" for="deployTestUsers" />
             <p:selectOneMenu value="#{deploymentBean.deployOptions.deployTestUsers}" widgetVar="deployTestUsers" id="deployTestUsers">
@@ -72,7 +72,7 @@
         </pre>
         <div class="flex flex-row-reverse">
           <p:commandButton id="closeDeploymentBtn" onclick="PF('fileUploadModal').hide();" value="#{ivy.cm.co('/common/Close')}"
-            icon="si si-remove-circle" styleClass="modal-input-button" />
+            icon="ti ti-circle-minus" styleClass="modal-input-button" />
           <p:commandButton id="backBtn" value="#{ivy.cm.co('/common/Back')}" icon="si si-navigation-left-circle-1"
             styleClass="ui-button-secondary ui-button-flat modal-input-button" actionListener="#{deploymentBean.hideDeployLogs}"
             update="fileUploadResponse fileUploadForm"/>

--- a/engine-cockpit/webContent/includes/dialogs/deployment.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/deployment.xhtml
@@ -30,7 +30,7 @@
               <span>#{ivy.cm.co('/deployment/Options')}</span>
             </div>
             <span class="flex align-items-center">
-              <i class="si #{deploymentBean.showDeployOptions ? 'ti-chevron-up' : 'ti-chevron-down'}"/>
+              <i class="#{deploymentBean.showDeployOptions ? 'ti ti-chevron-up' : 'ti ti-chevron-down'}"/>
             </span>
           </p:commandLink>
           <p:panelGrid id="deployOptionsPanel" columns="2" columnClasses="col-4, col-8" layout="flex" contentStyleClass="align-items-center"
@@ -64,7 +64,7 @@
     <h:panelGroup id="fileUploadResponse" layout="block">
       <h:panelGroup rendered="#{deploymentBean.showDeployLogs}">
         <h:panelGroup id="uploadStatus" layout="block" styleClass="deploy-status #{deploymentBean.status.styleClass}">
-          <i class="si #{deploymentBean.status.iconClass}"></i>
+          <i class="#{deploymentBean.status.iconClass}"></i>
           <h:outputText value="#{deploymentBean.status.text}"/>
         </h:panelGroup>
         <pre id="uploadLog" class="upload-log">

--- a/engine-cockpit/webContent/includes/dialogs/deployment.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/deployment.xhtml
@@ -30,7 +30,7 @@
               <span>#{ivy.cm.co('/deployment/Options')}</span>
             </div>
             <span class="flex align-items-center">
-              <i class="si #{deploymentBean.showDeployOptions ? 'si-arrow-up-1' : 'ti-chevron-down'}"/>
+              <i class="si #{deploymentBean.showDeployOptions ? 'ti-chevron-up' : 'ti-chevron-down'}"/>
             </span>
           </p:commandLink>
           <p:panelGrid id="deployOptionsPanel" columns="2" columnClasses="col-4, col-8" layout="flex" contentStyleClass="align-items-center"
@@ -55,7 +55,7 @@
         <div class="flex justify-content-end mt-4 pt-3" style="border-top-width: 1px; border-top-style: solid; border-color: #e5e7eb">
           <p:commandButton id="cancelDeploymentBtn" onclick="PF('fileUploadModal').hide();" value="#{ivy.cm.co('/common/Cancel')}"
             type="button" styleClass="ui-button-secondary ui-button-outlined mr-2" />
-          <p:commandButton id="uploadBtn" icon="si si-upload-bottom" value="#{ivy.cm.co('/deployment/Deploy')}" 
+          <p:commandButton id="uploadBtn" icon="ti ti-upload" value="#{ivy.cm.co('/deployment/Deploy')}" 
             actionListener="#{deploymentBean.uploadAndDeploy}" disabled="#{!deploymentBean.isFileSet()}"
             update="fileUploadResponse fileUploadForm"/>
         </div>
@@ -73,7 +73,7 @@
         <div class="flex flex-row-reverse">
           <p:commandButton id="closeDeploymentBtn" onclick="PF('fileUploadModal').hide();" value="#{ivy.cm.co('/common/Close')}"
             icon="ti ti-circle-minus" styleClass="modal-input-button" />
-          <p:commandButton id="backBtn" value="#{ivy.cm.co('/common/Back')}" icon="si si-navigation-left-circle-1"
+          <p:commandButton id="backBtn" value="#{ivy.cm.co('/common/Back')}" icon="ti ti-circle-arrow-left"
             styleClass="ui-button-secondary ui-button-flat modal-input-button" actionListener="#{deploymentBean.hideDeployLogs}"
             update="fileUploadResponse fileUploadForm"/>
         </div>

--- a/engine-cockpit/webContent/includes/dialogs/error.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/error.xhtml
@@ -10,7 +10,7 @@
       <h:outputText id="message" value="#{errorBean.selected.message}"/>
       <h:panelGroup>
         <p:outputLabel for="stackTrace" value="#{ivy.cm.co('/common/StackTrace')}"/>
-        <p:commandButton id="copyError" icon="si si-copy-paste" type="button" title="#{ivy.cm.co('/common/CopyToClipboard')}" onclick="var button=this; copyToClipboard($('#error\\:stackTrace').text(), button)"
+        <p:commandButton id="copyError" icon="ti ti-copy" type="button" title="#{ivy.cm.co('/common/CopyToClipboard')}" onclick="var button=this; copyToClipboard($('#error\\:stackTrace').text(), button)"
             styleClass="ui-button-flat rounded-button"/>
       </h:panelGroup>
       <p:outputPanel id="stackTrace" styleClass="code">

--- a/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
@@ -10,7 +10,7 @@
       <ul>
         <ui:repeat value="#{licenceBean.licenceEvents}" var="event">
           <li class="align-items-center gap-3">
-            <i class="m-0 si si-xl si-#{event.level eq 'ERROR' ? 'alert-circle error' : 'road-sign-warning warning'}"></i>
+            <i class="m-0 text-2xl si-#{event.level eq 'ERROR' ? 'alert-circle error' : 'road-sign-warning warning'}"></i>
             <div class="flex flex-column">
               <h:outputText styleClass="text-sm name" value="#{event.timestamp}" style="color: var(--text-color-secondary);" />
               <h:outputText styleClass="message" value="#{event.message}" />

--- a/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
@@ -10,7 +10,7 @@
       <ul>
         <ui:repeat value="#{licenceBean.licenceEvents}" var="event">
           <li class="align-items-center gap-3">
-            <i class="m-0 text-2xl #{event.level eq 'ERROR' ? 'alert-circle error' : 'road-sign-warning warning'}"></i>
+            <i class="m-0 text-2xl #{event.level eq 'ERROR' ? 'ti ti-alert-circle error' : 'ti ti-alert-triangle warning'}"></i>
             <div class="flex flex-column">
               <h:outputText styleClass="text-sm name" value="#{event.timestamp}" style="color: var(--text-color-secondary);" />
               <h:outputText styleClass="message" value="#{event.message}" />

--- a/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
@@ -10,7 +10,7 @@
       <ul>
         <ui:repeat value="#{licenceBean.licenceEvents}" var="event">
           <li class="align-items-center gap-3">
-            <i class="m-0 text-2xl si-#{event.level eq 'ERROR' ? 'alert-circle error' : 'road-sign-warning warning'}"></i>
+            <i class="m-0 text-2xl #{event.level eq 'ERROR' ? 'alert-circle error' : 'road-sign-warning warning'}"></i>
             <div class="flex flex-column">
               <h:outputText styleClass="text-sm name" value="#{event.timestamp}" style="color: var(--text-color-secondary);" />
               <h:outputText styleClass="message" value="#{event.message}" />

--- a/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/licenceevents.xhtml
@@ -15,7 +15,7 @@
               <h:outputText styleClass="text-sm name" value="#{event.timestamp}" style="color: var(--text-color-secondary);" />
               <h:outputText styleClass="message" value="#{event.message}" />
             </div>
-            <p:commandButton icon="si si-check-1" title="#{ivy.cm.co('/common/Confirm')}" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button ui-button-outlined"
+            <p:commandButton icon="ti ti-check" title="#{ivy.cm.co('/common/Confirm')}" styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button ui-button-outlined"
               id="confirmEventBtn" actionListener="#{licenceBean.confirmLicenceEvent(event)}" update="@form" />
           </li>
         </ui:repeat>
@@ -25,7 +25,7 @@
       <p:commandButton id="closeLicenceEventsDialog" onclick="PF('licenceEventsDialog').hide();" value="#{ivy.cm.co('/common/Close')}"
         type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="confirmAllLicenceEvents" ajax="false" 
-        actionListener="#{licenceBean.confirmAllLicenceEvents()}" value="#{ivy.cm.co('/licenceEvents/ConfirmAll')}" icon="si si-check-double-1"
+        actionListener="#{licenceBean.confirmAllLicenceEvents()}" value="#{ivy.cm.co('/licenceEvents/ConfirmAll')}" icon="ti ti-checks"
         styleClass="modal-input-button" />
     </div>
   </h:form>

--- a/engine-cockpit/webContent/includes/dialogs/moveapplication.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/moveapplication.xhtml
@@ -39,7 +39,7 @@
       <p:commandButton id="validateMoveApplication" update="moveApplicationForm" actionListener="#{moveApplicationBean.validate()}" value="#{ivy.cm.co('/moveApplication/Validate')}" 
         oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-check');"
         onclick="var button=this; buttonAddSpinner(button);"
-        icon="si ti-check" styleClass="modal-input-button" />
+        icon="ti ti-check" styleClass="modal-input-button" />
       <p:commandButton id="moveApplication" disabled="#{!moveApplicationBean.isValid()}" actionListener="#{moveApplicationBean.move()}" value="#{ivy.cm.co('/moveApplication/Move')}"
         oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-check');PF('moveApplicationModal').hide();"
         onclick="var button=this; buttonAddSpinner(button);" update="appDetailSecurityForm"

--- a/engine-cockpit/webContent/includes/dialogs/moveapplication.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/moveapplication.xhtml
@@ -9,7 +9,7 @@
 
    <h:outputText value="#{ivy.cm.co('/moveApplication/ChangeSecuritySystemDialogContent')}" />
 
-   <p:linkButton icon="si si-move-to-bottom" outcome="securitysystem-merge.xhtml" styleClass="mt-1" style="max-width:200px;" value="#{ivy.cm.co('/moveApplication/MergeSecuritySystem')}">
+   <p:linkButton icon="ti ti-arrow-big-down-lines" outcome="securitysystem-merge.xhtml" styleClass="mt-1" style="max-width:200px;" value="#{ivy.cm.co('/moveApplication/MergeSecuritySystem')}">
      <f:param name="source" value="#{moveApplicationBean.securitySystemName}"/>
    </p:linkButton>
 
@@ -37,13 +37,13 @@
     <div class="custom-dialog-footer">
       <p:commandButton id="cancelMoveApplication" onclick="PF('moveApplicationModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="validateMoveApplication" update="moveApplicationForm" actionListener="#{moveApplicationBean.validate()}" value="#{ivy.cm.co('/moveApplication/Validate')}" 
-        oncomplete="var button=this; buttonRemoveSpinner(button, 'si-check-1');"
+        oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-check');"
         onclick="var button=this; buttonAddSpinner(button);"
-        icon="si si-check-1" styleClass="modal-input-button" />
+        icon="si ti-check" styleClass="modal-input-button" />
       <p:commandButton id="moveApplication" disabled="#{!moveApplicationBean.isValid()}" actionListener="#{moveApplicationBean.move()}" value="#{ivy.cm.co('/moveApplication/Move')}"
-        oncomplete="var button=this; buttonRemoveSpinner(button, 'si-check-1');PF('moveApplicationModal').hide();"
+        oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-check');PF('moveApplicationModal').hide();"
         onclick="var button=this; buttonAddSpinner(button);" update="appDetailSecurityForm"
-        icon="si si-move-to-bottom" styleClass="modal-input-button" />
+        icon="ti ti-arrow-big-down-lines" styleClass="modal-input-button" />
     </div>
   </h:form>
 </p:dialog>

--- a/engine-cockpit/webContent/includes/dialogs/moveapplication.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/moveapplication.xhtml
@@ -37,11 +37,11 @@
     <div class="custom-dialog-footer">
       <p:commandButton id="cancelMoveApplication" onclick="PF('moveApplicationModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="validateMoveApplication" update="moveApplicationForm" actionListener="#{moveApplicationBean.validate()}" value="#{ivy.cm.co('/moveApplication/Validate')}" 
-        oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-check');"
+        oncomplete="var button=this; buttonRemoveSpinner(button, 'ti ti-check');"
         onclick="var button=this; buttonAddSpinner(button);"
         icon="ti ti-check" styleClass="modal-input-button" />
       <p:commandButton id="moveApplication" disabled="#{!moveApplicationBean.isValid()}" actionListener="#{moveApplicationBean.move()}" value="#{ivy.cm.co('/moveApplication/Move')}"
-        oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-check');PF('moveApplicationModal').hide();"
+        oncomplete="var button=this; buttonRemoveSpinner(button, 'ti ti-check');PF('moveApplicationModal').hide();"
         onclick="var button=this; buttonAddSpinner(button);" update="appDetailSecurityForm"
         icon="ti ti-arrow-big-down-lines" styleClass="modal-input-button" />
     </div>

--- a/engine-cockpit/webContent/includes/dialogs/newapplication.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/newapplication.xhtml
@@ -27,7 +27,7 @@
       <p:commandButton id="cancelNewApplication" onclick="PF('newApplicationModal').hide();" value="#{ivy.cm.co('/common/Cancel')}"
         type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="saveNewApplication" validateClient="true" ajax="false"
-        actionListener="#{applicationBean.createNewApplication}" value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk"
+        actionListener="#{applicationBean.createNewApplication}" value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy"
         styleClass="modal-input-button" />
     </div>
   </h:form>

--- a/engine-cockpit/webContent/includes/dialogs/newrole.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/newrole.xhtml
@@ -18,7 +18,7 @@
       <p:commandButton id="cancelNewRole" onclick="PF('newChildRoleModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="saveNewRole" validateClient="true" action="#{roleDetailBean.createNewChildRole}" ajax="false"
-        update="@form" value="#{ivy.cm.co('/common/Add')}" icon="si si-add" styleClass="modal-input-button" />
+        update="@form" value="#{ivy.cm.co('/common/Add')}" icon="ti ti-plus" styleClass="modal-input-button" />
     </div>
   </h:form>
 </p:dialog>

--- a/engine-cockpit/webContent/includes/dialogs/newsecuritysystem.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/newsecuritysystem.xhtml
@@ -26,7 +26,7 @@
       <p:commandButton id="cancelNewSecuritySystem" onclick="PF('newSecuritySystemModal').hide();" value="#{ivy.cm.co('/common/Cancel')}"
         type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="saveNewSecuritySystem" validateClient="true" update="form:securitySystemTable, @form"
-        actionListener="#{securityBean.createNewSecuritySystem}" value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk"
+        actionListener="#{securityBean.createNewSecuritySystem}" value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy"
         styleClass="modal-input-button" oncomplete="PF('newSecuritySystemModal').hide();" />
     </div>
   </h:form>

--- a/engine-cockpit/webContent/includes/dialogs/newuser.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/newuser.xhtml
@@ -44,7 +44,7 @@
         <p:commandButton id="cancelNewUser" onclick="PF('newUserModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
         <p:commandButton id="saveNewUser" validateClient="true" ajax="false" update="securitySystems"
-          action="#{userBean.newUser.creatNewUser}" value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" styleClass="modal-input-button" />
+          action="#{userBean.newUser.creatNewUser}" value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" styleClass="modal-input-button" />
     </div>
   </h:form>
 </p:dialog>

--- a/engine-cockpit/webContent/includes/dialogs/renamerole.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/renamerole.xhtml
@@ -21,7 +21,7 @@
       <p:commandButton id="cancelRenameRole" onclick="PF('renameRoleModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="renameRole" validateClient="true" action="#{roleDetailBean.renameRole}" ajax="false"
-        update="@form" value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" styleClass="modal-input-button" />
+        update="@form" value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" styleClass="modal-input-button" />
     </div>
   </h:form>
 </p:dialog>

--- a/engine-cockpit/webContent/includes/dialogs/searchenginetool.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/searchenginetool.xhtml
@@ -20,7 +20,7 @@
       <p:commandButton id="cancelSearchEngineQueryBtn" onclick="PF('searchEngineQueryToolModal').hide();" value="#{ivy.cm.co('/common/Cancel')}"
         type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="runSearchEngineQueryBtn" validateClient="true" update="@form"
-        actionListener="#{searchEngineBean.runQuery}" value="#{ivy.cm.co('/common/Run')}" icon="si si-send-email"
+        actionListener="#{searchEngineBean.runQuery}" value="#{ivy.cm.co('/common/Run')}" icon="ti ti-mail"
         styleClass="modal-input-button" />
     </div>
   </h:form>

--- a/engine-cockpit/webContent/includes/dialogs/sendtestmail.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/sendtestmail.xhtml
@@ -38,7 +38,7 @@
       <p:commandButton id="cancelSendTestMailBtn" onclick="PF('sendTestMailModal').hide()" value="#{ivy.cm.co('/common/Cancel')}" 
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="sendTestMailBtn" validateClient="true" update="debugLog result"
-        actionListener="#{emailBean.sendTestMail}" value="#{ivy.cm.co('/common/Send')}" icon="si si-send-email" styleClass="modal-input-button" />
+        actionListener="#{emailBean.sendTestMail}" value="#{ivy.cm.co('/common/Send')}" icon="ti ti-mail" styleClass="modal-input-button" />
     </div>
   </h:form>
 </p:dialog>

--- a/engine-cockpit/webContent/includes/dialogs/supportreport.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/supportreport.xhtml
@@ -18,7 +18,7 @@
       <p:commandButton id="cancel" onclick="PF('supportReportModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="download" ajax="false" value="#{ivy.cm.co('/common/Download')}"
         onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download');}"
-        title="#{ivy.cm.co('/supportReport/DownloadSupportReport')}" icon="si ti-download" styleClass="modal-input-button"
+        title="#{ivy.cm.co('/supportReport/DownloadSupportReport')}" icon="ti ti-download" styleClass="modal-input-button"
         style="width: 150px;">
         <p:fileDownload value="#{supportBean.supportReport}" />
       </p:commandButton>

--- a/engine-cockpit/webContent/includes/dialogs/supportreport.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/supportreport.xhtml
@@ -17,7 +17,7 @@
     <div class="custom-dialog-footer">
       <p:commandButton id="cancel" onclick="PF('supportReportModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="download" ajax="false" value="#{ivy.cm.co('/common/Download')}"
-        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download');}"
+        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti ti-download');}"
         title="#{ivy.cm.co('/supportReport/DownloadSupportReport')}" icon="ti ti-download" styleClass="modal-input-button"
         style="width: 150px;">
         <p:fileDownload value="#{supportBean.supportReport}" />

--- a/engine-cockpit/webContent/includes/dialogs/supportreport.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/supportreport.xhtml
@@ -17,8 +17,8 @@
     <div class="custom-dialog-footer">
       <p:commandButton id="cancel" onclick="PF('supportReportModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="download" ajax="false" value="#{ivy.cm.co('/common/Download')}"
-        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'si-download-bottom');}"
-        title="#{ivy.cm.co('/supportReport/DownloadSupportReport')}" icon="si si-download-bottom" styleClass="modal-input-button"
+        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download');}"
+        title="#{ivy.cm.co('/supportReport/DownloadSupportReport')}" icon="si ti-download" styleClass="modal-input-button"
         style="width: 150px;">
         <p:fileDownload value="#{supportBean.supportReport}" />
       </p:commandButton>

--- a/engine-cockpit/webContent/includes/dialogs/updateroleparent.xhtml
+++ b/engine-cockpit/webContent/includes/dialogs/updateroleparent.xhtml
@@ -21,7 +21,7 @@
       <p:commandButton id="cancelupdateRoleParent" onclick="PF('updateRoleParentModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="updateRoleParent" validateClient="true" action="#{roleDetailBean.updateRoleParent}" ajax="false"
-        update="@form" value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" styleClass="modal-input-button" />
+        update="@form" value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" styleClass="modal-input-button" />
     </div>
   </h:form>
 </p:dialog>

--- a/engine-cockpit/webContent/includes/template/exception.xhtml
+++ b/engine-cockpit/webContent/includes/template/exception.xhtml
@@ -16,7 +16,7 @@
         <h:outputText value="#{ivy.cm.co('/exception/ViewExpiredExceptionDialogContent')}" />
       </h1>
       <br />
-      <p:button href="login.xhtml" value="#{ivy.cm.co('/common/Login')}" icon="si si-login-3" />
+      <p:button href="login.xhtml" value="#{ivy.cm.co('/common/Login')}" icon="ti ti-login-2" />
     </p:dialog>
 
     <!--  Exception Handler for any other Exception -->

--- a/engine-cockpit/webContent/includes/template/info-template.xhtml
+++ b/engine-cockpit/webContent/includes/template/info-template.xhtml
@@ -32,7 +32,7 @@
                 <pm:menu widgetVar="sidebar_menu">
                   <p:menuitem id="sr_apps" value="#{ivy.cm.co('/common/Applications')}" icon="ti ti-layout-grid" containerStyleClass="active-nav-page" />
                   <p:menuitem id="sr_cockpit" value="#{ivy.cm.co('/common/EngineCockpit')}" icon="ti ti-settings animated swing" url="#{engineInfo.engineCockpitUrl}" />
-                  <p:submenu  id="sr_setup" label="#{ivy.cm.co('/infoTemplate/SetupEngine')}" icon="text-xl si-startup-launch animated swing">
+                  <p:submenu  id="sr_setup" label="#{ivy.cm.co('/infoTemplate/SetupEngine')}" icon="text-xl ti ti-plane-tilt animated swing">
                     <p:menuitem id="sr_setup_install" value="#{ivy.cm.co('/infoTemplate/InstallAxonIvyEngine')}" icon="ti ti-tool" url="setup.xhtml"/>
                     <p:menuitem id="sr_setup_migrate" value="#{ivy.cm.co('/infoTemplate/MigrateAxonIvyEngine')}" icon="ti ti-circle-arrow-right" url="migrate.xhtml" />
                   </p:submenu>

--- a/engine-cockpit/webContent/includes/template/info-template.xhtml
+++ b/engine-cockpit/webContent/includes/template/info-template.xhtml
@@ -30,13 +30,13 @@
             <div class="layout-menu-container" style="justify-content: right;">
               <h:form id="menuform">
                 <pm:menu widgetVar="sidebar_menu">
-                  <p:menuitem id="sr_apps" value="#{ivy.cm.co('/common/Applications')}" icon="si si-module" containerStyleClass="active-nav-page" />
-                  <p:menuitem id="sr_cockpit" value="#{ivy.cm.co('/common/EngineCockpit')}" icon="si si-cog animated swing" url="#{engineInfo.engineCockpitUrl}" />
-                  <p:submenu  id="sr_setup" label="#{ivy.cm.co('/infoTemplate/SetupEngine')}" icon="si si-lg si-startup-launch animated swing">
-                    <p:menuitem id="sr_setup_install" value="#{ivy.cm.co('/infoTemplate/InstallAxonIvyEngine')}" icon="si si-tools-wench" url="setup.xhtml"/>
-                    <p:menuitem id="sr_setup_migrate" value="#{ivy.cm.co('/infoTemplate/MigrateAxonIvyEngine')}" icon="si si-navigation-right-circle" url="migrate.xhtml" />
+                  <p:menuitem id="sr_apps" value="#{ivy.cm.co('/common/Applications')}" icon="ti ti-layout-grid" containerStyleClass="active-nav-page" />
+                  <p:menuitem id="sr_cockpit" value="#{ivy.cm.co('/common/EngineCockpit')}" icon="ti ti-settings animated swing" url="#{engineInfo.engineCockpitUrl}" />
+                  <p:submenu  id="sr_setup" label="#{ivy.cm.co('/infoTemplate/SetupEngine')}" icon="text-xl si-startup-launch animated swing">
+                    <p:menuitem id="sr_setup_install" value="#{ivy.cm.co('/infoTemplate/InstallAxonIvyEngine')}" icon="ti ti-tool" url="setup.xhtml"/>
+                    <p:menuitem id="sr_setup_migrate" value="#{ivy.cm.co('/infoTemplate/MigrateAxonIvyEngine')}" icon="ti ti-circle-arrow-right" url="migrate.xhtml" />
                   </p:submenu>
-                  <p:menuitem id="sr_doc" value="#{ivy.cm.co('/infoTemplate/Documentation')}" icon="si si-office-file-doc-1 animated swing" url="#{ivyAdvisor.advisor.docBaseUrl}" />
+                  <p:menuitem id="sr_doc" value="#{ivy.cm.co('/infoTemplate/Documentation')}" icon="ti ti-file-type-doc animated swing" url="#{ivyAdvisor.advisor.docBaseUrl}" />
                   <p:menuitem id="sr_shutdown" title="#{ivy.cm.co('/infoTemplate/ShutdownAxonIvyEngine')}" icon="si si-power-button animated swing" rendered="#{engineInfo.canShutdown()}" actionListener="#{engineInfo.openShutdownDialog()}" />
                 </pm:menu>
               </h:form>

--- a/engine-cockpit/webContent/includes/template/info-template.xhtml
+++ b/engine-cockpit/webContent/includes/template/info-template.xhtml
@@ -37,7 +37,7 @@
                     <p:menuitem id="sr_setup_migrate" value="#{ivy.cm.co('/infoTemplate/MigrateAxonIvyEngine')}" icon="ti ti-circle-arrow-right" url="migrate.xhtml" />
                   </p:submenu>
                   <p:menuitem id="sr_doc" value="#{ivy.cm.co('/infoTemplate/Documentation')}" icon="ti ti-file-type-doc animated swing" url="#{ivyAdvisor.advisor.docBaseUrl}" />
-                  <p:menuitem id="sr_shutdown" title="#{ivy.cm.co('/infoTemplate/ShutdownAxonIvyEngine')}" icon="si si-power-button animated swing" rendered="#{engineInfo.canShutdown()}" actionListener="#{engineInfo.openShutdownDialog()}" />
+                  <p:menuitem id="sr_shutdown" title="#{ivy.cm.co('/infoTemplate/ShutdownAxonIvyEngine')}" icon="ti ti-power animated swing" rendered="#{engineInfo.canShutdown()}" actionListener="#{engineInfo.openShutdownDialog()}" />
                 </pm:menu>
               </h:form>
             </div>
@@ -68,7 +68,7 @@
         id="shutdownDialogShutdown"
         disabled="#{engineInfo.shutdownButtonsDisabled}"
         actionListener="#{engineInfo.shutdown()}"
-        styleClass="modal-input-button" icon="si si-power-button" />
+        styleClass="modal-input-button" icon="ti ti-power" />
     </f:facet>
   </p:dialog>
 

--- a/engine-cockpit/webContent/includes/template/sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/sidebar.xhtml
@@ -12,17 +12,17 @@
     <div class="layout-menu-container">
       <h:form id="menuform">
         <pm:menu widgetVar="sidebar_menu">
-          <p:menuitem id="sr_dashboard" value="#{ivy.cm.co('/sidebar/Dashboard')}" icon="si si-layout-dashboard" url="dashboard.xhtml" />
+          <p:menuitem id="sr_dashboard" value="#{ivy.cm.co('/sidebar/Dashboard')}" icon="ti ti-layout-dashboard" url="dashboard.xhtml" />
           <p:menuitem id="sr_applications" value="#{ivy.cm.co('/common/Applications')}" icon="si si-layout-module"
             url="applications.xhtml" />
           <p:submenu id="sr_security" label="#{ivy.cm.co('/common/Security')}" icon="si si-shield-lock">
-            <p:menuitem id="sr_security_system" value="#{ivy.cm.co('/common/SecuritySystems')}" icon="si si-lock-1"
+            <p:menuitem id="sr_security_system" value="#{ivy.cm.co('/common/SecuritySystems')}" icon="ti ti-lock"
               url="securitysystem.xhtml" />
-            <p:menuitem id="sr_users" value="#{ivy.cm.co('/common/Users')}" icon="si si-single-neutral-actions" url="users.xhtml" />
-            <p:menuitem id="sr_roles" value="#{ivy.cm.co('/common/Roles')}" icon="si si-multiple-neutral-1" url="roles.xhtml" />
+            <p:menuitem id="sr_users" value="#{ivy.cm.co('/common/Users')}" icon="ti ti-user-check" url="users.xhtml" />
+            <p:menuitem id="sr_roles" value="#{ivy.cm.co('/common/Roles')}" icon="ti ti-users" url="roles.xhtml" />
           </p:submenu>
 
-          <p:submenu id="sr_configuration" label="#{ivy.cm.co('/common/Configuration')}" icon="si si-cog">
+          <p:submenu id="sr_configuration" label="#{ivy.cm.co('/common/Configuration')}" icon="ti ti-settings">
             <p:menuitem id="sr_variables" value="#{ivy.cm.co('/common/Variables')}" icon="si si-archive-folder"
               url="variables.xhtml" />
             <p:menuitem id="sr_business_calendar" value="#{ivy.cm.co('/common/BusinessCalendar')}" icon="si si-calendar"
@@ -32,71 +32,71 @@
           </p:submenu>
 
           <p:submenu id="sr_services" label="#{ivy.cm.co('/common/Services')}" icon="si si-conversation-chat-2">
-            <p:menuitem id="sr_notification_channels" value="#{ivy.cm.co('/common/NotificationChannels')}" icon="si si-advertising-megaphone-2" url="notification-channels.xhtml"/>
+            <p:menuitem id="sr_notification_channels" value="#{ivy.cm.co('/common/NotificationChannels')}" icon="ti ti-speakerphone" url="notification-channels.xhtml"/>
             <p:menuitem id="sr_database" value="#{ivy.cm.co('/common/Databases')}" icon="si si-database"
               url="databases.xhtml" />
-            <p:menuitem id="sr_web_service" value="#{ivy.cm.co('/common/WebServiceClients')}" icon="si si-network-arrow"
+            <p:menuitem id="sr_web_service" value="#{ivy.cm.co('/common/WebServiceClients')}" icon="ti ti-network"
               url="webservices.xhtml" />
-            <p:menuitem id="sr_web_service_processes" value="#{ivy.cm.co('/common/WebServiceProcesses')}" icon="si si-network-arrow"
+            <p:menuitem id="sr_web_service_processes" value="#{ivy.cm.co('/common/WebServiceProcesses')}" icon="ti ti-network"
               url="webserviceprocesses.xhtml" />
-            <p:menuitem id="sr_rest_client" value="#{ivy.cm.co('/common/RestClients')}" icon="si si-network-share"
+            <p:menuitem id="sr_rest_client" value="#{ivy.cm.co('/common/RestClients')}" icon="ti ti-world"
               url="restclients.xhtml" />
-            <p:menuitem id="sr_rest_services" value="#{ivy.cm.co('/common/RestServices')}" icon="si si-network-browser"
+            <p:menuitem id="sr_rest_services" value="#{ivy.cm.co('/common/RestServices')}" icon="ti ti-browser"
               url="restservices.xhtml" />
             <p:menuitem id="sr_searchengine" value="#{ivy.cm.co('/common/SearchEngine')}" icon="si si-monitor-heart-beat-search"
               url="searchengine.xhtml" />
           </p:submenu>
-          <p:submenu id="sr_system" label="#{ivy.cm.co('/common/System')}" icon="si si-cog-double-2">
-            <p:menuitem id="sr_admins" value="#{ivy.cm.co('/common/Administrators')}" icon="si si-single-neutral-shield"
+          <p:submenu id="sr_system" label="#{ivy.cm.co('/common/System')}" icon="ti ti-settings">
+            <p:menuitem id="sr_admins" value="#{ivy.cm.co('/common/Administrators')}" icon="ti ti-lock-square-rounded"
               url="admins.xhtml" />
             <p:menuitem id="sr_systemdb" value="#{ivy.cm.co('/common/SystemDatabase')}" icon="si si-database-settings"
               url="systemdb.xhtml" />
             <p:menuitem id="sr_licence" value="#{ivy.cm.co('/common/Licence')}" icon="si si-real-estate-action-house-key"
               url="licence.xhtml" />
-            <p:menuitem id="sr_web_server" value="#{ivy.cm.co('/common/WebServer')}" icon="si si-network-signal"
+            <p:menuitem id="sr_web_server" value="#{ivy.cm.co('/common/WebServer')}" icon="ti ti-building-broadcast-tower"
               url="webserver.xhtml" />
-            <p:menuitem id="sr_system_config" value="#{ivy.cm.co('/common/SystemConfiguration')}" icon="si si-cog-double"
+            <p:menuitem id="sr_system_config" value="#{ivy.cm.co('/common/SystemConfiguration')}" icon="ti ti-settings-double"
               url="systemconfig.xhtml" />
-            <p:menuitem id="sr_ssl" value="#{ivy.cm.co('/common/SSL')}" icon="si si-lock-1"
+            <p:menuitem id="sr_ssl" value="#{ivy.cm.co('/common/SSL')}" icon="ti ti-lock"
               url="sslconfig.xhtml" />
             <p:menuitem id="sr_cluster" value="#{ivy.cm.co('/common/Cluster')}" icon="si si-monitor-network" url="cluster.xhtml"
               rendered="#{clusterBean.clusterServer or param['cluster'] != null}" />
-            <p:menuitem id="sr_editor" value="#{ivy.cm.co('/common/ConfigFileEditor')}" icon="si si-common-file-text-edit" url="editor.xhtml" />
+            <p:menuitem id="sr_editor" value="#{ivy.cm.co('/common/ConfigFileEditor')}" icon="ti ti-file-text-edit" url="editor.xhtml" />
           </p:submenu>
           <p:submenu id="sr_monitor" label="#{ivy.cm.co('/common/Monitor')}" icon="si si-pie-line-graph-desktop">
             <p:menuitem id="sr_monitor_os" value="#{ivy.cm.co('/sidebar/OS')}" icon="si si-server-search" url="monitorOs.xhtml" />
             <p:submenu id="sr_monitor_java" label="#{ivy.cm.co('/sidebar/Java')}" icon="si si-coffee-cup">
               <p:menuitem id="sr_monitor_java_jvm" value="#{ivy.cm.co('/sidebar/JVM')}" icon="si si-coffee-cup" url="monitorJvm.xhtml" />
-              <p:menuitem id="sr_monitor_java_memory" value="#{ivy.cm.co('/sidebar/Memory')}" icon="si si-analytics-board-graph-line"
+              <p:menuitem id="sr_monitor_java_memory" value="#{ivy.cm.co('/sidebar/Memory')}" icon="ti ti-chart-line"
                 url="monitorMemory.xhtml" />
               <p:menuitem id="sr_monitor_java_class_histogram" value="#{ivy.cm.co('/sidebar/ClassHistogram')}" icon="si si-computer-chip-search"
                 url="monitorClassHistogram.xhtml" />
-              <p:menuitem id="sr_monitor_java_threads" value="#{ivy.cm.co('/common/Threads')}" icon="si si-synchronize-arrow-clock" url="monitorThreads.xhtml" />
+              <p:menuitem id="sr_monitor_java_threads" value="#{ivy.cm.co('/common/Threads')}" icon="ti ti-clock-play" url="monitorThreads.xhtml" />
               <p:menuitem id="sr_monitor_java_jfr" value="#{ivy.cm.co('/sidebar/FlightRecorder')}" icon="si si-plane-take-off" url="monitorJfr.xhtml" />
               <p:menuitem id="sr_monitor_java_mbeans" value="#{ivy.cm.co('/sidebar/MBeans')}" icon="si si-graph-statistics-coffee"
                 url="mbeans.xhtml" />
             </p:submenu>
             <p:submenu id="sr_monitor_engine" label="#{ivy.cm.co('/sidebar/Engine')}" icon="si si-computer-chip-search">
-              <p:menuitem id="sr_monitor_engine_notification" value="#{ivy.cm.co('/sidebar/Notifications')}" icon="si si-advertising-megaphone-2" url="notifications.xhtml" />
+              <p:menuitem id="sr_monitor_engine_notification" value="#{ivy.cm.co('/sidebar/Notifications')}" icon="ti ti-speakerphone" url="notifications.xhtml" />
               <p:menuitem id="sr_monitor_engine_sessions" value="#{ivy.cm.co('/sidebar/Sessions')}" icon="si si-analytics-graph-line" url="monitor-sessions.xhtml" />
-              <p:menuitem id="sr_monitor_engine_jobs" value="#{ivy.cm.co('/sidebar/Jobs')}" icon="si si-task-list-approve" url="monitorJobs.xhtml" />
+              <p:menuitem id="sr_monitor_engine_jobs" value="#{ivy.cm.co('/sidebar/Jobs')}" icon="ti ti-clipboard-list" url="monitorJobs.xhtml" />
               <p:menuitem id="sr_monitor_engine_cache" value="#{ivy.cm.co('/sidebar/Cache')}" icon="si si-monitor-heart-beat-search" url="monitorCache.xhtml" />
-              <p:menuitem id="sr_monitor_engine_health" value="#{ivy.cm.co('/sidebar/Health')}" icon="si si-road-sign-warning" url="monitor-health.xhtml" />
+              <p:menuitem id="sr_monitor_engine_health" value="#{ivy.cm.co('/sidebar/Health')}" icon="ti ti-alert-triangle" url="monitor-health.xhtml" />
             </p:submenu>
-            <p:submenu id="sr_monitor_workflow" label="#{ivy.cm.co('/common/Workflow')}" icon="si si-layout-bullets">
-              <p:menuitem id="sr_monitor_workflow_documents" value="#{ivy.cm.co('/sidebar/Documents')}" icon="si si-office-file-doc-1" url="documents.xhtml" />
-              <p:menuitem id="sr_monitor_workflow_start_events" value="#{ivy.cm.co('/common/StartEvents')}" icon="si si-navigation-right-circle-1" url="monitorStartEvents.xhtml" />
-              <p:menuitem id="sr_monitor_workflow_intermediate_events" value="#{ivy.cm.co('/common/IntermediateEvents')}" icon="si si-time-clock-circle" url="monitorIntermediateEvents.xhtml" />
+            <p:submenu id="sr_monitor_workflow" label="#{ivy.cm.co('/common/Workflow')}" icon="ti ti-list">
+              <p:menuitem id="sr_monitor_workflow_documents" value="#{ivy.cm.co('/sidebar/Documents')}" icon="ti ti-file-type-doc" url="documents.xhtml" />
+              <p:menuitem id="sr_monitor_workflow_start_events" value="#{ivy.cm.co('/common/StartEvents')}" icon="ti ti-circle-arrow-right" url="monitorStartEvents.xhtml" />
+              <p:menuitem id="sr_monitor_workflow_intermediate_events" value="#{ivy.cm.co('/common/IntermediateEvents')}" icon="ti ti-clock" url="monitorIntermediateEvents.xhtml" />
             </p:submenu>
-            <p:submenu id="sr_monitor_performance" label="#{ivy.cm.co('/sidebar/Performance')}" icon="si si-time-clock-circle">
+            <p:submenu id="sr_monitor_performance" label="#{ivy.cm.co('/sidebar/Performance')}" icon="ti ti-clock">
               <p:menuitem id="sr_monitor_performance_process_execution" value="#{ivy.cm.co('/sidebar/ProcessExecution')}" icon="si si-optimization-timer"
                 url="monitorProcessExecution.xhtml" />
-              <p:menuitem id="sr_monitor_performance_traces" value="#{ivy.cm.co('/sidebar/SlowRequests')}" icon="si si-alarm-bell-timer"
+              <p:menuitem id="sr_monitor_performance_traces" value="#{ivy.cm.co('/sidebar/SlowRequests')}" icon="ti ti-bell-plus"
                 url="monitorTraces.xhtml" />
-              <p:menuitem id="sr_monitor_performance_traffic_graph" value="#{ivy.cm.co('/sidebar/TrafficGraph')}" icon="si si-view-1"
+              <p:menuitem id="sr_monitor_performance_traffic_graph" value="#{ivy.cm.co('/sidebar/TrafficGraph')}" icon="ti ti-eye"
                 url="monitorTrafficGraph.xhtml" />
             </p:submenu>
-            <p:menuitem id="sr_logs" value="#{ivy.cm.co('/sidebar/Logs')}" icon="si si-common-file-text" url="logs.xhtml" />
+            <p:menuitem id="sr_logs" value="#{ivy.cm.co('/sidebar/Logs')}" icon="ti ti-file-text" url="logs.xhtml" />
           </p:submenu>
         </pm:menu>
       </h:form>

--- a/engine-cockpit/webContent/includes/template/sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/sidebar.xhtml
@@ -13,9 +13,9 @@
       <h:form id="menuform">
         <pm:menu widgetVar="sidebar_menu">
           <p:menuitem id="sr_dashboard" value="#{ivy.cm.co('/sidebar/Dashboard')}" icon="ti ti-layout-dashboard" url="dashboard.xhtml" />
-          <p:menuitem id="sr_applications" value="#{ivy.cm.co('/common/Applications')}" icon="si si-layout-module"
+          <p:menuitem id="sr_applications" value="#{ivy.cm.co('/common/Applications')}" icon="ti ti-layout-grid"
             url="applications.xhtml" />
-          <p:submenu id="sr_security" label="#{ivy.cm.co('/common/Security')}" icon="si si-shield-lock">
+          <p:submenu id="sr_security" label="#{ivy.cm.co('/common/Security')}" icon="ti ti-shield-lock">
             <p:menuitem id="sr_security_system" value="#{ivy.cm.co('/common/SecuritySystems')}" icon="ti ti-lock"
               url="securitysystem.xhtml" />
             <p:menuitem id="sr_users" value="#{ivy.cm.co('/common/Users')}" icon="ti ti-user-check" url="users.xhtml" />
@@ -23,17 +23,17 @@
           </p:submenu>
 
           <p:submenu id="sr_configuration" label="#{ivy.cm.co('/common/Configuration')}" icon="ti ti-settings">
-            <p:menuitem id="sr_variables" value="#{ivy.cm.co('/common/Variables')}" icon="si si-archive-folder"
+            <p:menuitem id="sr_variables" value="#{ivy.cm.co('/common/Variables')}" icon="ti ti-archive"
               url="variables.xhtml" />
-            <p:menuitem id="sr_business_calendar" value="#{ivy.cm.co('/common/BusinessCalendar')}" icon="si si-calendar"
+            <p:menuitem id="sr_business_calendar" value="#{ivy.cm.co('/common/BusinessCalendar')}" icon="ti ti-calendar-event"
               url="businesscalendar.xhtml" />
-            <p:menuitem id="sr_branding" value="#{ivy.cm.co('/common/Branding')}" icon="si si-buildings-1"
+            <p:menuitem id="sr_branding" value="#{ivy.cm.co('/common/Branding')}" icon="ti ti-buildings"
               url="branding.xhtml" />
           </p:submenu>
 
-          <p:submenu id="sr_services" label="#{ivy.cm.co('/common/Services')}" icon="si si-conversation-chat-2">
+          <p:submenu id="sr_services" label="#{ivy.cm.co('/common/Services')}" icon="ti ti-messages">
             <p:menuitem id="sr_notification_channels" value="#{ivy.cm.co('/common/NotificationChannels')}" icon="ti ti-speakerphone" url="notification-channels.xhtml"/>
-            <p:menuitem id="sr_database" value="#{ivy.cm.co('/common/Databases')}" icon="si si-database"
+            <p:menuitem id="sr_database" value="#{ivy.cm.co('/common/Databases')}" icon="ti ti-database"
               url="databases.xhtml" />
             <p:menuitem id="sr_web_service" value="#{ivy.cm.co('/common/WebServiceClients')}" icon="ti ti-network"
               url="webservices.xhtml" />
@@ -43,15 +43,15 @@
               url="restclients.xhtml" />
             <p:menuitem id="sr_rest_services" value="#{ivy.cm.co('/common/RestServices')}" icon="ti ti-browser"
               url="restservices.xhtml" />
-            <p:menuitem id="sr_searchengine" value="#{ivy.cm.co('/common/SearchEngine')}" icon="si si-monitor-heart-beat-search"
+            <p:menuitem id="sr_searchengine" value="#{ivy.cm.co('/common/SearchEngine')}" icon="ti ti-device-desktop-search"
               url="searchengine.xhtml" />
           </p:submenu>
           <p:submenu id="sr_system" label="#{ivy.cm.co('/common/System')}" icon="ti ti-settings">
             <p:menuitem id="sr_admins" value="#{ivy.cm.co('/common/Administrators')}" icon="ti ti-lock-square-rounded"
               url="admins.xhtml" />
-            <p:menuitem id="sr_systemdb" value="#{ivy.cm.co('/common/SystemDatabase')}" icon="si si-database-settings"
+            <p:menuitem id="sr_systemdb" value="#{ivy.cm.co('/common/SystemDatabase')}" icon="ti ti-database-cog"
               url="systemdb.xhtml" />
-            <p:menuitem id="sr_licence" value="#{ivy.cm.co('/common/Licence')}" icon="si si-real-estate-action-house-key"
+            <p:menuitem id="sr_licence" value="#{ivy.cm.co('/common/Licence')}" icon="ti ti-home-up"
               url="licence.xhtml" />
             <p:menuitem id="sr_web_server" value="#{ivy.cm.co('/common/WebServer')}" icon="ti ti-building-broadcast-tower"
               url="webserver.xhtml" />
@@ -59,28 +59,28 @@
               url="systemconfig.xhtml" />
             <p:menuitem id="sr_ssl" value="#{ivy.cm.co('/common/SSL')}" icon="ti ti-lock"
               url="sslconfig.xhtml" />
-            <p:menuitem id="sr_cluster" value="#{ivy.cm.co('/common/Cluster')}" icon="si si-monitor-network" url="cluster.xhtml"
+            <p:menuitem id="sr_cluster" value="#{ivy.cm.co('/common/Cluster')}" icon="ti ti-topology-star" url="cluster.xhtml"
               rendered="#{clusterBean.clusterServer or param['cluster'] != null}" />
             <p:menuitem id="sr_editor" value="#{ivy.cm.co('/common/ConfigFileEditor')}" icon="ti ti-file-text-edit" url="editor.xhtml" />
           </p:submenu>
-          <p:submenu id="sr_monitor" label="#{ivy.cm.co('/common/Monitor')}" icon="si si-pie-line-graph-desktop">
-            <p:menuitem id="sr_monitor_os" value="#{ivy.cm.co('/sidebar/OS')}" icon="si si-server-search" url="monitorOs.xhtml" />
-            <p:submenu id="sr_monitor_java" label="#{ivy.cm.co('/sidebar/Java')}" icon="si si-coffee-cup">
-              <p:menuitem id="sr_monitor_java_jvm" value="#{ivy.cm.co('/sidebar/JVM')}" icon="si si-coffee-cup" url="monitorJvm.xhtml" />
+          <p:submenu id="sr_monitor" label="#{ivy.cm.co('/common/Monitor')}" icon="ti ti-device-analytics">
+            <p:menuitem id="sr_monitor_os" value="#{ivy.cm.co('/sidebar/OS')}" icon="ti ti-database-search" url="monitorOs.xhtml" />
+            <p:submenu id="sr_monitor_java" label="#{ivy.cm.co('/sidebar/Java')}" icon="ti ti-coffee">
+              <p:menuitem id="sr_monitor_java_jvm" value="#{ivy.cm.co('/sidebar/JVM')}" icon="ti ti-coffee" url="monitorJvm.xhtml" />
               <p:menuitem id="sr_monitor_java_memory" value="#{ivy.cm.co('/sidebar/Memory')}" icon="ti ti-chart-line"
                 url="monitorMemory.xhtml" />
-              <p:menuitem id="sr_monitor_java_class_histogram" value="#{ivy.cm.co('/sidebar/ClassHistogram')}" icon="si si-computer-chip-search"
+              <p:menuitem id="sr_monitor_java_class_histogram" value="#{ivy.cm.co('/sidebar/ClassHistogram')}" icon="ti ti-settings-search"
                 url="monitorClassHistogram.xhtml" />
               <p:menuitem id="sr_monitor_java_threads" value="#{ivy.cm.co('/common/Threads')}" icon="ti ti-clock-play" url="monitorThreads.xhtml" />
-              <p:menuitem id="sr_monitor_java_jfr" value="#{ivy.cm.co('/sidebar/FlightRecorder')}" icon="si si-plane-take-off" url="monitorJfr.xhtml" />
-              <p:menuitem id="sr_monitor_java_mbeans" value="#{ivy.cm.co('/sidebar/MBeans')}" icon="si si-graph-statistics-coffee"
+              <p:menuitem id="sr_monitor_java_jfr" value="#{ivy.cm.co('/sidebar/FlightRecorder')}" icon="ti ti-plane-tilt" url="monitorJfr.xhtml" />
+              <p:menuitem id="sr_monitor_java_mbeans" value="#{ivy.cm.co('/sidebar/MBeans')}" icon="ti ti-presentation-analytics"
                 url="mbeans.xhtml" />
             </p:submenu>
-            <p:submenu id="sr_monitor_engine" label="#{ivy.cm.co('/sidebar/Engine')}" icon="si si-computer-chip-search">
+            <p:submenu id="sr_monitor_engine" label="#{ivy.cm.co('/sidebar/Engine')}" icon="ti ti-settings-search">
               <p:menuitem id="sr_monitor_engine_notification" value="#{ivy.cm.co('/sidebar/Notifications')}" icon="ti ti-speakerphone" url="notifications.xhtml" />
-              <p:menuitem id="sr_monitor_engine_sessions" value="#{ivy.cm.co('/sidebar/Sessions')}" icon="si si-analytics-graph-line" url="monitor-sessions.xhtml" />
+              <p:menuitem id="sr_monitor_engine_sessions" value="#{ivy.cm.co('/sidebar/Sessions')}" icon="ti ti-graph" url="monitor-sessions.xhtml" />
               <p:menuitem id="sr_monitor_engine_jobs" value="#{ivy.cm.co('/sidebar/Jobs')}" icon="ti ti-clipboard-list" url="monitorJobs.xhtml" />
-              <p:menuitem id="sr_monitor_engine_cache" value="#{ivy.cm.co('/sidebar/Cache')}" icon="si si-monitor-heart-beat-search" url="monitorCache.xhtml" />
+              <p:menuitem id="sr_monitor_engine_cache" value="#{ivy.cm.co('/sidebar/Cache')}" icon="ti ti-device-desktop-search" url="monitorCache.xhtml" />
               <p:menuitem id="sr_monitor_engine_health" value="#{ivy.cm.co('/sidebar/Health')}" icon="ti ti-alert-triangle" url="monitor-health.xhtml" />
             </p:submenu>
             <p:submenu id="sr_monitor_workflow" label="#{ivy.cm.co('/common/Workflow')}" icon="ti ti-list">
@@ -89,7 +89,7 @@
               <p:menuitem id="sr_monitor_workflow_intermediate_events" value="#{ivy.cm.co('/common/IntermediateEvents')}" icon="ti ti-clock" url="monitorIntermediateEvents.xhtml" />
             </p:submenu>
             <p:submenu id="sr_monitor_performance" label="#{ivy.cm.co('/sidebar/Performance')}" icon="ti ti-clock">
-              <p:menuitem id="sr_monitor_performance_process_execution" value="#{ivy.cm.co('/sidebar/ProcessExecution')}" icon="si si-optimization-timer"
+              <p:menuitem id="sr_monitor_performance_process_execution" value="#{ivy.cm.co('/sidebar/ProcessExecution')}" icon="ti ti-calendar-clock"
                 url="monitorProcessExecution.xhtml" />
               <p:menuitem id="sr_monitor_performance_traces" value="#{ivy.cm.co('/sidebar/SlowRequests')}" icon="ti ti-bell-plus"
                 url="monitorTraces.xhtml" />

--- a/engine-cockpit/webContent/includes/template/sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/sidebar.xhtml
@@ -55,13 +55,13 @@
               url="licence.xhtml" />
             <p:menuitem id="sr_web_server" value="#{ivy.cm.co('/common/WebServer')}" icon="ti ti-building-broadcast-tower"
               url="webserver.xhtml" />
-            <p:menuitem id="sr_system_config" value="#{ivy.cm.co('/common/SystemConfiguration')}" icon="ti ti-settings-double"
+            <p:menuitem id="sr_system_config" value="#{ivy.cm.co('/common/SystemConfiguration')}" icon="ti ti-settings"
               url="systemconfig.xhtml" />
             <p:menuitem id="sr_ssl" value="#{ivy.cm.co('/common/SSL')}" icon="ti ti-lock"
               url="sslconfig.xhtml" />
             <p:menuitem id="sr_cluster" value="#{ivy.cm.co('/common/Cluster')}" icon="ti ti-topology-star" url="cluster.xhtml"
               rendered="#{clusterBean.clusterServer or param['cluster'] != null}" />
-            <p:menuitem id="sr_editor" value="#{ivy.cm.co('/common/ConfigFileEditor')}" icon="ti ti-file-text-edit" url="editor.xhtml" />
+            <p:menuitem id="sr_editor" value="#{ivy.cm.co('/common/ConfigFileEditor')}" icon="ti ti-file-text" url="editor.xhtml" />
           </p:submenu>
           <p:submenu id="sr_monitor" label="#{ivy.cm.co('/common/Monitor')}" icon="ti ti-device-analytics">
             <p:menuitem id="sr_monitor_os" value="#{ivy.cm.co('/sidebar/OS')}" icon="ti ti-database-search" url="monitorOs.xhtml" />

--- a/engine-cockpit/webContent/includes/template/template.xhtml
+++ b/engine-cockpit/webContent/includes/template/template.xhtml
@@ -59,7 +59,7 @@
             <h:outputText rendered="#{clusterBean.clusterServer}">
               <li class="topbar-item topbar-notifications cluster-warning">
                 <a href="#">
-                  <i class="topbar-icon si si-monitor-network animated swing"></i>
+                  <i class="topbar-icon ti ti-topology-star animated swing"></i>
                 </a>
                 <ul>
                   <li>

--- a/engine-cockpit/webContent/includes/template/template.xhtml
+++ b/engine-cockpit/webContent/includes/template/template.xhtml
@@ -38,7 +38,7 @@
         
         <div class="layout-breadcrumb">
           <ul class="inline-flex align-items-center">
-            <li><a href="dashboard.xhtml"><i class="text-xl ti-home"></i></a></li>
+            <li><a href="dashboard.xhtml"><i class="text-xl ti ti-home"></i></a></li>
             <li>/</li>
             <ui:insert name="breadcrumb" />
           </ul>
@@ -64,7 +64,7 @@
                 <ul>
                   <li>
                     <a href="#{advisorBean.engineGuideBaseUrl}/integration/cluster/configuration.html#changes">
-                      <i class="text-xl ti-alert-triangle"></i>
+                      <i class="text-xl ti ti-alert-triangle"></i>
                       <span style="max-width: calc(100% - 40px)">
                         <b>#{ivy.cm.co('/template/ClusterMode')}"</b><br/>
                         #{ivy.cm.co('/template/ClusterModeWarning')}"
@@ -133,19 +133,19 @@
               <ul>
                 <li>
                   <p:link id="profileLink" href="profile.xhtml">
-                    <i class="text-xl ti-user-check"></i>
+                    <i class="text-xl ti ti-user-check"></i>
                     <span>#{ivy.cm.co('/profile/Profile')}</span>
                   </p:link>
                 </li>
                 <li>
                   <p:commandLink id="sessionLogoutBtn" actionListener="#{loginBean.logout}">
-                    <i class="text-xl ti-logout"></i>
+                    <i class="text-xl ti ti-logout"></i>
                     <span>#{ivy.cm.co('/template/Logout')}</span>
                   </p:commandLink>
                 </li>
                 <li>
                   <p:commandLink id="supportReport" type="button" onclick="PF('supportReportModal').show()">
-                    <i class="text-xl ti-help-circle"></i>
+                    <i class="text-xl ti ti-help-circle"></i>
                     <span>#{ivy.cm.co('/template/SupportReport')}</span>
                   </p:commandLink>
                 </li>

--- a/engine-cockpit/webContent/includes/template/template.xhtml
+++ b/engine-cockpit/webContent/includes/template/template.xhtml
@@ -32,13 +32,13 @@
       <div class="layout-topbar-wrapper">
         <div class="layout-topbar-left">
           <a href="#" class="menu-button">
-           <i class="pi pi-bars"/>
+           <i class="ti ti-menu-2"/>
           </a>
         </div>
         
         <div class="layout-breadcrumb">
           <ul class="inline-flex align-items-center">
-            <li><a href="dashboard.xhtml"><i class="si si-lg si-house-chimney-2"></i></a></li>
+            <li><a href="dashboard.xhtml"><i class="text-xl ti-home"></i></a></li>
             <li>/</li>
             <ui:insert name="breadcrumb" />
           </ul>
@@ -51,7 +51,7 @@
             <h:outputText rendered="#{not empty licenceBean.licenceEvents}">
               <li class="topbar-item topbar-notifications licence-notification">
                 <a href="#" onclick="PF('licenceEventsDialog').show();">
-                  <i class="topbar-icon si si-alarm-bell-timer animated swing"></i>
+                  <i class="topbar-icon ti ti-bell-plus animated swing"></i>
                 </a>
               </li>
             </h:outputText>
@@ -64,7 +64,7 @@
                 <ul>
                   <li>
                     <a href="#{advisorBean.engineGuideBaseUrl}/integration/cluster/configuration.html#changes">
-                      <i class="si si-lg si-road-sign-warning"></i>
+                      <i class="text-xl ti-alert-triangle"></i>
                       <span style="max-width: calc(100% - 40px)">
                         <b>#{ivy.cm.co('/template/ClusterMode')}"</b><br/>
                         #{ivy.cm.co('/template/ClusterModeWarning')}"
@@ -78,7 +78,7 @@
             <h:outputText rendered="#{not empty healthBean.messages}">
               <li class="topbar-item topbar-notifications health-messages">
                 <a href="#">
-                  <i class="topbar-icon si si-road-sign-warning animated swing"></i>
+                  <i class="topbar-icon si ti-alert-triangle animated swing"></i>
                   <h:outputText id="health-check-badge" value="#{healthBean.messageCount}" styleClass="health-check-badge" />
                 </a>
                 <ul>
@@ -86,7 +86,7 @@
                     <h:panelGroup>
                       <li>
                         <a href="#{msg.actionLink}">
-                          <i class="si si-lg #{msg.severityIcon} #{msg.severityClass}"></i>
+                          <i class="text-xl #{msg.severityIcon} #{msg.severityClass}"></i>
                           <span style="max-width: calc(100% - 40px)">
                             <b>#{msg.message}</b><br/>
                             #{msg.description}
@@ -105,7 +105,7 @@
             <ui:insert name="topbar-items">
               <li class="topbar-item">
                 <a href="#{advisorBean.cockpitEngineGuideUrl}index.html" target="_blank" rel="noopener noreferrer">
-                  <i class="topbar-icon si si-question-circle"></i>
+                  <i class="topbar-icon ti ti-help-circle"></i>
                 </a>
               </li>
             </ui:insert>
@@ -124,7 +124,7 @@
                   <h:outputText rendered="#{not empty loginBean.gravatarHash}">
                     <img src="https://www.gravatar.com/avatar/#{loginBean.gravatarHash}?d=404" style="border-radius: 10px; display: none;" onload="showGravatarImg(this);"/>
                   </h:outputText>
-                  <i class="si si-single-neutral-circle" style="font-size: 28px; padding: 2px;"></i>
+                  <i class="ti ti-user-circle" style="font-size: 28px; padding: 2px;"></i>
                 </span>
                 <span id="sessionUserName" class="topbar-item-name profile-name">
                   <span>#{loginBean.sessionUserName}</span>
@@ -133,25 +133,25 @@
               <ul>
                 <li>
                   <p:link id="profileLink" href="profile.xhtml">
-                    <i class="si si-lg si-single-neutral-actions"></i>
+                    <i class="text-xl ti-user-check"></i>
                     <span>#{ivy.cm.co('/profile/Profile')}</span>
                   </p:link>
                 </li>
                 <li>
                   <p:commandLink id="sessionLogoutBtn" actionListener="#{loginBean.logout}">
-                    <i class="si si-lg si-logout-1"></i>
+                    <i class="text-xl ti-logout"></i>
                     <span>#{ivy.cm.co('/template/Logout')}</span>
                   </p:commandLink>
                 </li>
                 <li>
                   <p:commandLink id="supportReport" type="button" onclick="PF('supportReportModal').show()">
-                    <i class="si si-lg si-help-wheel"></i>
+                    <i class="text-xl ti-help-circle"></i>
                     <span>#{ivy.cm.co('/template/SupportReport')}</span>
                   </p:commandLink>
                 </li>
                 <li>
                   <p:link id="serverIndex" type="button" href="/">
-                    <i class="si si-lg si si-information-circle"></i>
+                    <i class="text-xl ti ti-info-circle"></i>
                     <span>#{ivy.cm.co('/template/ServerIndex')}</span>
                   </p:link>
                 </li>

--- a/engine-cockpit/webContent/includes/template/template.xhtml
+++ b/engine-cockpit/webContent/includes/template/template.xhtml
@@ -78,7 +78,7 @@
             <h:outputText rendered="#{not empty healthBean.messages}">
               <li class="topbar-item topbar-notifications health-messages">
                 <a href="#">
-                  <i class="topbar-icon si ti-alert-triangle animated swing"></i>
+                  <i class="topbar-icon ti ti-alert-triangle animated swing"></i>
                   <h:outputText id="health-check-badge" value="#{healthBean.messageCount}" styleClass="health-check-badge" />
                 </a>
                 <ul>

--- a/engine-cockpit/webContent/includes/template/template.xhtml
+++ b/engine-cockpit/webContent/includes/template/template.xhtml
@@ -113,7 +113,7 @@
             <li class="topbar-item themeswitch-item">
               <p:commandLink id="themeSwitcher" onclick="PrimeFaces.FreyaConfigurator.changeLayout('ivy', '#{ivyFreyaTheme.mode == 'light' ? 'dark' : 'light'}');"
                 style="text-decoration: none;">
-                <i class="topbar-icon pi pi-#{ivyFreyaTheme.mode == 'light' ? 'moon' : 'sun'}"/>
+                <i class="topbar-icon #{ivyFreyaTheme.mode == 'light' ? 'ti ti-moon' : 'ti ti-sun-high'}"/>
                 <p:ajax onstart="PrimeFaces.FreyaConfigurator.beforeResourceChange();" listener="#{ivyFreyaTheme.toggleTheme}" update="themeSwitcher" />
               </p:commandLink>
             </li>

--- a/engine-cockpit/webContent/includes/template/wizard-sidebar.xhtml
+++ b/engine-cockpit/webContent/includes/template/wizard-sidebar.xhtml
@@ -12,10 +12,10 @@
     <div class="layout-menu-container">
       <h:form id="menuform">
         <pm:menu widgetVar="menu">
-          <p:menuitem id="server" value="#{ivy.cm.co('/common/Applications')}" icon="si si-module" url="#{wizardBean.infoPageUrl}" />
-          <p:menuitem id="cockpit" value="#{ivy.cm.co('/common/Cockpit')}" icon="si si-cog" url="dashboard.xhtml" />
-          <p:menuitem id="setup" value="#{ivy.cm.co('/common/Setup')}" icon="si si-tools-wench" url="setup.xhtml" />
-          <p:menuitem id="migrate" value="#{ivy.cm.co('/common/Migration')}" icon="si si-navigation-right-circle" url="migrate.xhtml" />
+          <p:menuitem id="server" value="#{ivy.cm.co('/common/Applications')}" icon="ti ti-layout-grid" url="#{wizardBean.infoPageUrl}" />
+          <p:menuitem id="cockpit" value="#{ivy.cm.co('/common/Cockpit')}" icon="ti ti-settings" url="dashboard.xhtml" />
+          <p:menuitem id="setup" value="#{ivy.cm.co('/common/Setup')}" icon="ti ti-tool" url="setup.xhtml" />
+          <p:menuitem id="migrate" value="#{ivy.cm.co('/common/Migration')}" icon="ti ti-circle-arrow-right" url="migrate.xhtml" />
         </pm:menu>
       </h:form>
     </div>

--- a/engine-cockpit/webContent/includes/template/wizard.xhtml
+++ b/engine-cockpit/webContent/includes/template/wizard.xhtml
@@ -29,7 +29,7 @@
       <div class="layout-topbar-wrapper">
         <div class="layout-topbar-left">
           <a href="#" class="menu-button">
-           <i class="pi pi-bars"/>
+           <i class="ti ti-menu-2"/>
           </a>
           <a id="bannerLogo" class="layout-topbar-logo" href="#{engineInfo.homeUrl}">
             <p:graphicImage name="resources/images/#{ivyFreyaTheme.logo}.svg" />
@@ -46,7 +46,7 @@
                   <h:outputText rendered="#{not empty loginBean.gravatarHash}">
                     <img src="https://www.gravatar.com/avatar/#{loginBean.gravatarHash}?d=404" style="border-radius: 10px; display: none;" onload="showGravatarImg(this);"/>
                   </h:outputText>
-                  <i class="si si-single-neutral-circle" style="font-size: 28px; padding: 2px;"></i>
+                  <i class="ti ti-user-circle" style="font-size: 28px; padding: 2px;"></i>
                 </span>
                 <span id="sessionUserName" class="topbar-item-name profile-name">
                   <span>#{loginBean.sessionUserName}</span>
@@ -64,13 +64,13 @@
                 <li>
                   <p:link type="button" href="#{advisorBean.engineGuideBaseUrl}/reference/setup-wizard.html" 
                     target="_blank" rel="noopener noreferrer">
-                    <i class="si si-lg si-question-circle"></i>
+                    <i class="text-xl ti-help-circle"></i>
                     <span>#{ivy.cm.co('/common/Help')}</span>
                   </p:link>
                 </li>
                 <li>
                   <p:commandLink id="sessionLogoutBtn" actionListener="#{loginBean.logout}">
-                    <i class="si si-lg si-logout-1"></i>
+                    <i class="text-xl ti-logout"></i>
                     <span>#{ivy.cm.co('/wizard/Logout')}</span>
                   </p:commandLink>
                 </li>

--- a/engine-cockpit/webContent/includes/template/wizard.xhtml
+++ b/engine-cockpit/webContent/includes/template/wizard.xhtml
@@ -64,13 +64,13 @@
                 <li>
                   <p:link type="button" href="#{advisorBean.engineGuideBaseUrl}/reference/setup-wizard.html" 
                     target="_blank" rel="noopener noreferrer">
-                    <i class="text-xl ti-help-circle"></i>
+                    <i class="text-xl ti ti-help-circle"></i>
                     <span>#{ivy.cm.co('/common/Help')}</span>
                   </p:link>
                 </li>
                 <li>
                   <p:commandLink id="sessionLogoutBtn" actionListener="#{loginBean.logout}">
-                    <i class="text-xl ti-logout"></i>
+                    <i class="text-xl ti ti-logout"></i>
                     <span>#{ivy.cm.co('/wizard/Logout')}</span>
                   </p:commandLink>
                 </li>

--- a/engine-cockpit/webContent/includes/template/wizard.xhtml
+++ b/engine-cockpit/webContent/includes/template/wizard.xhtml
@@ -56,7 +56,7 @@
                 <li class="themeswitch-item">
                   <p:commandLink id="themeSwitcher" onclick="PrimeFaces.FreyaConfigurator.changeLayout('ivy', '#{ivyFreyaTheme.mode == 'light' ? 'dark' : 'light'}');"
                     style="text-decoration: none;">
-                    <i class="topbar-icon pi pi-#{ivyFreyaTheme.mode == 'light' ? 'moon' : 'sun'}"/>
+                    <i class="topbar-icon #{ivyFreyaTheme.mode == 'light' ? 'ti ti-moon' : 'ti ti-sun-high'}"/>
                     <span>#{ivyFreyaTheme.mode == 'light' ? ivy.cm.co('/wizard/Dark') : ivy.cm.co('/wizard/Light')}</span>
                     <p:ajax onstart="PrimeFaces.FreyaConfigurator.beforeResourceChange();" listener="#{ivyFreyaTheme.toggleTheme}" update="themeSwitcher" />
                   </p:commandLink>

--- a/engine-cockpit/webContent/resources/composite/Administrators.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Administrators.xhtml
@@ -11,7 +11,7 @@
     <p:dataTable var="admin" value="#{administratorBean.admins}" id="adminTable" widgetVar="adminTable" styleClass="ui-fluid" emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
       <f:facet name="header">
         <div class="ui-input-icon-left filter-container">
-          <i class="pi pi-search"/>
+          <i class="ti ti-search"/>
           <p:inputText id="globalFilter" onkeyup="PF('adminTable').filter()" value="#{administratorBean.filter}" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" />
         </div>
       </f:facet>
@@ -19,7 +19,7 @@
       <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{admin.name}" filterBy="#{admin.name}">
         <h:panelGroup styleClass="flex align-items-center">
           <h:outputText value="#{admin.name}" styleClass="ml-1 admin-name">
-            <h:panelGroup layout="block" styleClass="user-avatar si si-single-neutral-shield">
+            <h:panelGroup layout="block" styleClass="user-avatar ti ti-lock-square-rounded">
               <img src="https://www.gravatar.com/avatar/#{admin.gravatarHash}?d=404" onload="showGravatarImg(this);"/>
             </h:panelGroup>
           </h:outputText>
@@ -43,11 +43,11 @@
       </p:column>
 
       <p:column styleClass="table-btn-2">
-        <p:commandButton id="editAdminBtn" disabled="#{admin.external}" actionListener="#{administratorBean.setAdmin(admin)}" icon="si si-pencil"
+        <p:commandButton id="editAdminBtn" disabled="#{admin.external}" actionListener="#{administratorBean.setAdmin(admin)}" icon="ti ti-pencil"
           title="#{ivy.cm.co('/common/Edit')}" update="admins:editAdminDialog" styleClass="ui-button-secondary rounded-button"
           oncomplete="PF('editAdminDialog').show();" process="@this" />
         <p:commandButton id="deleteAdmin"  actionListener="#{administratorBean.setAdmin(admin)}"
-          update="@form:deleteAdminDialog" icon="si si-bin-1" title="#{ivy.cm.co('/common/Delete')}"
+          update="@form:deleteAdminDialog" icon="ti ti-trash" title="#{ivy.cm.co('/common/Delete')}"
           styleClass="ml-1 ui-button-danger rounded-button" process="@this"
           disabled="#{administratorBean.isDeleteButtonDisabled(admin)}" oncomplete="PF('deleteAdminDialog').show();" />
       </p:column>
@@ -59,7 +59,7 @@
       <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('deleteAdminDialog').hide();" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="deleteAdminYesBtn" value="#{ivy.cm.co('/common/Delete')}" immediate="true" styleClass="modal-input-button"
-        actionListener="#{administratorBean.deleteAdmin}" update="#{cc.attrs.updateFields}" icon="si si-bin-1" />
+        actionListener="#{administratorBean.deleteAdmin}" update="#{cc.attrs.updateFields}" icon="ti ti-trash" />
     </p:confirmDialog>
   </h:form>
 
@@ -138,11 +138,11 @@
           styleClass="ui-button-secondary ui-button-flat modal-input-button" immediate="true" />
 
         <p:commandButton id="addAdmin" rendered="#{empty administratorBean.admin.name}" validateClient="true" update="#{cc.attrs.updateFields}"
-          actionListener="#{administratorBean.createAdmin()}" value="#{ivy.cm.co('/common/Create')}" icon="si si-floppy-disk"
+          actionListener="#{administratorBean.createAdmin()}" value="#{ivy.cm.co('/common/Create')}" icon="ti ti-device-floppy"
           styleClass="modal-input-button" oncomplete="if (!args.validationFailed) PF('editAdminDialog').hide();" />
 
         <p:commandButton id="updateAdmin" rendered="#{not empty administratorBean.admin.name}" validateClient="true" update="#{cc.attrs.updateFields}"
-          actionListener="#{administratorBean.updateAdmin()}" value="#{ivy.cm.co('/common/Update')}" icon="si si-floppy-disk"
+          actionListener="#{administratorBean.updateAdmin()}" value="#{ivy.cm.co('/common/Update')}" icon="ti ti-device-floppy"
           styleClass="modal-input-button" oncomplete="if (!args.validationFailed) PF('editAdminDialog').hide();" />
       </div>
     </h:form>

--- a/engine-cockpit/webContent/resources/composite/ApplicationTabs.xhtml
+++ b/engine-cockpit/webContent/resources/composite/ApplicationTabs.xhtml
@@ -15,7 +15,7 @@
     <p:ajax event="tabChange" listener="#{cc.attrs.tabChange}" update="@this #{cc.attrs.update}" />
     <p:tab title="#{app.name}" titleStyleClass="application-tab">
       <f:facet name="title">
-        <i class="si si-module mr-1" />
+        <i class="ti ti-layout-grid mr-1" />
         <h:outputText value="#{app.name}" />
       </f:facet>
       <cc:insertChildren />
@@ -24,7 +24,7 @@
   <h:panelGroup rendered="#{empty managerBean.applications}" layout="block" 
     styleClass="flex align-items-center">
     <h:outputText value="#{ivy.cm.co('/applicationTabs/NoConfiguredApplication')}" />
-    <p:linkButton styleClass="ml-3" icon="si si-add" value="#{ivy.cm.co('/applicationTabs/CreateApplication')}" href="applications.xhtml" />
+    <p:linkButton styleClass="ml-3" icon="ti ti-plus" value="#{ivy.cm.co('/applicationTabs/CreateApplication')}" href="applications.xhtml" />
   </h:panelGroup>
 </cc:implementation>
 

--- a/engine-cockpit/webContent/resources/composite/ApplicationTabs.xhtml
+++ b/engine-cockpit/webContent/resources/composite/ApplicationTabs.xhtml
@@ -15,7 +15,7 @@
     <p:ajax event="tabChange" listener="#{cc.attrs.tabChange}" update="@this #{cc.attrs.update}" />
     <p:tab title="#{app.name}" titleStyleClass="application-tab">
       <f:facet name="title">
-        <i class="ti ti-layout-grid mr-1" />
+        <i class="ti ti-cube mr-1" />
         <h:outputText value="#{app.name}" />
       </f:facet>
       <cc:insertChildren />

--- a/engine-cockpit/webContent/resources/composite/Bean.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Bean.xhtml
@@ -11,9 +11,9 @@
   <h:form id="eventBean">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-cog"></i>
+        <i class="pr-3 ti ti-settings"></i>
         <h6 class="m-0">#{ivy.cm.co('/bean/Bean')}</h6>
-        <p:commandButton id="start" title="#{ivy.cm.co('/bean/StartsBean')}" icon="si si-controls-play"
+        <p:commandButton id="start" title="#{ivy.cm.co('/bean/StartsBean')}" icon="ti ti-player-play"
             action="#{cc.attrs.event.start()}" update="@form" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{cc.attrs.event.running}"/>
         <p:commandButton id="stop" title="#{ivy.cm.co('/bean/StopsBean')}" icon="si si-controls-stop"
             action="#{cc.attrs.event.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{!cc.attrs.event.running}"/>

--- a/engine-cockpit/webContent/resources/composite/Bean.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Bean.xhtml
@@ -15,7 +15,7 @@
         <h6 class="m-0">#{ivy.cm.co('/bean/Bean')}</h6>
         <p:commandButton id="start" title="#{ivy.cm.co('/bean/StartsBean')}" icon="ti ti-player-play"
             action="#{cc.attrs.event.start()}" update="@form" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{cc.attrs.event.running}"/>
-        <p:commandButton id="stop" title="#{ivy.cm.co('/bean/StopsBean')}" icon="si si-controls-stop"
+        <p:commandButton id="stop" title="#{ivy.cm.co('/bean/StopsBean')}" icon="ti ti-player-stop"
             action="#{cc.attrs.event.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{!cc.attrs.event.running}"/>
       </div>
     </div>

--- a/engine-cockpit/webContent/resources/composite/BreadcrumbInfos.xhtml
+++ b/engine-cockpit/webContent/resources/composite/BreadcrumbInfos.xhtml
@@ -11,13 +11,13 @@
   <li style="margin-left: 2rem; font-size: 14px;">
     <h:panelGroup rendered="#{!cc.attrs.appContext}">
       <a href="security-detail.xhtml?securitySystemName=#{managerBean.selectedSecuritySystem.securitySystemName}" title="#{ivy.cm.co('/breadcrumbInfos/SelectedSecuritySystem')}">
-        <i class="si si-lock-1 link-icon"></i> 
+        <i class="ti ti-lock link-icon"></i> 
         <h:outputText value="#{managerBean.selectedSecuritySystem.securitySystemName}" />
       </a>
     </h:panelGroup>
     <h:panelGroup rendered="#{cc.attrs.appContext}">
       <a href="#{managerBean.getSelectedApplicationDetailLink()}" title="#{ivy.cm.co('/breadcrumbInfos/SelectedApplication')}">
-        <i class="si si-module link-icon"></i> 
+        <i class="ti ti-layout-grid link-icon"></i> 
         <h:outputText value="#{managerBean.selectedApplicationName}" />
       </a>
     </h:panelGroup>

--- a/engine-cockpit/webContent/resources/composite/BreadcrumbInfos.xhtml
+++ b/engine-cockpit/webContent/resources/composite/BreadcrumbInfos.xhtml
@@ -17,7 +17,7 @@
     </h:panelGroup>
     <h:panelGroup rendered="#{cc.attrs.appContext}">
       <a href="#{managerBean.getSelectedApplicationDetailLink()}" title="#{ivy.cm.co('/breadcrumbInfos/SelectedApplication')}">
-        <i class="ti ti-layout-grid link-icon"></i> 
+        <i class="ti ti-cube link-icon"></i> 
         <h:outputText value="#{managerBean.selectedApplicationName}" />
       </a>
     </h:panelGroup>

--- a/engine-cockpit/webContent/resources/composite/ChannelState.xhtml
+++ b/engine-cockpit/webContent/resources/composite/ChannelState.xhtml
@@ -12,7 +12,7 @@
     <i class="table-icon #{cc.attrs.channel.stateIcon}" />
     <h:panelGroup rendered="#{cc.attrs.channel.locked}">
       <h:outputText value="#{cc.attrs.channel.locks}" />
-      <i class="si si-synchronize-arrow-clock table-icon"></i>
+      <i class="ti ti-clock-play table-icon"></i>
       <h:outputText value="#{cc.attrs.channel.nextRetryIn}" />
     </h:panelGroup>
   </p:outputPanel>

--- a/engine-cockpit/webContent/resources/composite/ChannelState.xhtml
+++ b/engine-cockpit/webContent/resources/composite/ChannelState.xhtml
@@ -18,7 +18,7 @@
   </p:outputPanel>
   <p:tooltip id="lockDetails" for="state" rendered="#{cc.attrs.channel.locked}">
     <h5 class="flex align-items-center">
-      <i class="si si-computer-chip-search"></i>
+      <i class="ti ti-settings-search"></i>
       <h:outputText value="&#160;" />
       #{ivy.cm.co('/channelState/ErrorInformation')}
     </h5>

--- a/engine-cockpit/webContent/resources/composite/Configuration.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Configuration.xhtml
@@ -29,7 +29,7 @@
 
       <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{config.key}" filterBy="#{config.key}">
         <h:panelGroup styleClass="config-name table-cell-autocut">
-          <i class="si si-#{config.icon} table-icon"></i>
+          <i class="ti ti-#{config.icon} table-icon"></i>
           <h:outputText value="#{config.key}" title="#{config.key} - #{config.description}" />
         </h:panelGroup>
       </p:column>

--- a/engine-cockpit/webContent/resources/composite/Configuration.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Configuration.xhtml
@@ -18,10 +18,10 @@
       <f:facet name="header">
         <div class="flex">
           <span class="ui-input-icon-left filter-container" style="width: 100%;">
-            <i class="pi pi-search"/>
+            <i class="ti ti-search"/>
             <p:inputText id="globalFilter" onkeyup="PF('configTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{cc.attrs.bean.filter}" />
           </span>
-          <p:commandButton id="filterBtn" title="#{ivy.cm.co('/configuration/Filter')} #{cc.attrs.bean.contentFilterText}" type="button" icon="si si-filter-1"
+          <p:commandButton id="filterBtn" title="#{ivy.cm.co('/configuration/Filter')} #{cc.attrs.bean.contentFilterText}" type="button" icon="ti ti-filter"
             styleClass="ui-button-secondary rounded-button ml-1 flex-shrink-0" onclick="PF('filterPanel').show();"
             rendered="#{cc.attrs.showContentFilter}" />
         </div>
@@ -42,19 +42,19 @@
         <h:outputText value="#{config.shortSource}" title="#{config.source}" />
       </p:column>
       <p:column styleClass="table-btn-2">
-        <p:commandButton id="editConfigBtn" icon="si si-pencil" title="#{ivy.cm.co('/common/Edit')}"
+        <p:commandButton id="editConfigBtn" icon="ti ti-pencil" title="#{ivy.cm.co('/common/Edit')}"
           styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" process="@this"
           actionListener="#{cc.attrs.bean.setActiveConfig(config.key)}" update=":#{cc.clientId}:editConfigurationModal"
           oncomplete="PF('editConfigurationModal').show();" />
         <p:commandButton title="#{ivy.cm.co('/common/More')}" id="tasksButton" disabled="#{config.default}" type="button"
-          icon="si si-navigation-menu" styleClass="flex-shrink-0 ml-1 ui-button-secondary ui-button-outlined rounded-button" />
+          icon="ti ti-menu-2" styleClass="flex-shrink-0 ml-1 ui-button-secondary ui-button-outlined rounded-button" />
         <p:menu overlay="true" trigger="tasksButton" my="right top" at="right bottom" id="activityMenu">
           <p:menuitem value="#{ivy.cm.co('/configuration/ViewFile')}" icon="si si-common-file-search"
             oncomplete="PF('showConfigurationFileModal').show()"
             actionListener="#{cc.attrs.bean.setActiveConfig(config.key)}" update=":#{cc.clientId}:showConfigurationFileModal"
             id="showFileBtn" process="@this" disabled="#{!config.fileExist()}">
           </p:menuitem>
-          <p:menuitem value="#{ivy.cm.co('/common/Reset')}" icon="si si-undo" process="@this"
+          <p:menuitem value="#{ivy.cm.co('/common/Reset')}" icon="ti ti-arrow-back-up" process="@this"
             actionListener="#{cc.attrs.bean.setActiveConfig(config.key)}" id="resetConfigBtn"
             update=":#{cc.clientId}:resetConfigConfirmDialog" oncomplete="PF('resetConfigConfirmDialog').show()" />
         </p:menu>
@@ -69,7 +69,7 @@
       <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('resetConfigConfirmDialog').hide();" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="resetConfigConfirmYesBtn" value="#{ivy.cm.co('/common/Reset')}" update=":#{cc.clientId}:form:configTable" immediate="true"
-        actionListener="#{cc.attrs.bean.resetConfig}" icon="si si-undo" styleClass="modal-input-button"
+        actionListener="#{cc.attrs.bean.resetConfig}" icon="ti ti-arrow-back-up" styleClass="modal-input-button"
         onsuccess="PF('resetConfigConfirmDialog').hide();" />
     </h:form>
   </p:confirmDialog>
@@ -82,7 +82,7 @@
         <h:outputText value="#{cc.attrs.bean.activeConfig.source}" />
         <pe:codeMirror id="codeBlock" value="#{cc.attrs.bean.activeConfig.fileContent}" mode="yaml" readonly="true" />
       </p:panelGrid>
-      <p:commandButton id="downloadConfigurationFile" ajax="false" value="#{ivy.cm.co('/common/Download')}" icon="si si-download-bottom"
+      <p:commandButton id="downloadConfigurationFile" ajax="false" value="#{ivy.cm.co('/common/Download')}" icon="ti ti-download"
         styleClass="modal-input-button" style="width: 125px;">
         <p:fileDownload value="#{cc.attrs.bean.activeConfig.downloadFile()}" />
       </p:commandButton>
@@ -165,7 +165,7 @@
           type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
         <p:commandButton id="saveEditConfiguration" update=":#{cc.clientId}:form:configTable" partialSubmit="true"
           onsuccess="PF('editConfigurationModal').hide();" actionListener="#{cc.attrs.bean.saveConfig}" value="#{ivy.cm.co('/common/Save')}"
-          icon="si si-floppy-disk" process="editConfigurationForm:editConfigurationValue" styleClass="modal-input-button" />
+          icon="ti ti-device-floppy" process="editConfigurationForm:editConfigurationValue" styleClass="modal-input-button" />
       </div>
     </h:form>
   </p:dialog>

--- a/engine-cockpit/webContent/resources/composite/Configuration.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Configuration.xhtml
@@ -29,7 +29,7 @@
 
       <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{config.key}" filterBy="#{config.key}">
         <h:panelGroup styleClass="config-name table-cell-autocut">
-          <i class="ti ti-#{config.icon} table-icon"></i>
+          <i class="{config.icon} table-icon"></i>
           <h:outputText value="#{config.key}" title="#{config.key} - #{config.description}" />
         </h:panelGroup>
       </p:column>

--- a/engine-cockpit/webContent/resources/composite/Configuration.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Configuration.xhtml
@@ -49,7 +49,7 @@
         <p:commandButton title="#{ivy.cm.co('/common/More')}" id="tasksButton" disabled="#{config.default}" type="button"
           icon="ti ti-menu-2" styleClass="flex-shrink-0 ml-1 ui-button-secondary ui-button-outlined rounded-button" />
         <p:menu overlay="true" trigger="tasksButton" my="right top" at="right bottom" id="activityMenu">
-          <p:menuitem value="#{ivy.cm.co('/configuration/ViewFile')}" icon="si si-common-file-search"
+          <p:menuitem value="#{ivy.cm.co('/configuration/ViewFile')}" icon="ti ti-file-search"
             oncomplete="PF('showConfigurationFileModal').show()"
             actionListener="#{cc.attrs.bean.setActiveConfig(config.key)}" update=":#{cc.clientId}:showConfigurationFileModal"
             id="showFileBtn" process="@this" disabled="#{!config.fileExist()}">

--- a/engine-cockpit/webContent/resources/composite/ConnectionTestResult.xhtml
+++ b/engine-cockpit/webContent/resources/composite/ConnectionTestResult.xhtml
@@ -36,11 +36,11 @@
            value="#{ivy.cm.co('/common/Close')}" type="button" update="connTestForm"
            styleClass="modal-input-button ui-button-secondary ui-button-flat"/>
         <p:commandButton id="testTlsConectionBtn" title="#{ivy.cm.co('/connectionTestResult/TLSTestButtonTitle')}" rendered="#{tlsTesterBean.isHttps(cc.attrs.url) || tlsTesterBean.isJdbc(cc.attrs.url)}"
-           icon="si si-arrow-right" value="#{ivy.cm.co('/connectionTestResult/TLSTestButton')}"
+           icon="ti ti-arrow-right" value="#{ivy.cm.co('/connectionTestResult/TLSTestButton')}"
            update="@form" styleClass="modal-input-button"
            actionListener="#{tlsTesterBean.testConnection(cc.attrs.url)}" />
         <p:commandButton id="testConnectionBtn" title="#{ivy.cm.co('/connectionTestResult/TestConnection')}" update="@form" value="#{ivy.cm.co('/connectionTestResult/TestConnection')}"
-           icon="si si-arrow-right" styleClass="modal-input-button" actionListener="#{cc.attrs.testMethod};"
+           icon="ti ti-arrow-right" styleClass="modal-input-button" actionListener="#{cc.attrs.testMethod};"
            immediate="true" process="@this" async="true" onclick="buttonAddSpinner(this);" action="#{tlsTesterBean.setTlsTestRendered(false)}"/>
       </div>
     </h:form>

--- a/engine-cockpit/webContent/resources/composite/DirectoryBrowser.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DirectoryBrowser.xhtml
@@ -45,7 +45,7 @@
       <p:commandButton id="cancelDirectoryBrowser" onclick="PF('directoryBrowserDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
         styleClass="ui-button-secondary ui-button-flat modal-input-button" />
       <p:commandButton id="chooseDirectoryName" actionListener="#{cc.attrs.returnListener}" value="#{ivy.cm.co('/common/Choose')}"
-        icon="si si-check-1" styleClass="modal-input-button" update="#{cc.attrs.updateFields}"
+        icon="ti ti-check" styleClass="modal-input-button" update="#{cc.attrs.updateFields}"
         onclick="PF('directoryBrowserDialog').hide();" disabled="#{cc.attrs.directoryBrowser.tree.childCount == 0}"/>
     </f:facet>
   </p:dialog>

--- a/engine-cockpit/webContent/resources/composite/DirectoryBrowser.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DirectoryBrowser.xhtml
@@ -20,7 +20,7 @@
           selection="#{cc.attrs.directoryBrowser.selectedNode}" dynamic="true" styleClass="col-6">
           <p:ajax event="expand" listener="#{cc.attrs.directoryBrowser.onNodeExpand}" update="@form:tree" />
           <p:ajax event="select" update="@form:nodeAttrTable" />
-          <p:treeNode type="browserNode" icon="si si-#{cc.attrs.directoryBrowser.icon(node)}">
+          <p:treeNode type="browserNode" icon="#{cc.attrs.directoryBrowser.icon(node)}">
             <h:outputText value="#{node.displayName()}" />
           </p:treeNode>
           <p:treeNode type="nextPage">

--- a/engine-cockpit/webContent/resources/composite/DownloadDialog.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DownloadDialog.xhtml
@@ -12,7 +12,7 @@
     modal="true" responsive="true" closeOnEscape="true">
     <h:form id="downloadForm">
       <p:commandButton id="downloadBtn" ajax="false" value="#{ivy.cm.co('/common/Download')}"
-        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download');}"
+        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti ti-download');}"
         title="#{cc.attrs.title}" icon="ti ti-download" styleClass="modal-input-button" style="width: 150px;">
         <p:fileDownload value="#{cc.attrs.bean.allResourcesDownload}" />
       </p:commandButton>

--- a/engine-cockpit/webContent/resources/composite/DownloadDialog.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DownloadDialog.xhtml
@@ -12,8 +12,8 @@
     modal="true" responsive="true" closeOnEscape="true">
     <h:form id="downloadForm">
       <p:commandButton id="downloadBtn" ajax="false" value="#{ivy.cm.co('/common/Download')}"
-        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'si-download-bottom');}"
-        title="#{cc.attrs.title}" icon="si si-download-bottom" styleClass="modal-input-button" style="width: 150px;">
+        onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download');}"
+        title="#{cc.attrs.title}" icon="si ti-download" styleClass="modal-input-button" style="width: 150px;">
         <p:fileDownload value="#{cc.attrs.bean.allResourcesDownload}" />
       </p:commandButton>
       <p:commandButton id="cancel" onclick="PF('downloadModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"

--- a/engine-cockpit/webContent/resources/composite/DownloadDialog.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DownloadDialog.xhtml
@@ -13,7 +13,7 @@
     <h:form id="downloadForm">
       <p:commandButton id="downloadBtn" ajax="false" value="#{ivy.cm.co('/common/Download')}"
         onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download');}"
-        title="#{cc.attrs.title}" icon="si ti-download" styleClass="modal-input-button" style="width: 150px;">
+        title="#{cc.attrs.title}" icon="ti ti-download" styleClass="modal-input-button" style="width: 150px;">
         <p:fileDownload value="#{cc.attrs.bean.allResourcesDownload}" />
       </p:commandButton>
       <p:commandButton id="cancel" onclick="PF('downloadModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"

--- a/engine-cockpit/webContent/resources/composite/DynamicConfig.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DynamicConfig.xhtml
@@ -55,7 +55,7 @@
                     placeholder="#{property.defaultValue}" />
 
                   <p:commandButton id="testTlsConectionBtn"
-                    title="#{ivy.cm.co('/dynamicConfig/TLSConnectionTestButton')}" icon="si si-phone-actions-call" 
+                    title="#{ivy.cm.co('/dynamicConfig/TLSConnectionTestButton')}" icon="ti ti-phone-outgoing" 
                     actionListener="#{tlsTesterBean.testConnection(property.value)}"
                     oncomplete="PF('connectionTestModel').show()"
                     update="identityProvider:connectionTestModel"

--- a/engine-cockpit/webContent/resources/composite/DynamicConfig.xhtml
+++ b/engine-cockpit/webContent/resources/composite/DynamicConfig.xhtml
@@ -20,10 +20,10 @@
         <div class="card ui-fluid">
           <div class="card-header">
             <div class="card-title flex align-items-center">
-              <i class="pr-3 si si-information-circle"></i>
+              <i class="pr-3 ti ti-info-circle"></i>
               <h6 class="m-0">#{group.name}</h6>
 
-              <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk"
+              <p:commandButton title="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy"
                 id="save"
                 styleClass="flex-shrink-0 ml-auto ml-1 ui-button-success rounded-button"
                 rendered="#{!group.keyValue}"
@@ -36,7 +36,7 @@
                 oncomplete="PF('propertyKeyValueModal').show();"
                 process="@this"
                 update="identityProvider:dynamicConfigKeyValueForm"
-                title="#{ivy.cm.co('/common/Add')}" icon="si si-add"
+                title="#{ivy.cm.co('/common/Add')}" icon="ti ti-plus"
                 styleClass="flex-shrink-0 ml-auto rounded-button" />
 
             </div>
@@ -63,7 +63,7 @@
                     disabled="#{!tlsTesterBean.isLdaps(property.value)}" />
 
                   <p:commandButton id="browseDirectory"
-                    icon="si si-network-browser" title="#{ivy.cm.co('/common/Browse')}"
+                    icon="ti ti-browser" title="#{ivy.cm.co('/common/Browse')}"
                     actionListener="#{identityProviderBean.browseProperty(property)}"
                     oncomplete="PF('directoryBrowserDialog').show();"
                     update="directoryBrowser:directoryBrowserForm directoryBrowser:chooseDirectoryName"
@@ -74,7 +74,7 @@
                   <h:panelGroup id="usedByHelpString"
                     styleClass="label-help-icon"
                     rendered="#{property.hasSecondLine()}">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="@parent"
                       value="#{property.description}" position="top"
                       styleClass="pre-tooltip" />
@@ -99,7 +99,7 @@
                   <h:panelGroup id="usedByHelpPassword"
                     styleClass="label-help-icon"
                     rendered="#{property.hasSecondLine()}">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="@parent"
                       value="#{property.description}"
                       styleClass="pre-tooltip" position="top" />
@@ -119,7 +119,7 @@
                   <h:panelGroup id="usedByHelpBoolean"
                     styleClass="label-help-icon"
                     rendered="#{property.hasSecondLine()}">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="@parent"
                       value="#{property.description}"
                       styleClass="pre-tooltip" position="top" />
@@ -140,7 +140,7 @@
                   <h:panelGroup id="usedByHelpNumber"
                     styleClass="label-help-icon"
                     rendered="#{property.hasSecondLine()}">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="@parent"
                       value="#{property.description}"
                       styleClass="pre-tooltip" position="top" />
@@ -163,7 +163,7 @@
                   <h:panelGroup id="usedByHelpDropdown"
                     styleClass="label-help-icon"
                     rendered="#{property.hasSecondLine()}">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="@parent"
                       value="#{property.description}"
                       styleClass="pre-tooltip" position="top" />
@@ -193,13 +193,13 @@
                   <p:column styleClass="table-btn-2">
                     <p:commandButton id="editPropertyBtn"
                       actionListener="#{dynamicConfigListDialogBean.setProperty(property.getKeyValueProperty(), keyValue.key, keyValue.value)}"
-                      icon="si si-pencil" title="#{ivy.cm.co('/common/Edit')}"
+                      icon="ti ti-pencil" title="#{ivy.cm.co('/common/Edit')}"
                       styleClass="ui-button-secondary rounded-button"
                       oncomplete="PF('propertyKeyValueModal').show();"
                       process="@this"
                       update="identityProvider:dynamicConfigKeyValueForm" />
                     <p:commandButton id="deleteKeyValueBtn"
-                      type="button" icon="si si-bin-1" title="#{ivy.cm.co('/common/Delete')}"
+                      type="button" icon="ti ti-trash" title="#{ivy.cm.co('/common/Delete')}"
                       styleClass="ml-1 ui-button-danger rounded-button">
                       <p:ajax
                         listener="#{property.getKeyValueProperty().removeKeyValue(keyValue.key)}"
@@ -213,7 +213,7 @@
                     <h:panelGroup id="usedByHelpKeyValue"
                       styleClass="label-help-icon"
                       rendered="#{property.hasSecondLine()}">
-                      <i class="si si-question-circle"></i>
+                      <i class="ti ti-help-circle"></i>
                       <p:tooltip for="@parent"
                         value="#{property.description}"
                         styleClass="pre-tooltip" position="top" />
@@ -271,7 +271,7 @@
               requiredMessage="#{ivy.cm.co('/common/RequiredMessage')}" required="true"
               value="#{dynamicConfigListDialogBean.newValue}" />
             <p:commandButton id="browseDirectory"
-              icon="si si-network-browser" title="#{ivy.cm.co('/common/Browse')}"
+              icon="ti ti-browser" title="#{ivy.cm.co('/common/Browse')}"
               actionListener="#{identityProviderBean.browseBeanProperty(dynamicConfigListDialogBean)}"
               oncomplete="PF('directoryBrowserDialog').show();"
               rendered="#{dynamicConfigListDialogBean.isDirectoryBrowser()}"
@@ -292,7 +292,7 @@
         <p:commandButton id="savePropertyKeyAttribute"
           validateClient="true" ajax="false"
           actionListener="#{dynamicConfigListDialogBean.saveProp}"
-          value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk"
+          value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy"
           update="identityProvider:dynamicConfigForm"
           styleClass="modal-input-button" />
       </div>

--- a/engine-cockpit/webContent/resources/composite/Error.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Error.xhtml
@@ -9,7 +9,7 @@
 <cc:implementation>
   <h:panelGroup styleClass="flex justify-content-between #{cc.attrs.styleClass}">
     <h:outputText id="message" value="#{cc.attrs.error.message}" />
-    <p:commandButton id="showDetails" rendered="#{cc.attrs.error.available}" icon="si si-navigation-menu-horizontal" styleClass="ml-1 flex-shrink-0 rounded-button" title="#{ivy.cm.co('/error/ShowFullError')}" 
+    <p:commandButton id="showDetails" rendered="#{cc.attrs.error.available}" icon="ti ti-dots" styleClass="ml-1 flex-shrink-0 rounded-button" title="#{ivy.cm.co('/error/ShowFullError')}" 
         update="errorDialog" action="#{errorBean.setSelected(cc.attrs.error)}" oncomplete="PF('errorDialog').show();"/>
   </h:panelGroup>
 </cc:implementation>

--- a/engine-cockpit/webContent/resources/composite/EventBeanThreads.xhtml
+++ b/engine-cockpit/webContent/resources/composite/EventBeanThreads.xhtml
@@ -12,7 +12,7 @@
   <h:form id="eventBeanThreads">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-navigation-right-circle-1"></i>
+        <i class="pr-3 ti ti-circle-arrow-right"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/Threads')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/resources/composite/FeatureEditor.xhtml
+++ b/engine-cockpit/webContent/resources/composite/FeatureEditor.xhtml
@@ -14,21 +14,21 @@
 <cc:implementation>
   <p:commandButton id="editFeatureBtn"
     actionListener="#{cc.attrs.bean.setFeature(feature.clazz)}"
-    icon="si si-pencil" title="#{ivy.cm.co('/common/Edit')}" disabled="#{feature.default}"
+    icon="ti ti-pencil" title="#{ivy.cm.co('/common/Edit')}" disabled="#{feature.default}"
     update="@form" rendered="#{!cc.attrs.isNewFeature}"
     oncomplete="PF('featureModal').show();" process="@this" 
     styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
 
   <p:commandButton id="deleteFeatureBtn" disabled="#{feature.default}"
     actionListener="#{cc.attrs.bean.removeFeature(feature.clazz)}"
-    update="#{cc.attrs.formName}" icon="si si-bin-1" title="#{ivy.cm.co('/common/Delete')}"
+    update="#{cc.attrs.formName}" icon="ti ti-trash" title="#{ivy.cm.co('/common/Delete')}"
     rendered="#{!cc.attrs.isNewFeature}" process="@this"
     styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
 
   <p:commandButton id="newServiceFeatureBtn"
     oncomplete="PF('featureModal').show();" process="@this"
     actionListener="#{cc.attrs.bean.setFeature(null)}"
-    update="featureModal" title="#{ivy.cm.co('/common/Add')}" icon="si si-add"
+    update="featureModal" title="#{ivy.cm.co('/common/Add')}" icon="ti ti-plus"
     rendered="#{cc.attrs.isNewFeature}"
     styleClass="flex-shrink-0 ml-auto rounded-button" />
 
@@ -55,7 +55,7 @@
         <p:commandButton id="saveFeature" validateClient="true"
           onsuccess="PF('featureModal').hide()"
           action="#{cc.attrs.bean.saveFeature(cc.attrs.isNewFeature)}" value="#{ivy.cm.co('/common/Save')}"
-          icon="si si-floppy-disk" update="#{cc.attrs.formName}"
+          icon="ti ti-device-floppy" update="#{cc.attrs.formName}"
           styleClass="modal-input-button" process="@form" />
       </div>
     </h:form>

--- a/engine-cockpit/webContent/resources/composite/Firings.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Firings.xhtml
@@ -12,7 +12,7 @@
   <h:form id="eventFiring">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-navigation-right-circle-1"></i>
+        <i class="pr-3 ti ti-circle-arrow-right"></i>
         <h6 class="m-0">#{ivy.cm.co('/firings/Executions')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/resources/composite/HelpServiceDialog.xhtml
+++ b/engine-cockpit/webContent/resources/composite/HelpServiceDialog.xhtml
@@ -15,7 +15,7 @@
       </p:panelGrid>
       <div class="custom-dialog-footer" style="justify-content: space-between;">
         <a href="#{cc.attrs.service.helpUrl}" target="_blank" rel="noopener noreferrer">
-          <i class="text-2xl ti-help-circle"></i>
+          <i class="text-2xl ti ti-help-circle"></i>
         </a>
         <p:commandButton id="closeHelpServices" onclick="PF('helpServicesModal').hide();" value="#{ivy.cm.co('/common/Close')}" type="button"
           icon="ti ti-x" styleClass="ui-button-secondary modal-input-button" />

--- a/engine-cockpit/webContent/resources/composite/HelpServiceDialog.xhtml
+++ b/engine-cockpit/webContent/resources/composite/HelpServiceDialog.xhtml
@@ -15,10 +15,10 @@
       </p:panelGrid>
       <div class="custom-dialog-footer" style="justify-content: space-between;">
         <a href="#{cc.attrs.service.helpUrl}" target="_blank" rel="noopener noreferrer">
-          <i class="si si-xl si-question-circle"></i>
+          <i class="si si-xl ti-help-circle"></i>
         </a>
         <p:commandButton id="closeHelpServices" onclick="PF('helpServicesModal').hide();" value="#{ivy.cm.co('/common/Close')}" type="button"
-          icon="si si-close" styleClass="ui-button-secondary modal-input-button" />
+          icon="ti ti-x" styleClass="ui-button-secondary modal-input-button" />
       </div>
     </h:form>
   </p:dialog>

--- a/engine-cockpit/webContent/resources/composite/HelpServiceDialog.xhtml
+++ b/engine-cockpit/webContent/resources/composite/HelpServiceDialog.xhtml
@@ -15,7 +15,7 @@
       </p:panelGrid>
       <div class="custom-dialog-footer" style="justify-content: space-between;">
         <a href="#{cc.attrs.service.helpUrl}" target="_blank" rel="noopener noreferrer">
-          <i class="si si-xl ti-help-circle"></i>
+          <i class="text-2xl ti-help-circle"></i>
         </a>
         <p:commandButton id="closeHelpServices" onclick="PF('helpServicesModal').hide();" value="#{ivy.cm.co('/common/Close')}" type="button"
           icon="ti ti-x" styleClass="ui-button-secondary modal-input-button" />

--- a/engine-cockpit/webContent/resources/composite/Licence.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Licence.xhtml
@@ -14,7 +14,7 @@
   <h:form enctype="multipart/form-data" id="fileUploadForm">
     <div class="file-upload">
       <p:commandButton id="chooseFileBtn" value="#{ivy.cm.co('/licence/ChooseLicence')}" onclick="PF('uploadDnd').show();return false;"
-        icon="si si-add" styleClass="mb-2"/>
+        icon="ti ti-plus" styleClass="mb-2"/>
       <p:inputTextarea id="dropZone" styleClass="drop-zone" readonly="true"
         style="width: 100%; line-height: 100px; text-align: center; margin-bottom: 20px;"
         value="#{ivy.cm.co('/licence/ChooseLicencePlaceholder')}" rows="1" />

--- a/engine-cockpit/webContent/resources/composite/LogView.xhtml
+++ b/engine-cockpit/webContent/resources/composite/LogView.xhtml
@@ -9,7 +9,7 @@
   <p:panel id="logPanel" widgetVar="#{cc.attrs.log.fileName}">
     <f:facet name="header">
       <span onclick="PF('#{cc.attrs.log.fileName}').toggle()" style="cursor: pointer;" class="inline-flex">
-        <i class="si si-common-file-text table-icon panel-title-icon"/>
+        <i class="ti ti-file-text table-icon panel-title-icon"/>
         <h:outputText value="#{cc.attrs.log.fileName} (#{cc.attrs.log.size})" styleClass="ml-1" />
       </span>
     </f:facet>
@@ -17,12 +17,12 @@
       <h:form id="fileForm">
         <p:commandLink id="showLog" ajax="false" title="#{ivy.cm.co('/logs/OpenLog')}"
           styleClass="ui-panel-titlebar-icon ui-corner-all ui-state-default">
-          <i class="si si-expand-6"/>
+          <i class="ti ti-queue-pop-out"/>
           <p:fileDownload contentDisposition="inline" value="#{cc.attrs.log.file}" />
         </p:commandLink>
         <p:commandLink id="downloadLog" ajax="false" title="#{ivy.cm.co('/logs/DownloadLog')}" 
           styleClass="ui-panel-titlebar-icon ui-corner-all ui-state-default">
-          <i class="si si-download-bottom"/>
+          <i class="ti ti-download"/>
           <p:fileDownload value="#{cc.attrs.log.file}" />
         </p:commandLink>
       </h:form>

--- a/engine-cockpit/webContent/resources/composite/MonitorGraph.xhtml
+++ b/engine-cockpit/webContent/resources/composite/MonitorGraph.xhtml
@@ -11,7 +11,7 @@
     <div class="card">
       <div class="card-header">
         <div class="card-title flex align-items-center">
-          <i class="pr-3 si si-#{cc.attrs.monitor.icon}"></i>
+          <i class="pr-3 #{cc.attrs.monitor.icon}"></i>
           <h6 class="m-0">#{cc.attrs.monitor.title}</h6>
           <h:outputText class="pl-4 ml-auto" value="#{cc.attrs.monitor.info}" />
         </div>

--- a/engine-cockpit/webContent/resources/composite/Poll.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Poll.xhtml
@@ -11,9 +11,9 @@
     <h:form id="eventPoll">
       <div class="card-header">
         <div class="card-title flex align-items-center">
-          <i class="pr-3 si si-time-clock-circle"></i>
+          <i class="pr-3 ti ti-clock"></i>
           <h6 class="m-0">#{ivy.cm.co('/poll/Poll')}</h6>
-          <p:commandButton id="pollBtn" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/poll/ScheduleToPollBean')}" icon="si si-synchronize-arrow-clock"
+          <p:commandButton id="pollBtn" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/poll/ScheduleToPollBean')}" icon="ti ti-clock-play"
               update="polls" styleClass="flex-shrink-0 ml-auto rounded-button" />
         </div>
       </div>
@@ -47,7 +47,7 @@
         <p:staticMessage severity="warn" detail="#{ivy.cm.co('/poll/PollBeanWarningMessage')}"/>
         <div class="custom-dialog-footer">
           <p:commandButton id="cancel" type="button" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-          <p:commandButton id="pollBtn" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/poll/Poll')}" icon="si si-controls-play"
+          <p:commandButton id="pollBtn" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/poll/Poll')}" icon="ti ti-player-play"
               styleClass="modal-input-button" actionListener="#{cc.attrs.event.poll()}" update="polls:eventPoll"/>
         </div>
       </h:form>

--- a/engine-cockpit/webContent/resources/composite/PropertyEditor.xhtml
+++ b/engine-cockpit/webContent/resources/composite/PropertyEditor.xhtml
@@ -11,19 +11,19 @@
 <cc:implementation>
   <p:commandButton id="editPropertyBtn"
     actionListener="#{cc.attrs.bean.setProperty(property.name)}"
-    icon="si si-pencil" title="#{ivy.cm.co('/common/Edit')}"
+    icon="ti ti-pencil" title="#{ivy.cm.co('/common/Edit')}"
     update="propertyModal" rendered="#{!cc.attrs.isNewProperty}"
     styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button"
     oncomplete="PF('propertyModal').show();" process="@this" />
   <p:commandButton id="deletePropertyBtn" disabled="#{property.default}"
     actionListener="#{cc.attrs.bean.removeProperty(property.name)}"
-    update="#{cc.attrs.formName}" icon="si si-bin-1" title="#{ivy.cm.co('/common/Delete')}"
+    update="#{cc.attrs.formName}" icon="ti ti-trash" title="#{ivy.cm.co('/common/Delete')}"
     rendered="#{!cc.attrs.isNewProperty}" process="@this"
     styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" />
   <p:commandButton id="newServicePropertyBtn" 
     oncomplete="PF('propertyModal').show();" process="@this"
     actionListener="#{cc.attrs.bean.setProperty(null)}" update="propertyModal" 
-    title="#{ivy.cm.co('/common/Add')}" icon="si si-add" rendered="#{cc.attrs.isNewProperty}"
+    title="#{ivy.cm.co('/common/Add')}" icon="ti ti-plus" rendered="#{cc.attrs.isNewProperty}"
     styleClass="flex-shrink-0 ml-auto rounded-button" />
 
   <p:dialog header="#{ivy.cm.co('/common/Property')}" style="text-align: left;" id="propertyModal" widgetVar="propertyModal" modal="true"
@@ -60,7 +60,7 @@
         styleClass="ui-button-secondary ui-button-flat modal-input-button" immediate="true" />
       <p:commandButton id="saveProperty" validateClient="true" 
         onsuccess="PF('propertyModal').hide()" action="#{cc.attrs.bean.saveProperty(cc.attrs.isNewProperty)}" 
-        value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" update="#{cc.attrs.formName}"
+        value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" update="#{cc.attrs.formName}"
         styleClass="modal-input-button" process="@form" />
     </div>
   </h:form>

--- a/engine-cockpit/webContent/resources/composite/RestHistory.xhtml
+++ b/engine-cockpit/webContent/resources/composite/RestHistory.xhtml
@@ -10,7 +10,7 @@
   <h:form id="execHistoryForm" style="overflow: auto;">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-optimization-timer"></i>
+        <i class="pr-3 ti ti-calendar-clock"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/ExecutionHistory')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/resources/composite/SecurityReportDownloadDialog.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SecurityReportDownloadDialog.xhtml
@@ -24,7 +24,7 @@
           </h:panelGroup>
           <h:panelGroup>
             <p:commandButton id="generateButton" value="#{ivy.cm.co('/securityReportDownloadDialog/Generate')}" widgetVar="generateButton"
-              icon="si si-office-file-xls-1"
+              icon="ti ti-file-type-xls"
               disabled="#{cc.attrs.bean.disableGenerateButton}"
               action="#{cc.attrs.bean.startReport}"
               update="downloadForm"
@@ -35,7 +35,7 @@
           <h:panelGroup>
             <p:commandButton id="downloadButton" widgetVar="downloadButton" disabled="#{cc.attrs.bean.disableDownloadButton}"
               value="#{ivy.cm.co('/common/Download')}" title="#{ivy.cm.co('/common/Download')}"
-              icon="si si-download-bottom" styleClass="modal-input-button" style="width: 120px;" ajax="false" onclick="PF('securityReportDownloadModal').hide();">
+              icon="ti ti-download" styleClass="modal-input-button" style="width: 120px;" ajax="false" onclick="PF('securityReportDownloadModal').hide();">
               <p:fileDownload value="#{cc.attrs.bean.allResourcesDownload}" />
             </p:commandButton>
             <p:commandButton id="cancel" onclick="PF('securityReportDownloadModal').hide();" action="#{cc.attrs.bean.cancel}" value="#{ivy.cm.co('/common/Cancel')}" ajax="false"

--- a/engine-cockpit/webContent/resources/composite/SecuritySystemTabs.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SecuritySystemTabs.xhtml
@@ -12,7 +12,7 @@
     <p:ajax event="tabChange" listener="#{cc.attrs.tabChange}" update="@this #{cc.attrs.update}" />
     <p:tab title="#{securitySystem.securitySystemName}" titleStyleClass="security-system-tab">
       <f:facet name="title">
-        <i class="si si-lock-1 mr-1" />
+        <i class="ti ti-lock mr-1" />
         <h:outputText value="#{securitySystem.securitySystemName}" />
       </f:facet>
       <cc:insertChildren />

--- a/engine-cockpit/webContent/resources/composite/Sidebar.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Sidebar.xhtml
@@ -9,7 +9,7 @@
 
 <cc:implementation>
   <a href="#" id="layout-config-button" class="layout-config-button" onclick="PF('liveStatePoll').start();">
-    <i class="si si-#{cc.attrs.icon}"></i>
+    <i class="#{cc.attrs.icon}"></i>
   </a>
   
   <div id="layout-config" class="layout-config">

--- a/engine-cockpit/webContent/resources/composite/Sidebar.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Sidebar.xhtml
@@ -16,7 +16,7 @@
     <div class="layout-config-content">
       <div class="flex">
         <h3>#{ivy.cm.co('/sidebar/LiveStats')}</h3>
-        <p:commandButton icon="si si-remove" styleClass="ml-auto ui-button-danger ui-button-outlined rounded-button layout-config-close" 
+        <p:commandButton icon="ti ti-x" styleClass="ml-auto ui-button-danger ui-button-outlined rounded-button layout-config-close" 
           onclick="PF('liveStatePoll').stop(); $('#layout-config').toggleClass('layout-config-active');" type="button" />
       </div>
 

--- a/engine-cockpit/webContent/resources/composite/SoapHistory.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SoapHistory.xhtml
@@ -10,7 +10,7 @@
   <h:form id="execHistoryForm" style="overflow: auto;">
     <div class="card-header">
       <div class="card-title flex align-items-center">
-        <i class="pr-3 si si-optimization-timer"></i>
+        <i class="pr-3 ti ti-calendar-clock"></i>
         <h6 class="m-0">#{ivy.cm.co('/common/ExecutionHistory')}</h6>
       </div>
     </div>

--- a/engine-cockpit/webContent/resources/composite/SslTable.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SslTable.xhtml
@@ -93,7 +93,7 @@
         <p:column headerText="#{ivy.cm.co('/sslTable/ExpiryDate')}">
           <h:panelGroup id="valid">
             <i
-              class="si table-icon #{certificate.isValid() ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
+              class="table-icon #{certificate.isValid() ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
             <h:outputText value="#{certificate.cert.notAfter}"
               id="expiryDate"
               styleClass="#{certificate.isValid() ? '' : 'state-inactive'}" />

--- a/engine-cockpit/webContent/resources/composite/SslTable.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SslTable.xhtml
@@ -18,7 +18,7 @@
       </p:growl>
       <div class="card-header">
         <div class="card-title flex align-items-center">
-          <i class="pr-3 si si-information-circle"></i>
+          <i class="pr-3 ti ti-info-circle"></i>
           <h6 class="m-0">#{cc.attrs.title}</h6>
           <p:fileUpload id="certUpload" mode="simple" skinSimple="true"
             multiple="false" auto="true"
@@ -104,7 +104,7 @@
 
         <p:column styleClass="table-btn-1">
           <p:commandButton id="delete"
-            title="#{ivy.cm.co('/common/Delete')}" icon="si si-bin-1"
+            title="#{ivy.cm.co('/common/Delete')}" icon="ti ti-trash"
             styleClass="ui-button-danger rounded-button"
             actionListener="#{cc.attrs.bean.deleteCertificate(certificate.alias)}"
             update="@form">
@@ -124,7 +124,7 @@
         <p:commandButton id="deleteYesBtn"
           value="#{ivy.cm.co('/common/Delete')}" type="button"
           styleClass="ui-confirmdialog-yes modal-input-button"
-          icon="si si-bin-1" />
+          icon="ti ti-trash" />
       </p:confirmDialog>
 
     </h:form>

--- a/engine-cockpit/webContent/resources/composite/SslTable.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SslTable.xhtml
@@ -74,7 +74,7 @@
         value="#{cc.attrs.bean.certificats}" id="storeCertificates">
         <p:column headerText="#{ivy.cm.co('/sslTable/Alias')}">
             <i
-              class="si table-icon #{certificate.isPrivateKey() ? 'shield-globe' : 'single-neutral-shield'}" id="icon"/>
+              class="table-icon #{certificate.isPrivateKey() ? 'ti ti-shield' : 'ti ti-user-shield'}" id="icon"/>
           <h:outputText value="#{certificate.alias}" id="alias" />
           <p:tooltip for="alias"
           value="#{certificate.isPrivateKey() ? ivy.cm.co('/sslTable/PrivateKey') : ivy.cm.co('/sslTable/PublicKey')}" />
@@ -93,7 +93,7 @@
         <p:column headerText="#{ivy.cm.co('/sslTable/ExpiryDate')}">
           <h:panelGroup id="valid">
             <i
-              class="si table-icon #{certificate.isValid() ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+              class="si table-icon #{certificate.isValid() ? 'ti ti-circle-check state-active' : 'ti ti-circle-minus state-inactive'}" />
             <h:outputText value="#{certificate.cert.notAfter}"
               id="expiryDate"
               styleClass="#{certificate.isValid() ? '' : 'state-inactive'}" />

--- a/engine-cockpit/webContent/resources/composite/SslTable.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SslTable.xhtml
@@ -74,7 +74,7 @@
         value="#{cc.attrs.bean.certificats}" id="storeCertificates">
         <p:column headerText="#{ivy.cm.co('/sslTable/Alias')}">
             <i
-              class="si table-icon si-#{certificate.isPrivateKey() ? 'shield-globe' : 'single-neutral-shield'}" id="icon"/>
+              class="si table-icon #{certificate.isPrivateKey() ? 'shield-globe' : 'single-neutral-shield'}" id="icon"/>
           <h:outputText value="#{certificate.alias}" id="alias" />
           <p:tooltip for="alias"
           value="#{certificate.isPrivateKey() ? ivy.cm.co('/sslTable/PrivateKey') : ivy.cm.co('/sslTable/PublicKey')}" />
@@ -93,7 +93,7 @@
         <p:column headerText="#{ivy.cm.co('/sslTable/ExpiryDate')}">
           <h:panelGroup id="valid">
             <i
-              class="si table-icon si-#{certificate.isValid() ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
+              class="si table-icon #{certificate.isValid() ? 'check-circle-1 state-active' : 'remove-circle state-inactive'}" />
             <h:outputText value="#{certificate.cert.notAfter}"
               id="expiryDate"
               styleClass="#{certificate.isValid() ? '' : 'state-inactive'}" />

--- a/engine-cockpit/webContent/resources/composite/SslTable.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SslTable.xhtml
@@ -27,7 +27,7 @@
             update="@form" style="display: none;" />
           <p:commandButton
             title="#{ivy.cm.co('/sslTable/AddCertificate')}"
-            icon="si si-upload-bottom" type="button" id="Certbtn"
+            icon="ti ti-upload" type="button" id="Certbtn"
             styleClass="flex-shrink-0 ml-auto ml-1 mr-1 rounded-button"
             onclick="document.getElementById(this.id.replace(':Certbtn',':certUpload_input')).click(); return false;">
           </p:commandButton>

--- a/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
@@ -195,7 +195,7 @@
             oncomplete="PF('createDatabaseDialog').hide();" />
           <p:commandButton id="confirmCreateButton" value="#{ivy.cm.co('/common/SaveAndCreate')}"
             disabled="#{systemDatabaseBean.dbCreatorRunning}"
-            icon="#{systemDatabaseBean.dbCreatorRunning ? 'button-refresh-arrows spinning' : 'database-settings'}"
+            icon="#{systemDatabaseBean.dbCreatorRunning ? 'ti ti-refresh spinning' : 'ti ti-database-cog'}"
             actionListener="#{systemDatabaseBean.createDatabase}" style="width: 170px;" update="@form"
             styleClass="modal-input-button" />
         </h:panelGroup>

--- a/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
@@ -30,8 +30,8 @@
           <div>
             <p:commandButton value="#{ivy.cm.co('/systemDb/CheckConnection')}" id="checkConnectionButton"
               styleClass="mr-1 wizard-top-button"
-              onstart="$('#connectionIcon').attr('class', 'si si-button-refresh-arrows si-is-spinning');" async="true"
-              icon="si si-check-1" update="#{cc.attrs.updateFields}"
+              onstart="$('#connectionIcon').attr('class', 'ti ti-refresh spinning');" async="true"
+              icon="ti ti-check" update="#{cc.attrs.updateFields}"
               actionListener="#{systemDatabaseBean.testConnection()}" />
             <p:commandButton value="#{ivy.cm.co('/systemDb/CreateDatabase')}" id="createDatabaseButton" icon="si si-database-settings"
               styleClass="mr-1 wizard-top-button ui-button-secondary" actionListener="#{systemDatabaseBean.initCreator()}"
@@ -140,7 +140,7 @@
                 <p:commandButton id="removeAdditionalProperty"
                   actionListener="#{systemDatabaseBean.removeProp(property.key)}"
                   update="@form:additionalPropertiesTable,#{cc.attrs.updateFields}"
-                  icon="si si-bin-1"
+                  icon="ti ti-trash"
                   title="#{ivy.cm.co('/common/Delete')}"
                   styleClass="ui-button-danger rounded-button"
                   process="@this" />
@@ -148,7 +148,7 @@
             </p:dataTable>
             <p:commandButton id="newAdditionalPropertyBtn"
               actionListener="#{systemDatabaseBean.addProp()}"
-              icon="si si-add" title="#{ivy.cm.co('/systemDb/AddProperty')}"
+              icon="ti ti-plus" title="#{ivy.cm.co('/systemDb/AddProperty')}"
               update="systemDb:addAdditionalPropertyDialog"
               value="#{ivy.cm.co('/systemDb/AddProperty')}"
               styleClass="mt-2 ui-button-secondary"
@@ -195,12 +195,12 @@
             oncomplete="PF('createDatabaseDialog').hide();" />
           <p:commandButton id="confirmCreateButton" value="#{ivy.cm.co('/common/SaveAndCreate')}"
             disabled="#{systemDatabaseBean.dbCreatorRunning}"
-            icon="si si-#{systemDatabaseBean.dbCreatorRunning ? 'button-refresh-arrows si-is-spinning' : 'database-settings'}"
+            icon="si si-#{systemDatabaseBean.dbCreatorRunning ? 'button-refresh-arrows spinning' : 'database-settings'}"
             actionListener="#{systemDatabaseBean.createDatabase}" style="width: 170px;" update="@form"
             styleClass="modal-input-button" />
         </h:panelGroup>
         <h:panelGroup rendered="#{systemDatabaseBean.dbCreatorFinished}">
-          <p:commandButton id="closeCreationButton" value="#{ivy.cm.co('/systemDb/Connect')}" icon="si si-check-1"
+          <p:commandButton id="closeCreationButton" value="#{ivy.cm.co('/systemDb/Connect')}" icon="ti ti-check"
             actionListener="#{systemDatabaseBean.testConnection}" onclick="PF('createDatabaseDialog').hide();"
             update="#{cc.attrs.updateFields}" styleClass="modal-input-button" />
         </h:panelGroup>
@@ -231,7 +231,7 @@
           type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
         <p:commandButton id="saveProperty" validateClient="true"
           update="@form,systemDb:systemDbForm:additionalPropertiesTable,#{cc.attrs.updateFields}" actionListener="#{systemDatabaseBean.saveProp()}"
-          value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" styleClass="modal-input-button"
+          value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" styleClass="modal-input-button"
           oncomplete="if (!args.validationFailed) PF('addAdditionalPropertyDialog').hide();" />
       </div>
     </h:form>

--- a/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
@@ -33,7 +33,7 @@
               onstart="$('#connectionIcon').attr('class', 'ti ti-refresh spinning');" async="true"
               icon="ti ti-check" update="#{cc.attrs.updateFields}"
               actionListener="#{systemDatabaseBean.testConnection()}" />
-            <p:commandButton value="#{ivy.cm.co('/systemDb/CreateDatabase')}" id="createDatabaseButton" icon="si si-database-settings"
+            <p:commandButton value="#{ivy.cm.co('/systemDb/CreateDatabase')}" id="createDatabaseButton" icon="ti ti-database-cog"
               styleClass="mr-1 wizard-top-button ui-button-secondary" actionListener="#{systemDatabaseBean.initCreator()}"
               update="systemDb:createDatabaseDialog" oncomplete="PF('createDatabaseDialog').show();"
               disabled="#{!systemDatabaseBean.connectionInfo.mustCreate}" />

--- a/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
+++ b/engine-cockpit/webContent/resources/composite/SystemDb.xhtml
@@ -195,7 +195,7 @@
             oncomplete="PF('createDatabaseDialog').hide();" />
           <p:commandButton id="confirmCreateButton" value="#{ivy.cm.co('/common/SaveAndCreate')}"
             disabled="#{systemDatabaseBean.dbCreatorRunning}"
-            icon="si si-#{systemDatabaseBean.dbCreatorRunning ? 'button-refresh-arrows spinning' : 'database-settings'}"
+            icon="#{systemDatabaseBean.dbCreatorRunning ? 'button-refresh-arrows spinning' : 'database-settings'}"
             actionListener="#{systemDatabaseBean.createDatabase}" style="width: 170px;" update="@form"
             styleClass="modal-input-button" />
         </h:panelGroup>

--- a/engine-cockpit/webContent/resources/composite/TableFilter.xhtml
+++ b/engine-cockpit/webContent/resources/composite/TableFilter.xhtml
@@ -20,7 +20,7 @@
           onclick="PF('filterPanel').hide();" type="button" />
         <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
           update="#{cc.attrs.update}" actionListener="#{cc.attrs.bean.resetSelectedContentFilters()}" />
-        <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="si si-check-1"
+        <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
           update="#{cc.attrs.update}" />
       </h:panelGroup>
     </h:form>

--- a/engine-cockpit/webContent/resources/composite/TableFilter.xhtml
+++ b/engine-cockpit/webContent/resources/composite/TableFilter.xhtml
@@ -18,7 +18,7 @@
       <h:panelGroup layout="block" styleClass="mt-1 flex justify-content-end">
         <p:commandButton id="cancelFilter" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-flat ui-button-secondary modal-input-button"
           onclick="PF('filterPanel').hide();" type="button" />
-        <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
+        <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="ti ti-circle-x"
           update="#{cc.attrs.update}" actionListener="#{cc.attrs.bean.resetSelectedContentFilters()}" />
         <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check"
           update="#{cc.attrs.update}" />

--- a/engine-cockpit/webContent/resources/composite/TopBarItem.xhtml
+++ b/engine-cockpit/webContent/resources/composite/TopBarItem.xhtml
@@ -6,7 +6,7 @@
 <cc:interface>
   <cc:attribute name="styleClass" default="help-link"/>
   <cc:attribute name="href" default="#{advisorBean.cockpitEngineGuideUrl}" />
-  <cc:attribute name="icon" default="ti-help-circle" />
+  <cc:attribute name="icon" default="ti ti-help-circle" />
   <cc:attribute name="title" default="#{ivy.cm.co('/topBarItem/Help')}" />
   <cc:attribute name="external" default="true" />
 </cc:interface>
@@ -16,7 +16,7 @@
        target="#{cc.attrs.external ? '_blank' : ''}" 
        rel="#{cc.attrs.external ? 'noopener noreferrer' : ''}" 
        title="#{cc.attrs.title}">
-      <i class="topbar-icon si #{cc.attrs.icon}"></i>
+      <i class="topbar-icon #{cc.attrs.icon}"></i>
     </a>
   </li>
 </cc:implementation>

--- a/engine-cockpit/webContent/resources/composite/TopBarItem.xhtml
+++ b/engine-cockpit/webContent/resources/composite/TopBarItem.xhtml
@@ -6,7 +6,7 @@
 <cc:interface>
   <cc:attribute name="styleClass" default="help-link"/>
   <cc:attribute name="href" default="#{advisorBean.cockpitEngineGuideUrl}" />
-  <cc:attribute name="icon" default="si-question-circle" />
+  <cc:attribute name="icon" default="ti-help-circle" />
   <cc:attribute name="title" default="#{ivy.cm.co('/topBarItem/Help')}" />
   <cc:attribute name="external" default="true" />
 </cc:interface>

--- a/engine-cockpit/webContent/resources/composite/UserSynch.xhtml
+++ b/engine-cockpit/webContent/resources/composite/UserSynch.xhtml
@@ -28,7 +28,7 @@
         styleClass="ui-button-secondary ui-button-flat modal-input-button" immediate="true">
       <p:resetInput target="@form" />
       <p:commandButton id="synchUserVar" validateClient="true" actionListener="#{cc.attrs.userSynch.synch}" value="#{ivy.cm.co('/userSynch/Synch')}"
-        icon="si si-button-refresh-arrows" styleClass="modal-input-button" update="@form" />
+        icon="ti ti-refresh" styleClass="modal-input-button" update="@form" />
       </p:commandButton>
     </div>
   </h:form>

--- a/engine-cockpit/webContent/resources/css/engine-cockpit.css
+++ b/engine-cockpit/webContent/resources/css/engine-cockpit.css
@@ -627,3 +627,12 @@ body .ui-tooltip .ui-panelgrid .ui-panelgrid-cell {
 .layout-wrapper .layout-topbar .layout-topbar-wrapper .layout-topbar-right .layout-topbar-actions > li.health-messages > ul {
   min-width: 350px;
 }
+
+/* Tabler Icons */
+.spinning {
+  animation: icon-spin 2s linear infinite reverse;
+}
+
+@keyframes icon-spin {
+  to { transform: rotate(360deg); }
+}

--- a/engine-cockpit/webContent/resources/css/engine-cockpit.css
+++ b/engine-cockpit/webContent/resources/css/engine-cockpit.css
@@ -209,7 +209,7 @@ body .ui-dialog.ui-confirm-dialog .ui-dialog-content {
 }
 
 /* Icons */
-.si.link-icon {
+.ti.link-icon {
   margin-right: 5px;
   position: relative;
   top: 2px;
@@ -326,12 +326,12 @@ body .ui-datatable thead th[class*="table-btn"] {
 }
 
 /* Search Engine */
-.si.icon-bold {
+.ti.icon-bold {
   font-weight: bold;
   font-size: 24px;
 }
 
-.si.state-icon {
+.ti.state-icon {
   position: relative;
   top: 3px;
   font-size: 1.2em;

--- a/engine-cockpit/webContent/resources/css/engine-cockpit.css
+++ b/engine-cockpit/webContent/resources/css/engine-cockpit.css
@@ -108,7 +108,7 @@ body .user-avatar > img {
   width: 100%; height: 33px;
 }
 .card .card-title-icon, 
-.card .card-title > .si {
+.card .card-title > .ti {
   font-size: 1.4em;
 }
 .grey-label-panel .ui-panelgrid-cell:nth-child(odd) > label {
@@ -185,7 +185,7 @@ body .ui-dialog.ui-confirm-dialog .ui-dialog-content {
   display: flex;
   font-size: medium;
 }
-.deploy-status .si {
+.deploy-status .ti {
   margin-right: 5px;
   top: 2px;
 }

--- a/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
+++ b/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
@@ -22,7 +22,7 @@
       styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
       <h:outputText value="#{logEntry.group}" />
       <h:panelGroup id="info">
-        <i class="si si-question-circle" />
+        <i class="ti ti-help-circle" />
         <p:tooltip for="info" value="#{logEntry.groupInfo}" />
       </h:panelGroup>
     </p:column>
@@ -35,7 +35,7 @@
         <p:column style="border:0px;" width="1em">
           <h:outputText value="#{logDataEntry.message()}" />
           <h:panelGroup id="infos" rendered="#{logDataEntry.extendedInformation() != null}">
-            <i class="si si-question-circle" />
+            <i class="ti ti-help-circle" />
             <p:tooltip for="infos">
               <h:panelGrid columns="1">
                 <h:outputText value="#{ivy.cm.co('/tlsTester/Issuer')}: #{logDataEntry.extendedInformation().issuer()}" />

--- a/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
+++ b/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
@@ -27,7 +27,7 @@
       </h:panelGroup>
     </p:column>
     <p:column width="2rem" styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
-      <h:outputText class="table-icon {tlsTesterBean.icon(logEntry.result)}"/>
+      <h:outputText class="table-icon #{tlsTesterBean.icon(logEntry.result)}"/>
     </p:column>
     <p:rowExpansion>
       <p:dataTable var="logDataEntry" styleClass="noHeader" value="#{logEntry.entryList}"

--- a/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
+++ b/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
@@ -27,7 +27,7 @@
       </h:panelGroup>
     </p:column>
     <p:column width="2rem" styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
-      <h:outputText class="si table-icon si-#{tlsTesterBean.icon(logEntry.result)}"/>
+      <h:outputText class="ti table-icon ti-#{tlsTesterBean.icon(logEntry.result)}"/>
     </p:column>
     <p:rowExpansion>
       <p:dataTable var="logDataEntry" styleClass="noHeader" value="#{logEntry.entryList}"

--- a/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
+++ b/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTester.xhtml
@@ -27,7 +27,7 @@
       </h:panelGroup>
     </p:column>
     <p:column width="2rem" styleClass="tls-tester-result-column #{tlsTesterBean.backgroundColor(logEntry.result)}">
-      <h:outputText class="ti table-icon ti-#{tlsTesterBean.icon(logEntry.result)}"/>
+      <h:outputText class="table-icon {tlsTesterBean.icon(logEntry.result)}"/>
     </p:column>
     <p:rowExpansion>
       <p:dataTable var="logDataEntry" styleClass="noHeader" value="#{logEntry.entryList}"

--- a/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTesterMissingCertView.xhtml
+++ b/engine-cockpit/webContent/resources/demo-jsfcomponents/TlsTesterMissingCertView.xhtml
@@ -17,7 +17,7 @@
     <h6>#{ivy.cm.co('/tlsTesterMissingCertView/MissingCert')}</h6>
     <p:rowToggler/>
     <h:outputText id="subject" value="#{cc.attrs.cert.subjectX500Principal}"></h:outputText>
-    <p:commandButton id="add" value="#{ivy.cm.co('/tlsTesterMissingCertView/AddToTruststore')}" icon="si si-add"
+    <p:commandButton id="add" value="#{ivy.cm.co('/tlsTesterMissingCertView/AddToTruststore')}" icon="ti ti-plus"
       styleClass="modal-input-button" 
       actionListener="#{trustStoreBean.addToStore(cc.attrs.cert)}"
       action="#{cc.attrs.bean.clearMissingCert()}"

--- a/engine-cockpit/webContent/resources/js/copyToClipboard.js
+++ b/engine-cockpit/webContent/resources/js/copyToClipboard.js
@@ -3,11 +3,11 @@ function copyToClipboard(content, button) {
     navigator.clipboard.writeText(content);
     if (button) {
       const icon = $(button).find('.ui-icon');
-      icon.removeClass('si-copy-paste')
-      icon.addClass('si-check-1');
+      icon.removeClass('ti-copy')
+      icon.addClass('ti-check');
       setTimeout(() => {
-        icon.removeClass('si-check-1');
-        icon.addClass('si-copy-paste')
+        icon.removeClass('ti-check');
+        icon.addClass('ti-copy')
       }, 1000);
     }
   } catch {

--- a/engine-cockpit/webContent/resources/js/copyToClipboard.js
+++ b/engine-cockpit/webContent/resources/js/copyToClipboard.js
@@ -3,11 +3,11 @@ function copyToClipboard(content, button) {
     navigator.clipboard.writeText(content);
     if (button) {
       const icon = $(button).find('.ui-icon');
-      icon.removeClass('ti-copy')
-      icon.addClass('ti-check');
+      icon.removeClass('ti ti-copy')
+      icon.addClass('ti ti-check');
       setTimeout(() => {
-        icon.removeClass('ti-check');
-        icon.addClass('ti-copy')
+        icon.removeClass('ti ti-check');
+        icon.addClass('ti ti-copy')
       }, 1000);
     }
   } catch {

--- a/engine-cockpit/webContent/resources/js/engine-cockpit.js
+++ b/engine-cockpit/webContent/resources/js/engine-cockpit.js
@@ -5,14 +5,14 @@ function buttonAddSpinner(button) {
   $(button).addClass('ui-state-disabled');
   var icon = $(button).find('.ui-icon');
   icon.removeClass(function (index, css) {
-    return (css.match(/(^|\s)si-\S+/g) || []).join(' '); // removes anything that starts with "si-"
+    return (css.match(/(^|\s)ti ti-\S+/g) || []).join(' '); // removes anything that starts with "ti ti-"
   });
-  $(icon).addClass('ti-refresh spinning');
+  $(icon).addClass('ti ti-refresh spinning');
 }
 
 function buttonRemoveSpinner(button, defaultIcon) {
   var icon = $(button).find('.ui-icon')
-  $(icon).removeClass('ti-refresh spinning');
+  $(icon).removeClass('ti ti-refresh spinning');
   $(icon).addClass(defaultIcon);
   $(button).removeClass('ui-state-disabled');
 }

--- a/engine-cockpit/webContent/resources/js/engine-cockpit.js
+++ b/engine-cockpit/webContent/resources/js/engine-cockpit.js
@@ -7,12 +7,12 @@ function buttonAddSpinner(button) {
   icon.removeClass(function (index, css) {
     return (css.match(/(^|\s)si-\S+/g) || []).join(' '); // removes anything that starts with "si-"
   });
-  $(icon).addClass('si-button-refresh-arrows si-is-spinning');
+  $(icon).addClass('ti-refresh spinning');
 }
 
 function buttonRemoveSpinner(button, defaultIcon) {
   var icon = $(button).find('.ui-icon')
-  $(icon).removeClass('si-button-refresh-arrows si-is-spinning');
+  $(icon).removeClass('ti-refresh spinning');
   $(icon).addClass(defaultIcon);
   $(button).removeClass('ui-state-disabled');
 }

--- a/engine-cockpit/webContent/view/admins.xhtml
+++ b/engine-cockpit/webContent/view/admins.xhtml
@@ -21,19 +21,19 @@
       </p:growl>
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-single-neutral-shield card-title-icon"></i>
+          <i class="pr-3 ti ti-lock-square-rounded card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Administrators')}</h2>
           <h:form id="addAdminForm" styleClass="ml-auto">
             <p:splitButton value="#{ivy.cm.co('/common/Add')}"
-                icon="si si-add" title="#{ivy.cm.co('/admins/AddAdministrator')}"
+                icon="ti ti-plus" title="#{ivy.cm.co('/admins/AddAdministrator')}"
                 id="newAdminBtn" oncomplete="PF('editAdminDialog').show();"
                 process="@this" actionListener="#{administratorBean.addAdmin()}" update="admins:editAdminDialog">
-             <p:menuitem id="configure" value="#{ivy.cm.co('/common/Configuration')}" icon="si si-cog"
+             <p:menuitem id="configure" value="#{ivy.cm.co('/common/Configuration')}" icon="ti ti-settings"
                   onclick="window.location.href='#{administratorBean.configurationUri}'" />
-             <p:menuitem id="synch" value="#{ivy.cm.co('/common/Synchronize')}" icon="si si-button-refresh-arrows #{administratorBean.syncRunning ? 'si-is-spinning' : ''} spin-icon"
+             <p:menuitem id="synch" value="#{ivy.cm.co('/common/Synchronize')}" icon="ti ti-refresh #{administratorBean.syncRunning ? 'spinning' : ''} spin-icon"
                   immediate="true" process="@this" actionListener="#{administratorBean.triggerSynch()}" update="@parent"
                   rendered="#{administratorBean.hasIdentityProvider()}" />
-             <p:menuitem id="userSyncLog" value="#{ivy.cm.co('/common/SynchronizationLog')}" icon="si si-common-file-text"
+             <p:menuitem id="userSyncLog" value="#{ivy.cm.co('/common/SynchronizationLog')}" icon="ti ti-file-text"
                   rendered="#{administratorBean.hasIdentityProvider()}"
                   onclick="window.location.href='#{administratorBean.synchLogUri}'" />
             </p:splitButton>

--- a/engine-cockpit/webContent/view/application-detail.xhtml
+++ b/engine-cockpit/webContent/view/application-detail.xhtml
@@ -23,7 +23,7 @@
     </ui:define>
     
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="config-link" href="#{managerBean.configLogUrl}" icon="si-common-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
+      <cc:TopBarItem styleClass="config-link" href="#{managerBean.configLogUrl}" icon="ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}applications.html#application-detail" />
     </ui:define>
 
@@ -34,9 +34,9 @@
             <div class="grid">
               <cc:OverviewBox box="white" count="#{applicationDetailBean.sessionCount}" icon="si si-style-two-pin-user"
                 title="#{ivy.cm.co('/common/Sessions')}" link="users.xhtml" />
-              <cc:OverviewBox box="blue" count="#{applicationDetailBean.usersCount}" icon="si si-single-neutral-actions"
+              <cc:OverviewBox box="blue" count="#{applicationDetailBean.usersCount}" icon="ti ti-user-check"
                 title="#{ivy.cm.co('/common/Users')}" link="users.xhtml" />
-              <cc:OverviewBox box="gray" count="#{applicationDetailBean.casesCount}" icon="si si-layout-bullets"
+              <cc:OverviewBox box="gray" count="#{applicationDetailBean.casesCount}" icon="ti ti-list"
                 title="#{ivy.cm.co('/common/RunningCases')}" link="#" />
               <cc:OverviewBox box="darkgray" count="#{applicationDetailBean.pmCount}" icon="si si-module-three-2"
                 title="#{ivy.cm.co('/applicationDetail/ProcessModels')}" link="#" />

--- a/engine-cockpit/webContent/view/application-detail.xhtml
+++ b/engine-cockpit/webContent/view/application-detail.xhtml
@@ -23,7 +23,7 @@
     </ui:define>
     
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="config-link" href="#{managerBean.configLogUrl}" icon="ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
+      <cc:TopBarItem styleClass="config-link" href="#{managerBean.configLogUrl}" icon="ti ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}applications.html#application-detail" />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/application-detail.xhtml
+++ b/engine-cockpit/webContent/view/application-detail.xhtml
@@ -32,13 +32,13 @@
         <div class="grid">
           <div class="col-12">
             <div class="grid">
-              <cc:OverviewBox box="white" count="#{applicationDetailBean.sessionCount}" icon="si si-style-two-pin-user"
+              <cc:OverviewBox box="white" count="#{applicationDetailBean.sessionCount}" icon="ti ti-user-pin"
                 title="#{ivy.cm.co('/common/Sessions')}" link="users.xhtml" />
               <cc:OverviewBox box="blue" count="#{applicationDetailBean.usersCount}" icon="ti ti-user-check"
                 title="#{ivy.cm.co('/common/Users')}" link="users.xhtml" />
               <cc:OverviewBox box="gray" count="#{applicationDetailBean.casesCount}" icon="ti ti-list"
                 title="#{ivy.cm.co('/common/RunningCases')}" link="#" />
-              <cc:OverviewBox box="darkgray" count="#{applicationDetailBean.pmCount}" icon="si si-module-three-2"
+              <cc:OverviewBox box="darkgray" count="#{applicationDetailBean.pmCount}" icon="ti ti-packages"
                 title="#{ivy.cm.co('/applicationDetail/ProcessModels')}" link="#" />
             </div>
           </div>

--- a/engine-cockpit/webContent/view/applications.xhtml
+++ b/engine-cockpit/webContent/view/applications.xhtml
@@ -18,7 +18,7 @@
         <h:form id="form" onkeypress="if (event.keyCode == 13) return false;">
           <p:growl for="applicationMessage" id="applicationMessage" showDetail="true" />
           <div class="flex align-items-center mb-3">
-            <i class="pr-3 si si-layout-module card-title-icon"></i>
+            <i class="pr-3 ti ti-layout-grid card-title-icon"></i>
             <h2 class="m-0">#{ivy.cm.co('/common/Applications')}</h2>
             <p:commandButton styleClass="ml-auto" id="createApplicationBtn" widgetVar="createApplication" icon="ti ti-plus"
               value="#{ivy.cm.co('/common/Add')}" onclick="PF('newApplicationModal').show();" type="button" />
@@ -68,7 +68,7 @@
 
             <p:column styleClass="table-btn-5">              
               <h:panelGroup id="deployBtnHint">
-                <p:commandButton title="#{ivy.cm.co('/common/Deployment')}" icon="si si-upload-bottom" rendered="#{activity.app}"
+                <p:commandButton title="#{ivy.cm.co('/common/Deployment')}" icon="ti ti-upload" rendered="#{activity.app}"
                   id="deployBtn" styleClass="mr-1 rounded-button" actionListener="#{deploymentBean.setAppNameAndVersion(activity.name, activity.version)}">
                   <p:ajax update="deployPanel" listener="#{applicationBean.setActiveActivity(activity)}"
                     oncomplete="PF('fileUploadModal').show()" />
@@ -90,7 +90,7 @@
                 type="button" styleClass="mr-1 ui-button-success rounded-button">
                 <p:ajax update="form" listener="#{activity.activate}" />
               </p:commandButton>
-              <p:commandButton title="#{ivy.cm.co('/common/Deactivate')}" id="deactivateButton" icon="si si-controls-stop" rendered="#{activity.app}" disabled="#{activity.notStopable}"
+              <p:commandButton title="#{ivy.cm.co('/common/Deactivate')}" id="deactivateButton" icon="ti ti-player-stop" rendered="#{activity.app}" disabled="#{activity.notStopable}"
                 type="button" styleClass="mr-1 ui-button-danger rounded-button">
                 <p:ajax update="form" listener="#{activity.deactivate}" />
               </p:commandButton>
@@ -100,7 +100,7 @@
               <p:menu overlay="true" trigger="tasksButton" my="right top" at="right bottom" id="activityMenu">
                 <p:menuitem value="#{ivy.cm.co('/common/Lock')}" icon="ti ti-lock" rendered="#{activity.app}" disabled="#{activity.notLockable}"
                   actionListener="#{activity.lock}" update="form" />
-                <p:menuitem value="#{ivy.cm.co('/applications/ReleaseButtonTitle')}" rendered="#{activity.app}" icon="si si-heavy-equipment-hook"
+                <p:menuitem value="#{ivy.cm.co('/applications/ReleaseButtonTitle')}" rendered="#{activity.app}" icon="ti ti-crane"
                   disabled="#{!activity.releasable}" actionListener="#{activity.release}" update="form" />
                 <p:menuitem id="deleteBtn" value="#{ivy.cm.co('/common/Delete')}" icon="ti ti-trash" disabled="#{not empty activity.isDeletable()}"
                   actionListener="#{applicationBean.setActiveActivity(activity)}"

--- a/engine-cockpit/webContent/view/applications.xhtml
+++ b/engine-cockpit/webContent/view/applications.xhtml
@@ -20,20 +20,20 @@
           <div class="flex align-items-center mb-3">
             <i class="pr-3 si si-layout-module card-title-icon"></i>
             <h2 class="m-0">#{ivy.cm.co('/common/Applications')}</h2>
-            <p:commandButton styleClass="ml-auto" id="createApplicationBtn" widgetVar="createApplication" icon="si si-add"
+            <p:commandButton styleClass="ml-auto" id="createApplicationBtn" widgetVar="createApplication" icon="ti ti-plus"
               value="#{ivy.cm.co('/common/Add')}" onclick="PF('newApplicationModal').show();" type="button" />
           </div>
           <div class="table-search flex ui-fluid">
             <span class="ui-input-icon-left filter-container">
-              <i class="pi pi-search"/>
+              <i class="ti ti-search"/>
               <p:inputText id="globalFilter" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{applicationBean.filter}">
                 <p:ajax event="keyup" delay="300" update="@form:tree" />
               </p:inputText>
             </span>
-            <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
+            <p:commandButton id="expandAll" icon="ti ti-arrows-vertical"
               actionListener="#{applicationBean.expandAllNodes}" update="tree" title="#{ivy.cm.co('/common/ExpandAll')}"
               styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
-            <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
+            <p:commandButton id="collapseAll" icon="ti ti-arrows-minimize"
               actionListener="#{applicationBean.collapseAllNodes}" update="tree" title="#{ivy.cm.co('/common/CollapseAll')}"
               styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
           </div>
@@ -76,7 +76,7 @@
               </h:panelGroup>
               
               <p:commandButton id="convertButton"
-                icon="si si-button-refresh-arrows" 
+                icon="ti ti-refresh" 
                 actionListener="#{applicationBean.setActiveActivity(activity)}"
                 rendered="#{activity.canConvert()}"
                 update="form:convertDialog"
@@ -86,7 +86,7 @@
                 styleClass="mr-1 ui-button-danger rounded-button">
               </p:commandButton>              
                
-              <p:commandButton title="#{ivy.cm.co('/common/Activate')}" icon="si si-controls-play" rendered="#{activity.app}" disabled="#{activity.notStartable}"
+              <p:commandButton title="#{ivy.cm.co('/common/Activate')}" icon="ti ti-player-play" rendered="#{activity.app}" disabled="#{activity.notStartable}"
                 type="button" styleClass="mr-1 ui-button-success rounded-button">
                 <p:ajax update="form" listener="#{activity.activate}" />
               </p:commandButton>
@@ -95,18 +95,18 @@
                 <p:ajax update="form" listener="#{activity.deactivate}" />
               </p:commandButton>
               
-              <p:commandButton title="#{ivy.cm.co('/common/More')}" id="tasksButton" type="button" icon="si si-navigation-menu"
+              <p:commandButton title="#{ivy.cm.co('/common/More')}" id="tasksButton" type="button" icon="ti ti-menu-2"
                 styleClass="mr-1 ui-button-secondary rounded-button ui-button-outlined" />
               <p:menu overlay="true" trigger="tasksButton" my="right top" at="right bottom" id="activityMenu">
-                <p:menuitem value="#{ivy.cm.co('/common/Lock')}" icon="si si-lock-1" rendered="#{activity.app}" disabled="#{activity.notLockable}"
+                <p:menuitem value="#{ivy.cm.co('/common/Lock')}" icon="ti ti-lock" rendered="#{activity.app}" disabled="#{activity.notLockable}"
                   actionListener="#{activity.lock}" update="form" />
                 <p:menuitem value="#{ivy.cm.co('/applications/ReleaseButtonTitle')}" rendered="#{activity.app}" icon="si si-heavy-equipment-hook"
                   disabled="#{!activity.releasable}" actionListener="#{activity.release}" update="form" />
-                <p:menuitem id="deleteBtn" value="#{ivy.cm.co('/common/Delete')}" icon="si si-bin-1" disabled="#{not empty activity.isDeletable()}"
+                <p:menuitem id="deleteBtn" value="#{ivy.cm.co('/common/Delete')}" icon="ti ti-trash" disabled="#{not empty activity.isDeletable()}"
                   actionListener="#{applicationBean.setActiveActivity(activity)}"
                   update="form:deleteConfirmDialog" oncomplete="PF('deleteConfirmDialog').show();"
                   title="#{activity.notDeletableMessage}" style="pointer-events: all;" />
-                <p:menuitem id="forceDeleteBtn" value="#{ivy.cm.co('/applications/ForceDeleteButtonTitle')}" rendered="#{activity.app and not empty activity.isDeletable()}" icon="si si-bin-1"
+                <p:menuitem id="forceDeleteBtn" value="#{ivy.cm.co('/applications/ForceDeleteButtonTitle')}" rendered="#{activity.app and not empty activity.isDeletable()}" icon="ti ti-trash"
                   actionListener="#{applicationBean.setActiveActivity(activity)}"
                   update="form:deleteConfirmDialog" oncomplete="PF('deleteConfirmDialog').show();" />
               </p:menu>
@@ -126,9 +126,9 @@
             <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('deleteConfirmDialog').hide();" type="button"
               styleClass="ui-button-secondary ui-button-flat modal-input-button" />
             <p:commandButton id="deleteConfirmYesBtn" value="#{ivy.cm.co('/common/Delete')}" immediate="true" styleClass="modal-input-button"
-              actionListener="#{applicationBean.activeActivity.delete}" update="form" icon="si si-bin-1" rendered="#{not isForceDelete}" />
+              actionListener="#{applicationBean.activeActivity.delete}" update="form" icon="ti ti-trash" rendered="#{not isForceDelete}" />
             <p:commandButton id="foreceDeleteConfirmYesBtn" value="#{ivy.cm.co('/applications/ForceDeleteButtonTitle')}" immediate="true" styleClass="modal-input-button"
-              actionListener="#{applicationBean.activeActivity.forceDelete}" update="form" icon="si si-bin-1" rendered="#{isForceDelete}" />
+              actionListener="#{applicationBean.activeActivity.forceDelete}" update="form" icon="ti ti-trash" rendered="#{isForceDelete}" />
           </p:confirmDialog>
 
           <p:confirmDialog id="convertDialog"
@@ -150,10 +150,10 @@
             </f:facet>
 
             <p:commandButton id="convertConfirmYesBtn" widgetVar="convertConfirmYesBtn" value="#{ivy.cm.co('/applications/Convert')}" styleClass="modal-input-button" disabled="#{applicationBean.activeActivity.notConvertable}"
-              actionListener="#{applicationBean.activeActivity.convert}" update="conversionLog convertConfirmYesBtn" oncomplete="PF('convertConfirmYesBtn').disable();PF('convertFinishBtn').enable();" icon="si si-button-refresh-arrows" />
+              actionListener="#{applicationBean.activeActivity.convert}" update="conversionLog convertConfirmYesBtn" oncomplete="PF('convertConfirmYesBtn').disable();PF('convertFinishBtn').enable();" icon="ti ti-refresh" />
 
             <p:commandButton id="convertFinishBtn" widgetVar="convertFinishBtn" value="#{ivy.cm.co('/common/Finish')}" styleClass="modal-input-button" disabled="true"
-              update="conversionLog convertConfirmYesBtn" oncomplete="PF('convertDialog').hide();reloadTree();" icon="si si-check-circle-1" />
+              update="conversionLog convertConfirmYesBtn" oncomplete="PF('convertDialog').hide();reloadTree();" icon="ti ti-circle-check" />
           </p:confirmDialog>
         </h:form>
         <ui:include src="../includes/dialogs/newapplication.xhtml" />

--- a/engine-cockpit/webContent/view/applications.xhtml
+++ b/engine-cockpit/webContent/view/applications.xhtml
@@ -45,7 +45,7 @@
               <h:outputLink rendered="#{activity.detailView != '#'}" value="#{activity.detailView}">
                 <h:outputText value="#{activity.displayName}" styleClass="activity-name"
                   title="#{activity.activityType} #{activity.displayName}">
-                  <i class="si si-#{activity.icon} table-icon" title="#{activity.activityType}" />
+                  <i class="#{activity.icon} table-icon" title="#{activity.activityType}" />
                 </h:outputText>
               </h:outputLink>
               <h:outputText rendered="#{activity.pmv}"
@@ -57,7 +57,7 @@
             <p:column headerText="#{ivy.cm.co('/common/State')}" responsivePriority="2" style="text-align: center; width: 50px;">
               <h:panelGroup styleClass="module-state">
                   <h:outputText rendered="#{activity.app}">
-                <i class="ml-2 si si-#{activity.releaseStateIcon} table-icon" title="#{activity.releaseState}"></i>
+                <i class="ml-2 #{activity.releaseStateIcon} table-icon" title="#{activity.releaseState}"></i>
               </h:outputText>
               </h:panelGroup>
             </p:column>

--- a/engine-cockpit/webContent/view/branding.xhtml
+++ b/engine-cockpit/webContent/view/branding.xhtml
@@ -45,7 +45,7 @@
             <div class="custom-dialog-footer" style="justify-content: space-between;">
               <a href="#{advisorBean.engineGuideBaseUrl}/configuration/files/custom-css.html" target="_blank"
                 rel="noopener noreferrer" style="float: left;">
-                <i class="si si-xl ti-help-circle"></i>
+                <i class="text-2xl ti-help-circle"></i>
               </a>
               <div>
                 <p:commandButton id="saveCustomCss" process="editCustomCssForm:editCustomCssValue" partialSubmit="true"

--- a/engine-cockpit/webContent/view/branding.xhtml
+++ b/engine-cockpit/webContent/view/branding.xhtml
@@ -45,7 +45,7 @@
             <div class="custom-dialog-footer" style="justify-content: space-between;">
               <a href="#{advisorBean.engineGuideBaseUrl}/configuration/files/custom-css.html" target="_blank"
                 rel="noopener noreferrer" style="float: left;">
-                <i class="text-2xl ti-help-circle"></i>
+                <i class="text-2xl ti ti-help-circle"></i>
               </a>
               <div>
                 <p:commandButton id="saveCustomCss" process="editCustomCssForm:editCustomCssValue" partialSubmit="true"

--- a/engine-cockpit/webContent/view/branding.xhtml
+++ b/engine-cockpit/webContent/view/branding.xhtml
@@ -25,7 +25,7 @@
           <p:autoUpdate />
         </p:growl>
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-buildings-1 card-title-icon"></i>
+          <i class="pr-3 ti ti-buildings card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Branding')}</h2>
           <p:commandButton styleClass="ml-auto" id="downloadAllResources" icon="ti ti-download"
             value="#{ivy.cm.co('/common/Download')}" onclick="PF('downloadModal').show();" type="button" />

--- a/engine-cockpit/webContent/view/branding.xhtml
+++ b/engine-cockpit/webContent/view/branding.xhtml
@@ -27,7 +27,7 @@
         <div class="flex align-items-center mb-3">
           <i class="pr-3 si si-buildings-1 card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Branding')}</h2>
-          <p:commandButton styleClass="ml-auto" id="downloadAllResources" icon="si si-download-bottom"
+          <p:commandButton styleClass="ml-auto" id="downloadAllResources" icon="ti ti-download"
             value="#{ivy.cm.co('/common/Download')}" onclick="PF('downloadModal').show();" type="button" />
         </div>
 
@@ -45,12 +45,12 @@
             <div class="custom-dialog-footer" style="justify-content: space-between;">
               <a href="#{advisorBean.engineGuideBaseUrl}/configuration/files/custom-css.html" target="_blank"
                 rel="noopener noreferrer" style="float: left;">
-                <i class="si si-xl si-question-circle"></i>
+                <i class="si si-xl ti-help-circle"></i>
               </a>
               <div>
                 <p:commandButton id="saveCustomCss" process="editCustomCssForm:editCustomCssValue" partialSubmit="true"
                   onsuccess="PF('editCustomCssModal').hide();" actionListener="#{brandingBean.saveCustomCss}" value="#{ivy.cm.co('/common/Save')}"
-                  icon="si si-floppy-disk" styleClass="modal-input-button" update="msgs" />
+                  icon="ti ti-device-floppy" styleClass="modal-input-button" update="msgs" />
                 <p:commandButton id="cancelCustomCss" onclick="PF('editCustomCssModal').hide();" value="#{ivy.cm.co('/common/Cancel')}"
                   type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
               </div>
@@ -64,7 +64,7 @@
             <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('resetBrandingConfirmDialog').hide();" type="button"
               styleClass="ui-button-secondary ui-button-flat modal-input-button" />
             <p:commandButton id="resetBrandingConfirmYesBtn" value="#{ivy.cm.co('/common/Reset')}" immediate="true" ajax="false"
-              actionListener="#{brandingBean.resetRes}" icon="si si-undo" styleClass="modal-input-button" />
+              actionListener="#{brandingBean.resetRes}" icon="ti ti-arrow-back-up" styleClass="modal-input-button" />
           </h:form>
         </p:confirmDialog>
 
@@ -120,7 +120,7 @@
             <f:facet name="footer">
               <p:commandButton id="cancelCssColor" onclick="PF('editCssColorModal').hide();" value="#{ivy.cm.co('/common/Cancel')}"
                 type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
-              <p:commandButton id="saveCssColor" icon="si si-floppy-disk" value="#{ivy.cm.co('/common/Save')}" 
+              <p:commandButton id="saveCssColor" icon="ti ti-device-floppy" value="#{ivy.cm.co('/common/Save')}" 
                 actionListener="#{brandingBean.saveColor}" 
                 styleClass="modal-input-button" ajax="false" />
             </f:facet>
@@ -133,7 +133,7 @@
             <p:commandButton value="#{ivy.cm.co('/common/Cancel')}" onclick="PF('resetColorConfirmDialog').hide();" type="button"
               styleClass="ui-button-secondary ui-button-flat modal-input-button" />
             <p:commandButton id="resetColorConfirmYesBtn" value="#{ivy.cm.co('/common/Reset')}" immediate="true" ajax="false"
-              actionListener="#{brandingBean.resetColor}" icon="si si-undo" styleClass="modal-input-button" />
+              actionListener="#{brandingBean.resetColor}" icon="ti ti-arrow-back-up" styleClass="modal-input-button" />
           </h:form>
         </p:confirmDialog>
 
@@ -144,7 +144,7 @@
             <h:form enctype="multipart/form-data" id="fileUploadForm">
               <div class="file-upload">
                 <p:commandButton id="chooseFileBtn" value="#{ivy.cm.co('/common/Choose')}" onclick="PF('uploadDnd').show();return false;"
-                  icon="si si-add" styleClass="mb-2"/>
+                  icon="ti ti-plus" styleClass="mb-2"/>
                 <p:inputTextarea id="dropZone" styleClass="drop-zone" readonly="true"
                   style="width: 100%; line-height: 100px; text-align: center; margin-bottom: 20px;"
                   value="#{ivy.cm.co('/branding/ChooseOrDropFileWhichEndsWith')} #{brandingBean.allowedExtensionsString}" rows="1" />

--- a/engine-cockpit/webContent/view/businesscalendar-detail.xhtml
+++ b/engine-cockpit/webContent/view/businesscalendar-detail.xhtml
@@ -20,7 +20,7 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="editor-link" href="#{businessCalendarBean.editUrl}" icon="ti-pencil" title="#{ivy.cm.co('/businessCalendarDetail/EditAppYamlFile')}" external="false" />
+      <cc:TopBarItem styleClass="editor-link" href="#{businessCalendarBean.editUrl}" icon="ti ti-pencil" title="#{ivy.cm.co('/businessCalendarDetail/EditAppYamlFile')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}configuration.html#business-calendar" />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/businesscalendar-detail.xhtml
+++ b/engine-cockpit/webContent/view/businesscalendar-detail.xhtml
@@ -20,7 +20,7 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="editor-link" href="#{businessCalendarBean.editUrl}" icon="si-pencil" title="#{ivy.cm.co('/businessCalendarDetail/EditAppYamlFile')}" external="false" />
+      <cc:TopBarItem styleClass="editor-link" href="#{businessCalendarBean.editUrl}" icon="ti-pencil" title="#{ivy.cm.co('/businessCalendarDetail/EditAppYamlFile')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}configuration.html#business-calendar" />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/businesscalendar.xhtml
+++ b/engine-cockpit/webContent/view/businesscalendar.xhtml
@@ -27,15 +27,15 @@
           <h:form id="treeForm">
             <div class="table-search flex ui-fluid">
               <span class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{businessCalendarBean.filter}">
                   <p:ajax event="keyup" delay="300" update="@form:tree" />
                 </p:inputText>
               </span>
-              <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
+              <p:commandButton id="expandAll" icon="ti ti-arrows-vertical"
                 actionListener="#{businessCalendarBean.expandAllNodes}" update="tree" title="#{ivy.cm.co('/common/ExpandAll')}"
                 styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
-              <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
+              <p:commandButton id="collapseAll" icon="ti ti-arrows-minimize"
                 actionListener="#{businessCalendarBean.collapseAllNodes}" update="tree" title="#{ivy.cm.co('/common/CollapseAll')}"
                 styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
             </div>

--- a/engine-cockpit/webContent/view/businesscalendar.xhtml
+++ b/engine-cockpit/webContent/view/businesscalendar.xhtml
@@ -19,7 +19,7 @@
       <div class="card">
         <p:growl id="msgs" />
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-calendar card-title-icon"></i>
+          <i class="pr-3 ti ti-calendar-event card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/BusinessCalendar')}</h2>
         </div>
 
@@ -47,7 +47,7 @@
               <p:column>
                 <p:treeNode>
                   <h:outputLink value="businesscalendar-detail.xhtml?calendarName=#{node.name}" id="calendarNode" styleClass="business-calendar">
-                    <i class="si si-calendar table-icon"></i>
+                    <i class="ti ti-calendar-event table-icon"></i>
                     <h:outputText value="#{node.name}" />
                   </h:outputLink>
                 </p:treeNode>

--- a/engine-cockpit/webContent/view/cluster.xhtml
+++ b/engine-cockpit/webContent/view/cluster.xhtml
@@ -58,13 +58,13 @@
                 <p:column headerText="#{ivy.cm.co('/common/IsMaster')}" sortBy="#{node.master}">
                   <h:outputText>
                     <i
-                      class="#{node.master ? 'check-circle-1' : 'remove-circle'} table-icon #{node.master ? 'state-active' : 'state-inactive'}"></i>
+                      class="#{node.master ? 'ti ti-circle-check' : 'ti ti-circle-minus'} table-icon #{node.master ? 'state-active' : 'state-inactive'}"></i>
                   </h:outputText>
                 </p:column>
                 <p:column headerText="#{ivy.cm.co('/common/IsLocal')}" sortBy="#{node.local}">
                   <h:outputText>
                     <i
-                      class="#{node.local ? 'check-circle-1' : 'remove-circle'} table-icon #{node.local ? 'state-active' : 'state-inactive'}"></i>
+                      class="#{node.local ? 'ti ti-circle-check' : 'ti ti-circle-minus'} table-icon #{node.local ? 'state-active' : 'state-inactive'}"></i>
                   </h:outputText>
                 </p:column>
                 <p:column headerText="#{ivy.cm.co('/common/StartTimestamp')}" sortBy="#{node.startTimestamp}">

--- a/engine-cockpit/webContent/view/cluster.xhtml
+++ b/engine-cockpit/webContent/view/cluster.xhtml
@@ -58,13 +58,13 @@
                 <p:column headerText="#{ivy.cm.co('/common/IsMaster')}" sortBy="#{node.master}">
                   <h:outputText>
                     <i
-                      class="si si-#{node.master ? 'check-circle-1' : 'remove-circle'} table-icon #{node.master ? 'state-active' : 'state-inactive'}"></i>
+                      class="#{node.master ? 'check-circle-1' : 'remove-circle'} table-icon #{node.master ? 'state-active' : 'state-inactive'}"></i>
                   </h:outputText>
                 </p:column>
                 <p:column headerText="#{ivy.cm.co('/common/IsLocal')}" sortBy="#{node.local}">
                   <h:outputText>
                     <i
-                      class="si si-#{node.local ? 'check-circle-1' : 'remove-circle'} table-icon #{node.local ? 'state-active' : 'state-inactive'}"></i>
+                      class="#{node.local ? 'check-circle-1' : 'remove-circle'} table-icon #{node.local ? 'state-active' : 'state-inactive'}"></i>
                   </h:outputText>
                 </p:column>
                 <p:column headerText="#{ivy.cm.co('/common/StartTimestamp')}" sortBy="#{node.startTimestamp}">

--- a/engine-cockpit/webContent/view/cluster.xhtml
+++ b/engine-cockpit/webContent/view/cluster.xhtml
@@ -32,7 +32,7 @@
                 lazy="false" styleClass="ui-fluid" id="clusterTable">
                 <f:facet name="header">
                   <div class="ui-input-icon-left filter-container">
-                    <i class="pi pi-search"/>
+                    <i class="ti ti-search"/>
                     <p:inputText id="globalFilter" placeholder="Search" value="#{clusterBean.filter}" onkeyup="PF('clusterTable').filter()" />
                   </div>
                 </f:facet>

--- a/engine-cockpit/webContent/view/cluster.xhtml
+++ b/engine-cockpit/webContent/view/cluster.xhtml
@@ -16,14 +16,14 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-monitor-network card-title-icon"></i>
+          <i class="pr-3 ti ti-topology-star card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Cluster')}</h2>
         </div>
 
         <p:tabView id="clusterTabView" styleClass="tab-view-card">
           <p:tab id="nodesTab">
             <f:facet name="title">
-              <i class="si si-monitor table-icon" />
+              <i class="ti ti-device-desktop table-icon" />
               <h:outputText value=" #{ivy.cm.co('/cluster/Nodes')}" />
             </f:facet>
             <h:form id="nodesForm">
@@ -41,7 +41,7 @@
                   <p:commandLink id="clusterNode">
                     <p:ajax listener="#{clusterBean.setActiveClusterNode(node)}" process="@this"
                       oncomplete="PF('clusterNodeDialog').show()" update="clusterNodeDialog" />
-                    <i class="si si-monitor table-icon"></i>
+                    <i class="ti ti-device-desktop table-icon"></i>
                     <h:outputText value="#{node.name}" styleClass="node-name" />
                   </p:commandLink>
                 </p:column>
@@ -82,7 +82,7 @@
 
           <p:tab id="sessionsTab">
             <f:facet name="title">
-              <i class="si si-analytics-graph-line" />
+              <i class="ti ti-graph" />
               <h:outputText value=" #{ivy.cm.co('/cluster/Sessions')}" />
             </f:facet>
             <p:dataTable paginator="true" rows="20" paginatorPosition="bottom" paginatorAlwaysVisible="false"

--- a/engine-cockpit/webContent/view/dashboard.xhtml
+++ b/engine-cockpit/webContent/view/dashboard.xhtml
@@ -16,11 +16,11 @@
             <div class="grid">
               <cc:OverviewBox box="white" count="#{managerBean.sessionCount}" icon="si si-style-two-pin-user" title="#{ivy.cm.co('/common/Sessions')}"
                 link="monitor-sessions.xhtml" />
-              <cc:OverviewBox box="blue" count="#{managerBean.usersCount}" icon="si si-single-neutral-actions" title="#{ivy.cm.co('/common/Users')}"
+              <cc:OverviewBox box="blue" count="#{managerBean.usersCount}" icon="ti ti-user-check" title="#{ivy.cm.co('/common/Users')}"
                 link="users.xhtml" />
-              <cc:OverviewBox box="gray" count="#{managerBean.runningCasesCount}" icon="si si-layout-bullets"
+              <cc:OverviewBox box="gray" count="#{managerBean.runningCasesCount}" icon="ti ti-list"
                 title="#{ivy.cm.co('/common/RunningCases')}" link="applications.xhtml" />
-              <cc:OverviewBox box="darkgray" count="#{managerBean.applicationCount}" icon="si si-module" title="#{ivy.cm.co('/common/Applications')}"
+              <cc:OverviewBox box="darkgray" count="#{managerBean.applicationCount}" icon="ti ti-layout-grid" title="#{ivy.cm.co('/common/Applications')}"
                 link="applications.xhtml" />
             </div>
           </div>

--- a/engine-cockpit/webContent/view/dashboard.xhtml
+++ b/engine-cockpit/webContent/view/dashboard.xhtml
@@ -14,7 +14,7 @@
         <div class="grid">
           <div class="col-12">
             <div class="grid">
-              <cc:OverviewBox box="white" count="#{managerBean.sessionCount}" icon="si si-style-two-pin-user" title="#{ivy.cm.co('/common/Sessions')}"
+              <cc:OverviewBox box="white" count="#{managerBean.sessionCount}" icon="ti ti-user-pin" title="#{ivy.cm.co('/common/Sessions')}"
                 link="monitor-sessions.xhtml" />
               <cc:OverviewBox box="blue" count="#{managerBean.usersCount}" icon="ti ti-user-check" title="#{ivy.cm.co('/common/Users')}"
                 link="users.xhtml" />

--- a/engine-cockpit/webContent/view/databasedetail.xhtml
+++ b/engine-cockpit/webContent/view/databasedetail.xhtml
@@ -23,7 +23,7 @@
     <ui:define name="topbar-items">
       <li class="topbar-item help-dialog">
         <a href="#" onclick="PF('helpServicesModal').show();">
-          <i class="topbar-icon si si-question-circle"></i>
+          <i class="topbar-icon ti ti-help-circle"></i>
         </a>
       </li>
     </ui:define>

--- a/engine-cockpit/webContent/view/databases.xhtml
+++ b/engine-cockpit/webContent/view/databases.xhtml
@@ -30,7 +30,7 @@
               filteredValue="#{databaseBean.filteredDatabases}" lazy="false" id="databasesTable">
               <f:facet name="header">
                 <div class="ui-input-icon-left filter-container">
-                  <i class="pi pi-search"/>
+                  <i class="ti ti-search"/>
                   <p:inputText id="globalFilter" onkeyup="PF('databasesTable_#{app.id}').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{databaseBean.filter}" />
                 </div>
               </f:facet>

--- a/engine-cockpit/webContent/view/databases.xhtml
+++ b/engine-cockpit/webContent/view/databases.xhtml
@@ -19,7 +19,7 @@
       <div class="card">
         <p:growl id="msgs" />
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-database card-title-icon"></i>
+          <i class="pr-3 ti ti-database card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Databases')}</h2>
         </div>
         <cc:ApplicationTabs tabChange="#{databaseBean.reloadDatabases}" id="tabs">
@@ -39,7 +39,7 @@
                 styleClass="database-name-column">
                 <a href="#{database.getViewUrl(app.name)}">
                   <h:outputText value="#{database.name}" styleClass="database-name">
-                    <i class="si si-database table-icon"></i>
+                    <i class="ti ti-database table-icon"></i>
                   </h:outputText>
                 </a>
               </p:column>

--- a/engine-cockpit/webContent/view/documents.xhtml
+++ b/engine-cockpit/webContent/view/documents.xhtml
@@ -24,7 +24,7 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-office-file-doc-1 card-title-icon"></i>
+          <i class="pr-3 ti ti-file-type-doc card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/sidebar/Documents')}</h2>
         </div>
         <cc:SecuritySystemTabs tabChange="#{blobsBean.onload}" id="tabs">
@@ -35,7 +35,7 @@
               <f:facet name="header">
                 <div class="flex">
                   <span class="ui-input-icon-left filter-container ui-fluid" style="width: 100%;">
-                    <i class="pi pi-search"/>
+                    <i class="ti ti-search"/>
                     <p:inputText id="globalFilter" onkeyup="PF('blobsTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{blobsBean.dataModel.filter}" />
                   </span>
                 </div>
@@ -82,7 +82,7 @@
               </p:column>
               
               <p:column styleClass="table-btn-1">
-                <p:commandButton ajax="false" icon="si si-download-bottom" styleClass="rounded-button" onclick="PrimeFaces.monitorDownload(start, stop);">
+                <p:commandButton ajax="false" icon="ti ti-download" styleClass="rounded-button" onclick="PrimeFaces.monitorDownload(start, stop);">
                   <p:fileDownload value="#{blob.download()}"/>
                 </p:commandButton>
               </p:column>

--- a/engine-cockpit/webContent/view/editor.xhtml
+++ b/engine-cockpit/webContent/view/editor.xhtml
@@ -85,7 +85,7 @@
               <p:commandButton title="#{ivy.cm.co('/editor/DownloadP12')}" id="binaryDownload"
                 actionListener="#{editorBean.fileDownloadView()}"
                 value="#{ivy.cm.co('/editor/DownloadP12')}" ajax="false"
-                icon="si si-download-bottom" styleClass="ui-button-outlined">
+                icon="ti ti-download" styleClass="ui-button-outlined">
                 <p:fileDownload value="#{editorBean.file}" />
               </p:commandButton>
               <p:tooltip for="binaryDownload" value="#{editorBean.name} #{editorBean.size} #{ivy.cm.co('/common/Bytes')}" />
@@ -149,7 +149,7 @@
               <p:commandButton id="cancelEditor" onclick="window.location.reload(true)" value="#{ivy.cm.co('/common/Cancel')}" type="button"
                 styleClass="ml-auto ui-button-secondary ui-button-flat" disabled="#{editorBean.activeConfigFile == null}" />
               <p:commandButton id="saveEditor" styleClass="ml-1" value="#{ivy.cm.co('/common/Save')}" disabled="#{!editorBean.canSave()}"
-                icon="si si-floppy-disk" onclick="saveEditor()" actionListener="#{editorBean.activeConfigFile.save()}" widgetVar="saveEditor" />
+                icon="ti ti-device-floppy" onclick="saveEditor()" actionListener="#{editorBean.activeConfigFile.save()}" widgetVar="saveEditor" />
             </div>
           </h:form>
         </h:panelGroup>

--- a/engine-cockpit/webContent/view/editor.xhtml
+++ b/engine-cockpit/webContent/view/editor.xhtml
@@ -24,7 +24,7 @@
           <p:autoUpdate />
         </p:growl>
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-common-file-text-edit card-title-icon"></i>
+          <i class="pr-3 ti ti-file-pencil card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/ConfigFileEditor')}</h2>
 
           <h:form id="fileChooserForm" styleClass="ml-auto">
@@ -77,7 +77,7 @@
                 update="uploadDownloadBinary"
                 style="display: none;" />
               <p:commandButton title="#{ivy.cm.co('/editor/UploadP12')}" value="#{ivy.cm.co('/editor/UploadP12')}" 
-                icon="si si-upload-bottom"
+                icon="ti ti-upload"
                 type="button" id="uploadbtn"
                 styleClass="ui-button-outlined"
                 onclick="document.getElementById(this.id.replace(':uploadbtn',':binaryUpload_input')).click(); return false;">

--- a/engine-cockpit/webContent/view/info.xhtml
+++ b/engine-cockpit/webContent/view/info.xhtml
@@ -15,7 +15,7 @@
             <div class="col">
               <div class="card card-item card-item-big">
                 <div>
-                  <i class="si si-tools-wench container-icon-big" />
+                  <i class="ti ti-tool container-icon-big" />
                 </div>
                 <div>
                   <h5>#{ivy.cm.co('/info/MaintenanceMode')}</h5>
@@ -42,7 +42,7 @@
             <div class="col">
               <div class="card card-item card-item-big">
                 <div>
-                  <i class="si si-layout-dashboard container-icon-big" />
+                  <i class="ti ti-layout-dashboard container-icon-big" />
                 </div>
                 <div>
                   <h5>#{ivy.cm.co('/info/DemoPortal')}</h5>
@@ -61,7 +61,7 @@
             <div class="col">
               <div class="card card-item card-item-big">
                 <div style="">
-                  <i class="si si-share container-icon-big" />
+                  <i class="ti ti-share container-icon-big" />
                 </div>
                 <div>
                   <h5>#{ivy.cm.co('/info/NEODesigner')}</h5>
@@ -90,10 +90,10 @@
     
                   <div class="container-icon flex justify-content-center">
                     <div class="flex-1">
-                      <i class="si si-module icon-app" />
+                      <i class="ti ti-layout-grid icon-app" />
                     </div>
                     <div class="flex flex-1 justify-content-end">
-                      <p:linkButton href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}" icon="si si-cog-play" styleClass="flex-shrink-0 ml-auto rounded-button ui-button-outlined" />
+                      <p:linkButton href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}" icon="ti ti-settings-play" styleClass="flex-shrink-0 ml-auto rounded-button ui-button-outlined" />
                     </div>
                   </div>
                   
@@ -123,11 +123,11 @@
                 <div
                   style="margin-bottom: 30px; display: flex; justify-content: center; margin-top: 20px;">
                   <div style="position: absolute; left: 48%;">
-                    <i class="si si-tools-wench container-icon-big" />
+                    <i class="ti ti-tool container-icon-big" />
                   </div>
                   <div style="margin-left: auto;">
                     <p:link href="#{ivyAdvisor.advisor.docBaseUrl}">
-                      <i class="si si-office-file-doc-1 "
+                      <i class="ti ti-file-type-doc "
                         style="font-size: 22px;" />
                     </p:link>
                   </div>
@@ -141,7 +141,7 @@
                 <div class="mt-5 flex-1" style="margin-bottom: 20px;">
                   <p:linkButton id="noAppCockpit"
                     href="#{engineInfo.engineCockpitUrl}/faces/applications.xhtml"
-                    value="#{ivy.cm.co('/common/EngineCockpit')}" icon="si si-cog" />
+                    value="#{ivy.cm.co('/common/EngineCockpit')}" icon="ti ti-settings" />
                 </div>
               </div>
             </div>

--- a/engine-cockpit/webContent/view/licence.xhtml
+++ b/engine-cockpit/webContent/view/licence.xhtml
@@ -21,7 +21,7 @@
       </p:growl>
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-real-estate-action-house-key card-title-icon"></i>
+          <i class="pr-3 ti ti-home-up card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Licence')}</h2>
         </div>
         <cc:Licence id="licence"

--- a/engine-cockpit/webContent/view/login.xhtml
+++ b/engine-cockpit/webContent/view/login.xhtml
@@ -32,7 +32,7 @@
           weakLabel="#{ivy.cm.co('/common/Weak')}"
           strongLabel="#{ivy.cm.co('/common/Strong')}" />
 
-        <p:commandButton update="@form" id="login" actionListener="#{loginBean.login}" value="#{ivy.cm.co('/login/SignInButton')}" icon="si si-login-3" ajax="false"/>
+        <p:commandButton update="@form" id="login" actionListener="#{loginBean.login}" value="#{ivy.cm.co('/login/SignInButton')}" icon="ti ti-login-2" ajax="false"/>
         <p:messages globalOnly="true" id="loginMessage" />
         
         <h:panelGroup rendered="#{loginBean.OAuthProvider != null}" styleClass="oauth-providers">

--- a/engine-cockpit/webContent/view/logs.xhtml
+++ b/engine-cockpit/webContent/view/logs.xhtml
@@ -20,7 +20,7 @@
     <ui:define name="topbar-items">
       <li class="topbar-item">
         <a id="downloadAllLogs" href="#" onclick="PF('downloadModal').show();">
-          <i class="topbar-icon si si-download-bottom"></i>
+          <i class="topbar-icon ti ti-download"></i>
         </a>
       </li>
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}monitor.html#logs" />
@@ -36,7 +36,7 @@
             <div class="card-title">
               <h:form id="logChooserForm">
                 <div class="flex align-items-center">
-                  <i class="pr-3 si si-common-file-text"></i>
+                  <i class="pr-3 ti ti-file-text"></i>
                   <h2 class="m-0">#{ivy.cm.co('/sidebar/Logs')}</h2>
                   <p:calendar  id="calendar" styleClass="ml-auto" 
                     inputStyle="width:100px;"

--- a/engine-cockpit/webContent/view/mbeans.xhtml
+++ b/engine-cockpit/webContent/view/mbeans.xhtml
@@ -24,14 +24,14 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-coffee-cup"></i>
+                  <i class="pr-3 ti ti-coffee"></i>
                   <h6 class="m-0">#{ivy.cm.co('/sidebar/MBeans')}</h6>
                 </div>
               </div>
               <p:tree value="#{mBeansBean.root}" var="node" selectionMode="single"
                 style="border: none; max-height: 300px; overflow: auto; padding: 0;" id="mBeans">
                 <p:ajax event="select" update="attributes" listener="#{mBeansBean.onSelectNode}" />
-                <p:treeNode type="folder" icon="si si-folder-empty" ariaLabel="#{node.displayName}">
+                <p:treeNode type="folder" icon="ti ti-folder-open" ariaLabel="#{node.displayName}">
                   <h:outputText value="#{node.displayName}" />
                 </p:treeNode>
                 <p:treeNode type="bean" icon="ti ti-chart-bar" ariaLabel="#{node.displayName}">

--- a/engine-cockpit/webContent/view/mbeans.xhtml
+++ b/engine-cockpit/webContent/view/mbeans.xhtml
@@ -34,7 +34,7 @@
                 <p:treeNode type="folder" icon="si si-folder-empty" ariaLabel="#{node.displayName}">
                   <h:outputText value="#{node.displayName}" />
                 </p:treeNode>
-                <p:treeNode type="bean" icon="si si-analytics-bars" ariaLabel="#{node.displayName}">
+                <p:treeNode type="bean" icon="ti ti-chart-bar" ariaLabel="#{node.displayName}">
                   <h:outputText id="bean" value="#{node.displayName}" />
                   <p:tooltip for="bean" value="#{node.description}"/>
                 </p:treeNode>
@@ -45,7 +45,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-cog"></i>
+                  <i class="pr-3 ti ti-settings"></i>
                   <h6 class="m-0">#{ivy.cm.co('/common/Attributes')}</h6>
                 </div>
               </div>
@@ -61,7 +61,7 @@
                 </p:column>
                 <p:column styleClass="table-btn-1">
                   <p:commandButton id="addTrace" rendered="#{mAttr.isTraceable}" update="poll chart traces" immediate="true"
-                    actionListener="#{mBeansBean.addTrace(mAttr)}" icon="si si-analytics-graph" styleClass="rounded-button" title="#{ivy.cm.co('/monitor/mbean/AddTraceToChart')}"/>
+                    actionListener="#{mBeansBean.addTrace(mAttr)}" icon="ti ti-chart-dots" styleClass="rounded-button" title="#{ivy.cm.co('/monitor/mbean/AddTraceToChart')}"/>
                 </p:column>
               </p:dataTable>
             </div>
@@ -70,7 +70,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-analytics-bars"></i>
+                  <i class="pr-3 ti ti-chart-bar"></i>
                   <h6 class="m-0">#{ivy.cm.co('/common/Chart')}</h6>
                 </div>
               </div>
@@ -81,7 +81,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-analytics-bars"></i>
+                  <i class="pr-3 ti ti-chart-bar"></i>
                   <h6 class="m-0">#{ivy.cm.co('/monitor/mbean/Traces')}</h6>
                 </div>
               </div>
@@ -103,7 +103,7 @@
                 </p:column>
                 <p:column styleClass="table-btn-1">
                   <p:commandButton id="removeTrace" update="chart traces" immediate="true"
-                    actionListener="#{mBeansBean.removeTrace(trace)}" icon="si si-remove" styleClass="ui-button-danger rounded-button"
+                    actionListener="#{mBeansBean.removeTrace(trace)}" icon="ti ti-x" styleClass="ui-button-danger rounded-button"
                     title="#{ivy.cm.co('/monitor/mbean/RemoveTrace')}" />
                 </p:column>
               </p:dataTable>

--- a/engine-cockpit/webContent/view/migrate.xhtml
+++ b/engine-cockpit/webContent/view/migrate.xhtml
@@ -138,7 +138,7 @@
               id="taskTable" rowKey="#{task.name}">
               <p:column style="width:3%;">
                 <h:panelGroup id="taskState" styleClass="task-icon">
-                  <i class="mr-0 si si-#{task.stateIcon} link-icon"></i>
+                  <i class="mr-0 #{task.stateIcon} link-icon"></i>
                 </h:panelGroup>
               </p:column>
 

--- a/engine-cockpit/webContent/view/migrate.xhtml
+++ b/engine-cockpit/webContent/view/migrate.xhtml
@@ -15,10 +15,10 @@
           <p:autoUpdate />
         </p:growl>
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-navigation-right-circle card-title-icon"></i>
+          <i class="pr-3 ti ti-circle-arrow-right card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/migrate/MigrateOldEngine')}</h2>
           <p:linkButton href="#{advisorBean.engineGuideBaseUrl}/reference/migration-wizard.html" target="_blank" rel="noopener noreferrer"
-            styleClass="ml-auto ui-button-outlined rounded-button" icon="si si-question-circle" />
+            styleClass="ml-auto ui-button-outlined rounded-button" icon="ti ti-help-circle" />
         </div>
 
         <h:form id="locationForm">
@@ -59,7 +59,7 @@
               value="#{migrationBean.result.checks()}">
               <div>
                 <i style="position: relative; top: 2px;"
-                  class="#{check.success() ? 'si si-check-circle-1 state-active' : 'si si-delete-1 state-inactive'}"></i>
+                  class="#{check.success() ? 'ti ti-circle-check state-active' : 'ti ti-trash state-inactive'}"></i>
                 <h:outputText value=" #{check.message()}" />
                 <h:panelGroup rendered="#{not empty check.error()}">
                   <pre style="white-space: pre-wrap; word-break: break-all;"><code><h:outputText value="#{check.error()}" /></code></pre>
@@ -163,7 +163,7 @@
                   </h:panelGroup>
                   
                   <p:divider align="left" type="dashed">
-                    <p:commandButton actionListener="#{migrationBean.show(task)}" icon="si si-button-refresh-arrows" styleClass="ui-button-outlined" value="#{ivy.cm.co('/migrate/Log')}" update="log"></p:commandButton>
+                    <p:commandButton actionListener="#{migrationBean.show(task)}" icon="ti ti-refresh" styleClass="ui-button-outlined" value="#{ivy.cm.co('/migrate/Log')}" update="log"></p:commandButton>
                   </p:divider>
                   <h:panelGroup id="log" styleClass="log">
                     <p:scrollPanel style="height:300px;width:100%;">
@@ -207,7 +207,7 @@
           <div class="custom-dialog-footer">
             <p:commandButton id="startMigrationCancel" onclick="PF('startMigrationModal').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
               styleClass="ui-button-secondary ui-button-flat modal-input-button" style="width: 5rem;" />
-            <p:commandButton id="startMigrationStart" value="#{ivy.cm.co('/common/Start')}" icon="si si-check-1"
+            <p:commandButton id="startMigrationStart" value="#{ivy.cm.co('/common/Start')}" icon="ti ti-check"
               actionListener="#{migrationBean.execute}"
               update="locationForm migrationTaskForm"
               onsuccess="PF('migrationPoller').start();PF('startMigrationModal').hide();"

--- a/engine-cockpit/webContent/view/migrate.xhtml
+++ b/engine-cockpit/webContent/view/migrate.xhtml
@@ -41,7 +41,7 @@
             <f:facet name="header">
               <p:panelGrid columns="2" layout="flex" contentStyleClass="align-items-center" columnClasses="col-10, col-2">
                 <h:outputText value="#{ivy.cm.co('/migrate/Location')}" />
-                <p:commandButton icon="si si-heavy-equipment-hook"
+                <p:commandButton icon="ti ti-crane"
                 value="#{ivy.cm.co('/migrate/LoadLocation')}" id="checkLocation"
                 disabled="#{migrationBean.state == 'RUNNING'}"
                 actionListener="#{migrationBean.checkOldEngineLocation}"
@@ -93,7 +93,7 @@
             <f:facet name="header">
               <p:panelGrid columns="2" layout="flex" contentStyleClass="align-items-center" columnClasses="col-10, col-2">
                 <h:outputText value="#{ivy.cm.co('/migrate/Licence')}" />
-                 <p:fileUpload id="licenceUpload" chooseIcon="si si-upload-bottom"
+                 <p:fileUpload id="licenceUpload" chooseIcon="ti ti-upload"
                   style="font-weight: normal;width:100%;"
                   label="#{ivy.cm.co('/migrate/Upload')}"
                   mode="simple" skinSimple="true" auto="true"

--- a/engine-cockpit/webContent/view/monitor-health-checks.xhtml
+++ b/engine-cockpit/webContent/view/monitor-health-checks.xhtml
@@ -30,10 +30,10 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-road-sign-warning card-title-icon"></i>
+          <i class="pr-3 ti ti-alert-triangle card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/monitor/health/HealthChecks')}</h2>
           <p:commandButton id="refresh" actionListener="#{healthBean.refresh}" update="form" title="#{ivy.cm.co('/monitor/health/RefreshHealthChecks')}"
-              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
+              icon="ti ti-refresh" styleClass="flex-shrink-0 ml-auto rounded-button"/>
           
         </div>
         <h:form id="form" style="overflow: auto;">
@@ -46,7 +46,7 @@
              
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" onkeyup="PF('checkTable').filter()" value="#{healthBean.filter}" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}"/>
               </div>
             </f:facet>
@@ -70,11 +70,11 @@
              </p:column>
              
              <p:column styleClass="table-btn-3">
-               <p:commandButton id="enable" title="#{ivy.cm.co('/monitor/health/EnableCheck')}" icon="si si-check-circle-1"
+               <p:commandButton id="enable" title="#{ivy.cm.co('/monitor/health/EnableCheck')}" icon="ti ti-circle-check"
                  action="#{check.enable()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{check.enabled}"/>
-               <p:commandButton id="disable" title="#{ivy.cm.co('/monitor/health/DisableCheck')}" icon="si si-subtract-circle"
+               <p:commandButton id="disable" title="#{ivy.cm.co('/monitor/health/DisableCheck')}" icon="ti ti-circle-minus"
                  action="#{check.disable()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{!check.enabled}"/>
-               <p:commandButton id="checkNow" icon="si si-controls-play" title="#{ivy.cm.co('/monitor/health/RunCheckNow')}"
+               <p:commandButton id="checkNow" icon="ti ti-player-play" title="#{ivy.cm.co('/monitor/health/RunCheckNow')}"
                  action="#{check.checkNow()}" update="@form" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{! check.enabled}"/>
            </p:column>
           </p:dataTable>

--- a/engine-cockpit/webContent/view/monitor-health.xhtml
+++ b/engine-cockpit/webContent/view/monitor-health.xhtml
@@ -64,7 +64,7 @@
             </p:column>
             <p:column styleClass="table-btn-1">
               <p:button title="#{ivy.cm.co('/monitor/health/AdditionalInformationConfiguration')}" href="#{msg.actionLink}" rendered="#{msg.hasActionLink}" 
-                icon="si si-computer-chip-search" styleClass="rounded-button">
+                icon="ti ti-settings-search" styleClass="rounded-button">
               </p:button>
             </p:column>
           </p:dataTable>

--- a/engine-cockpit/webContent/view/monitor-health.xhtml
+++ b/engine-cockpit/webContent/view/monitor-health.xhtml
@@ -25,14 +25,14 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-road-sign-warning card-title-icon"></i>
+          <i class="pr-3 ti ti-alert-triangle card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/sidebar/Health')}</h2>
           <p:commandButton id="run" title="#{ivy.cm.co('/monitor/health/RunHealthChecks')}" action="#{healthBean.checkNow()}"
-              update="form" icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
+              update="form" icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
           <p:commandButton id="refresh" actionListener="#{healthBean.refresh}" update="form" title="#{ivy.cm.co('/monitor/health/RefreshHealth')}"
-              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button"/>
+              icon="ti ti-refresh" styleClass="flex-shrink-0 ml-1 rounded-button"/>
           <p:linkButton id="checks" title="#{ivy.cm.co('/monitor/health/HealthChecks')}" type="button" href="monitor-health-checks.xhtml"
-              icon="si si-road-sign-warning" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
+              icon="ti ti-alert-triangle" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" />
           
         </div>
         <h:form id="form" style="overflow: auto;">

--- a/engine-cockpit/webContent/view/monitor-sessions.xhtml
+++ b/engine-cockpit/webContent/view/monitor-sessions.xhtml
@@ -107,7 +107,7 @@
                <p:column headerText="#{ivy.cm.co('/monitor/session/HTTPSessions')}" sortBy="#{ses.httpSessionCount}">
                 <h:panelGroup id="httpSessionGrp">
                    <h:outputText id="httpSession" value="#{ses.httpSessionCount}"/>
-                   <i class="ti-info-circle"/>
+                   <i class="ti ti-info-circle"/>
                 </h:panelGroup>
                 <p:tooltip for="httpSessionGrp" rendered="#{!ses.httpSessions.isEmpty()}">
                   <ui:repeat value="#{ses.httpSessions}" var="httpSession">

--- a/engine-cockpit/webContent/view/monitor-sessions.xhtml
+++ b/engine-cockpit/webContent/view/monitor-sessions.xhtml
@@ -30,7 +30,7 @@
                 <i class="pr-3 si si-analytics-graph-line card-title-icon"></i>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/Sessions')}</h2>
                 <p:commandButton id="refresh" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"
-                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
+                    icon="ti ti-refresh" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
               </div>
             </div>
             <p:dataTable var="ses" value="#{sessionBean.dataModel}"
@@ -40,11 +40,11 @@
               <f:facet name="header">
                 <div class="flex">
                   <div class="ui-input-icon-left filter-container" style="width: 100%;">
-                    <i class="pi pi-search"/>
+                    <i class="ti ti-search"/>
                     <p:inputText id="globalFilter" value="#{sessionBean.dataModel.filter}" onkeyup="PF('sessionTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" onkeypress="if (event.keyCode === 13) { return false; } else { return true; }" />
                   </div>
 
-                  <p:commandButton id="filterBtn" title="#{ivy.cm.co('/common/Filter')}" type="button" icon="si si-filter-1"
+                  <p:commandButton id="filterBtn" title="#{ivy.cm.co('/common/Filter')}" type="button" icon="ti ti-filter"
                     styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button" onclick="PF('filterPanel').show();" />
                   <p:overlayPanel id="filterPanel" for="filterBtn" widgetVar="filterPanel" styleClass="table-content-filter">
                     <h:panelGroup style="display:block;margin-bottom:5px;">
@@ -58,7 +58,7 @@
                         onclick="PF('filterPanel').hide();" type="button" />
                       <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
                         update="@form" actionListener="#{sessionBean.dataModel.resetFilters()}" />
-                      <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="si si-check-1" update="@form" />
+                      <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check" update="@form" />
                     </h:panelGroup>
                   </p:overlayPanel>
                 </div>
@@ -136,7 +136,7 @@
               </p:column>
 
               <p:column styleClass="table-btn-1">
-                <p:commandButton id="killSession" title="#{ivy.cm.co('/monitor/session/KillSession')}" icon="si si-logout-1"
+                <p:commandButton id="killSession" title="#{ivy.cm.co('/monitor/session/KillSession')}" icon="ti ti-logout"
                   actionListener="#{sessionBean.killSession(ses)}" ajax="true" update="@form" disabled="#{!ses.canKill()}" styleClass="ui-button-danger rounded-button" />
               </p:column>
             </p:dataTable>

--- a/engine-cockpit/webContent/view/monitor-sessions.xhtml
+++ b/engine-cockpit/webContent/view/monitor-sessions.xhtml
@@ -27,7 +27,7 @@
           <div class="card">
             <div class="card-header flex-wrap">
               <div class="card-title flex align-items-center">
-                <i class="pr-3 si si-analytics-graph-line card-title-icon"></i>
+                <i class="pr-3 ti ti-graph card-title-icon"></i>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/Sessions')}</h2>
                 <p:commandButton id="refresh" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"
                     icon="ti ti-refresh" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
@@ -56,7 +56,7 @@
                     <h:panelGroup layout="block" styleClass="mt-1 flex justify-content-end">
                       <p:commandButton id="cancelFilter" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-flat ui-button-secondary modal-input-button"
                         onclick="PF('filterPanel').hide();" type="button" />
-                      <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="si si-delete-2"
+                      <p:commandButton id="resetFilterBtn" value="#{ivy.cm.co('/common/Reset')}" styleClass="ml-1 ui-button-secondary modal-input-button" icon="ti ti-circle-x"
                         update="@form" actionListener="#{sessionBean.dataModel.resetFilters()}" />
                       <p:commandButton id="applyFilter" value="#{ivy.cm.co('/common/Apply')}" styleClass="ml-1 modal-input-button" icon="ti ti-check" update="@form" />
                     </h:panelGroup>
@@ -107,7 +107,7 @@
                <p:column headerText="#{ivy.cm.co('/monitor/session/HTTPSessions')}" sortBy="#{ses.httpSessionCount}">
                 <h:panelGroup id="httpSessionGrp">
                    <h:outputText id="httpSession" value="#{ses.httpSessionCount}"/>
-                   <i class="fa-info-circle"/>
+                   <i class="ti-info-circle"/>
                 </h:panelGroup>
                 <p:tooltip for="httpSessionGrp" rendered="#{!ses.httpSessions.isEmpty()}">
                   <ui:repeat value="#{ses.httpSessions}" var="httpSession">

--- a/engine-cockpit/webContent/view/monitor-sessions.xhtml
+++ b/engine-cockpit/webContent/view/monitor-sessions.xhtml
@@ -107,7 +107,7 @@
                <p:column headerText="#{ivy.cm.co('/monitor/session/HTTPSessions')}" sortBy="#{ses.httpSessionCount}">
                 <h:panelGroup id="httpSessionGrp">
                    <h:outputText id="httpSession" value="#{ses.httpSessionCount}"/>
-                   <i class="fa-solid fa-info-circle"/>
+                   <i class="fa-info-circle"/>
                 </h:panelGroup>
                 <p:tooltip for="httpSessionGrp" rendered="#{!ses.httpSessions.isEmpty()}">
                   <ui:repeat value="#{ses.httpSessions}" var="httpSession">

--- a/engine-cockpit/webContent/view/monitorCache.xhtml
+++ b/engine-cockpit/webContent/view/monitorCache.xhtml
@@ -35,7 +35,7 @@
             emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" onkeyup="PF('cacheTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{cacheBean.filter}" />
               </div>
             </f:facet>
@@ -101,7 +101,7 @@
               <h:outputText value="#{cache.info}" title="#{cache.info}"/>
             </p:column>
             <p:column styleClass="table-btn-1">
-              <p:commandButton title="#{ivy.cm.co('/common/Clear')}" id="clearButton" icon="si si-bin-1" disabled="#{cache.notClearable}"
+              <p:commandButton title="#{ivy.cm.co('/common/Clear')}" id="clearButton" icon="ti ti-trash" disabled="#{cache.notClearable}"
                   type="button" styleClass="ui-button-danger rounded-button">
                 <p:ajax update="@form" listener="#{cache.clear}"/>
               </p:commandButton>

--- a/engine-cockpit/webContent/view/monitorCache.xhtml
+++ b/engine-cockpit/webContent/view/monitorCache.xhtml
@@ -24,7 +24,7 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-monitor-heart-beat-search card-title-icon"></i>
+          <i class="pr-3 ti ti-device-desktop-search card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/monitor/Caches')}</h2>
         </div>
         <h:form id="form" style="overflow: auto;">

--- a/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
+++ b/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
@@ -131,7 +131,7 @@
             <div class="custom-dialog-footer">
               <p:commandButton id="cancel" type="button" onclick="PF('dumpMemoryDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
               <p:commandButton id="dump" ajax="false" value="#{ivy.cm.co('/monitor/classHistogram/Dump')}" update="form" title="#{ivy.cm.co('/monitor/classHistogram/DumpHeapMemory')}"
-                  onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download'); PF('dumpMemoryDialog').hide();}"
+                  onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti ti-download'); PF('dumpMemoryDialog').hide();}"
                   icon="ti ti-download" styleClass="modal-input-button">
                 <p:fileDownload value="#{classHistogramBean.dumpMemory()}"/>
               </p:commandButton>

--- a/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
+++ b/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
@@ -26,7 +26,7 @@
             <div class="card">
               <div class="card-header flex-wrap">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-computer-chip-search"></i>
+                  <i class="pr-3 ti ti-settings-search"></i>
                   <h2 class="m-0">#{ivy.cm.co('/sidebar/ClassHistogram')}</h2>
                   <p:commandButton id="refresh" icon="ti ti-refresh" action="#{classHistogramBean.refresh()}" title="#{ivy.cm.co('/monitor/classHistogram/Refresh')}"
                       update="@form" styleClass="flex-shrink-0 ml-auto rounded-button"/>

--- a/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
+++ b/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
@@ -28,12 +28,12 @@
                 <div class="card-title flex align-items-center">
                   <i class="pr-3 si si-computer-chip-search"></i>
                   <h2 class="m-0">#{ivy.cm.co('/sidebar/ClassHistogram')}</h2>
-                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{classHistogramBean.refresh()}" title="#{ivy.cm.co('/monitor/classHistogram/Refresh')}"
+                  <p:commandButton id="refresh" icon="ti ti-refresh" action="#{classHistogramBean.refresh()}" title="#{ivy.cm.co('/monitor/classHistogram/Refresh')}"
                       update="@form" styleClass="flex-shrink-0 ml-auto rounded-button"/>
                   <p:commandButton id="clear" actionListener="#{classHistogramBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/classHistogram/Clear')}"
-                      icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{classHistogramBean.notClearable}"/>
+                      icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{classHistogramBean.notClearable}"/>
                   <p:commandButton id="dump" update="dumpMemory" title="#{ivy.cm.co('/monitor/classHistogram/Dump')}" onclick="PF('dumpMemoryDialog').show();"
-                      icon="si si-download-bottom" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
+                      icon="si ti-download" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
                 </div>
               </div>
               <p:dataTable var="class" value="#{classHistogramBean.classes}" filteredValue="#{classHistogramBean.filteredClasses}"
@@ -42,7 +42,7 @@
                 paginator="true" rows="100" paginatorPosition="bottom" resizableColumns="true" sortBy="#{class.instances}">
                 <f:facet name="header">
                   <div class="ui-input-icon-left filter-container">
-                    <i class="pi pi-search"/>
+                    <i class="ti ti-search"/>
                     <p:inputText id="globalFilter" onkeyup="PF('classesTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}"
                       value="#{classHistogramBean.filter}" />
                   </div>
@@ -131,8 +131,8 @@
             <div class="custom-dialog-footer">
               <p:commandButton id="cancel" type="button" onclick="PF('dumpMemoryDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
               <p:commandButton id="dump" ajax="false" value="#{ivy.cm.co('/monitor/classHistogram/Dump')}" update="form" title="#{ivy.cm.co('/monitor/classHistogram/DumpHeapMemory')}"
-                  onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'si-download-bottom'); PF('dumpMemoryDialog').hide();}"
-                  icon="si si-download-bottom" styleClass="modal-input-button">
+                  onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download'); PF('dumpMemoryDialog').hide();}"
+                  icon="si ti-download" styleClass="modal-input-button">
                 <p:fileDownload value="#{classHistogramBean.dumpMemory()}"/>
               </p:commandButton>
             </div>

--- a/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
+++ b/engine-cockpit/webContent/view/monitorClassHistogram.xhtml
@@ -33,7 +33,7 @@
                   <p:commandButton id="clear" actionListener="#{classHistogramBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/classHistogram/Clear')}"
                       icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{classHistogramBean.notClearable}"/>
                   <p:commandButton id="dump" update="dumpMemory" title="#{ivy.cm.co('/monitor/classHistogram/Dump')}" onclick="PF('dumpMemoryDialog').show();"
-                      icon="si ti-download" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
+                      icon="ti ti-download" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
                 </div>
               </div>
               <p:dataTable var="class" value="#{classHistogramBean.classes}" filteredValue="#{classHistogramBean.filteredClasses}"
@@ -132,7 +132,7 @@
               <p:commandButton id="cancel" type="button" onclick="PF('dumpMemoryDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
               <p:commandButton id="dump" ajax="false" value="#{ivy.cm.co('/monitor/classHistogram/Dump')}" update="form" title="#{ivy.cm.co('/monitor/classHistogram/DumpHeapMemory')}"
                   onclick="var button=this; buttonAddSpinner(button); window.onblur = function(){buttonRemoveSpinner(button, 'ti-download'); PF('dumpMemoryDialog').hide();}"
-                  icon="si ti-download" styleClass="modal-input-button">
+                  icon="ti ti-download" styleClass="modal-input-button">
                 <p:fileDownload value="#{classHistogramBean.dumpMemory()}"/>
               </p:commandButton>
             </div>

--- a/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
@@ -77,7 +77,7 @@
              <p:column styleClass="table-btn-3">
               <p:commandButton id="start" title="#{ivy.cm.co('/monitor/startEvent/StartsTheBean')}" icon="ti ti-player-play"
                 action="#{bean.start()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
-              <p:commandButton id="stop" title="#{ivy.cm.co('/monitor/startEvent/StopsTheBean')}" icon="si si-controls-stop"
+              <p:commandButton id="stop" title="#{ivy.cm.co('/monitor/startEvent/StopsTheBean')}" icon="ti ti-player-stop"
                 action="#{bean.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{!bean.running}"/>
               <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/monitor/startEvent/ScheduleToPollTheBeanNow')}" icon="ti ti-clock-play"
                 action="#{intermediateEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="flex-shrink-0 ml-1 rounded-button" />

--- a/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorIntermediateEvents.xhtml
@@ -24,10 +24,10 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-navigation-right-circle-1 card-title-icon"></i>
+          <i class="pr-3 ti ti-circle-arrow-right card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/IntermediateEvents')}</h2>
           <p:commandButton id="refresh" actionListener="#{intermediateEventBean.refresh}" update="form" title="#{ivy.cm.co('/monitor/startEvent/RefreshStartEvents')}"
-              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
+              icon="ti ti-refresh" styleClass="flex-shrink-0 ml-auto rounded-button"/>
 
         </div>
         <h:form id="form" style="overflow: auto;" onkeypress="if (event.keyCode == 13) return false;">
@@ -38,14 +38,14 @@
             emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" onkeyup="PF('beanTable').filter()" value="#{intermediateEventBean.filter}" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" />
               </div>
             </f:facet>
 
             <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{bean.beanName}" filterBy="#{bean.beanName}">
               <a href="#{bean.detailUrl}">
-                <i class="si si-navigation-right-circle-1 table-icon"/>
+                <i class="ti ti-circle-arrow-right table-icon"/>
                 <h:outputText value="#{bean.beanName}"/>
               </a>
             </p:column>
@@ -75,11 +75,11 @@
             </p:column>
 
              <p:column styleClass="table-btn-3">
-              <p:commandButton id="start" title="#{ivy.cm.co('/monitor/startEvent/StartsTheBean')}" icon="si si-controls-play"
+              <p:commandButton id="start" title="#{ivy.cm.co('/monitor/startEvent/StartsTheBean')}" icon="ti ti-player-play"
                 action="#{bean.start()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
               <p:commandButton id="stop" title="#{ivy.cm.co('/monitor/startEvent/StopsTheBean')}" icon="si si-controls-stop"
                 action="#{bean.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{!bean.running}"/>
-              <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/monitor/startEvent/ScheduleToPollTheBeanNow')}" icon="si si-synchronize-arrow-clock"
+              <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/monitor/startEvent/ScheduleToPollTheBeanNow')}" icon="ti ti-clock-play"
                 action="#{intermediateEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="flex-shrink-0 ml-1 rounded-button" />
             </p:column>
           </p:dataTable>
@@ -92,7 +92,7 @@
             <div class="custom-dialog-footer">
               <p:commandButton id="cancel" type="button" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}"
                 styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-              <p:commandButton id="schedule" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/monitor/startEvent/Poll')}" icon="si si-controls-play"
+              <p:commandButton id="schedule" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/monitor/startEvent/Poll')}" icon="ti ti-player-play"
                 styleClass="modal-input-button" actionListener="#{intermediateEventBean.selected.poll()}" update="form"/>
             </div>
           </h:form>

--- a/engine-cockpit/webContent/view/monitorJfr.xhtml
+++ b/engine-cockpit/webContent/view/monitorJfr.xhtml
@@ -28,8 +28,8 @@
                 <div class="card-title flex align-items-center">
                   <i class="pr-3 si si-plane-take-off"></i>
                   <h2 class="m-0">#{ivy.cm.co('/monitor/JavaFlightRecorder')}</h2>
-                  <p:commandButton id="start" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}" onclick="PF('startRecordingDialog').show();" icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button"/>
-                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{jfrBean.refresh()}" update="@form startRecordingDialog" title="#{ivy.cm.co('/common/Refresh')}" styleClass="flex-shrink-0 ml-1 rounded-button"/>
+                  <p:commandButton id="start" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}" onclick="PF('startRecordingDialog').show();" icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button"/>
+                  <p:commandButton id="refresh" icon="ti ti-refresh" action="#{jfrBean.refresh()}" update="@form startRecordingDialog" title="#{ivy.cm.co('/common/Refresh')}" styleClass="flex-shrink-0 ml-1 rounded-button"/>
                 </div>
               </div>
               <p:dataTable var="recording" value="#{jfrBean.recordings}"
@@ -63,7 +63,7 @@
                     <p:fileDownload value="#{jfrBean.downloadRecording(recording)}"/>
                   </p:commandButton>
                   <p:commandButton id="close" action="#{jfrBean.closeRecording(recording)}" update="@form startRecordingDialog" title="#{ivy.cm.co('/common/DeleteRecording')}" disabled="#{not recording.canClose}"
-                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
+                    icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button"/>
                 </p:column>
               </p:dataTable>
             </div>
@@ -81,7 +81,7 @@
               <p:selectOneMenu id="configuration" value="#{jfrBean.configuration}">
                 <f:selectItems value="#{jfrBean.configurations}" var="config" itemLabel="#{config.label}" itemValue="#{config.name}" itemDescription="#{config.description}"/>
               </p:selectOneMenu>
-              <p:commandButton id="add" title="#{ivy.cm.co('/monitor/jfr/AddConfiguration')}" onclick="PF('uploadConfig').show();return false;" icon="si si-add" styleClass="ml-1 rounded-button"/>
+              <p:commandButton id="add" title="#{ivy.cm.co('/monitor/jfr/AddConfiguration')}" onclick="PF('uploadConfig').show();return false;" icon="ti ti-plus" styleClass="ml-1 rounded-button"/>
               <p:outputLabel for="name" value="#{ivy.cm.co('/common/Name')}"/>
               <p:inputText id="name" value="#{jfrBean.name}"/>
             </p:panelGrid>
@@ -99,7 +99,7 @@
             </p:panel>
             <div class="custom-dialog-footer">
               <p:commandButton id="cancel" type="button" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-              <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="si si-controls-play"
+              <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="ti ti-player-play"
                 styleClass="modal-input-button" actionListener="#{jfrBean.startRecording}" update="form"/>
             </div>
           </h:form>

--- a/engine-cockpit/webContent/view/monitorJfr.xhtml
+++ b/engine-cockpit/webContent/view/monitorJfr.xhtml
@@ -26,7 +26,7 @@
             <div class="card">
               <div class="card-header flex-wrap">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-plane-take-off"></i>
+                  <i class="pr-3 ti ti-plane-tilt"></i>
                   <h2 class="m-0">#{ivy.cm.co('/monitor/JavaFlightRecorder')}</h2>
                   <p:commandButton id="start" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}" onclick="PF('startRecordingDialog').show();" icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button"/>
                   <p:commandButton id="refresh" icon="ti ti-refresh" action="#{jfrBean.refresh()}" update="@form startRecordingDialog" title="#{ivy.cm.co('/common/Refresh')}" styleClass="flex-shrink-0 ml-1 rounded-button"/>
@@ -58,8 +58,8 @@
                 </p:column>
                 <p:column styleClass="table-btn-3">
                   <p:commandButton id="stop" action="#{jfrBean.stopRecording(recording)}" update="@form startRecordingDialog" title="#{ivy.cm.co('/common/StopRecording')}"
-                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{not recording.canStop}"/>
-                  <p:commandButton id="download" icon="pi pi-arrow-down" ajax="false" title="#{ivy.cm.co('/common/DownloadRecording')}" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{not recording.canDownload}">
+                    icon="ti ti-player-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{not recording.canStop}"/>
+                  <p:commandButton id="download" icon="ti ti-arrow-down" ajax="false" title="#{ivy.cm.co('/common/DownloadRecording')}" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{not recording.canDownload}">
                     <p:fileDownload value="#{jfrBean.downloadRecording(recording)}"/>
                   </p:commandButton>
                   <p:commandButton id="close" action="#{jfrBean.closeRecording(recording)}" update="@form startRecordingDialog" title="#{ivy.cm.co('/common/DeleteRecording')}" disabled="#{not recording.canClose}"

--- a/engine-cockpit/webContent/view/monitorJobs.xhtml
+++ b/engine-cockpit/webContent/view/monitorJobs.xhtml
@@ -27,10 +27,10 @@
        </p:growl>
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-task-list-approve card-title-icon"></i>
+          <i class="pr-3 ti ti-clipboard-list card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/sidebar/Jobs')}</h2>
           <p:commandButton id="refresh" actionListener="#{jobBean.refresh}" update="form" title="#{ivy.cm.co('/monitor/job/RefreshJobs')}"
-              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
+              icon="ti ti-refresh" styleClass="flex-shrink-0 ml-auto rounded-button"/>
 
         </div>
         <h:form id="form" style="overflow: auto;" onkeypress="if (event.keyCode == 13) return false;">
@@ -40,14 +40,14 @@
             id="jobTable" style="min-width: 950px;">
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" onkeyup="PF('jobTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{jobBean.filter}" />
               </div>
             </f:facet>
 
             <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{job.name}" filterBy="#{job.name}">
               <p:commandLink oncomplete="PF('jobDialog').show();" title="#{ivy.cm.co('/monitor/job/JobDetail')}" action="#{jobBean.setSelected(job)}" update="jobDialog">
-                <i class="si si-task-list-approve table-icon"/>
+                <i class="ti ti-clipboard-list table-icon"/>
                 <span><h:outputText value="#{job.name}"/></span>
               </p:commandLink>
             </p:column>
@@ -77,7 +77,7 @@
             </p:column>
 
              <p:column styleClass="table-btn-1">
-              <p:commandButton id="schedule" oncomplete="PF('scheduleJobDialog').show();" title="#{ivy.cm.co('/monitor/job/ScheduleExecuteJob')}" icon="si si-controls-play"
+              <p:commandButton id="schedule" oncomplete="PF('scheduleJobDialog').show();" title="#{ivy.cm.co('/monitor/job/ScheduleExecuteJob')}" icon="ti ti-player-play"
                 action="#{jobBean.setSelected(job)}" update="scheduleJobDialog" styleClass="rounded-button" />
             </p:column>
           </p:dataTable>
@@ -88,7 +88,7 @@
             <p:staticMessage severity="warn" detail="#{ivy.cm.co('/monitor/job/ScheduleJobTooltip')}" />
             <div class="custom-dialog-footer">
               <p:commandButton id="cancel" type="button" onclick="PF('scheduleJobDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-              <p:commandButton id="schedule" onclick="PF('scheduleJobDialog').hide();" value="#{ivy.cm.co('/common/Schedule')}" icon="si si-controls-play"
+              <p:commandButton id="schedule" onclick="PF('scheduleJobDialog').hide();" value="#{ivy.cm.co('/common/Schedule')}" icon="ti ti-player-play"
                   styleClass="modal-input-button" actionListener="#{jobBean.selected.schedule()}" update="form"/>
             </div>
           </h:form>
@@ -122,7 +122,7 @@
             <h:outputText id="lastErrorTime" value="#{jobBean.selected.lastErrorTime}"/>
             <h:panelGroup>
               <p:outputLabel for="lastError" value="#{ivy.cm.co('/common/LastError')}"/>
-              <p:commandButton id="copyError" icon="si si-copy-paste" type="button" title="#{ivy.cm.co('/common/CopyToClipboard')}" onclick="var button=this; copyToClipboard($('#job\\:lastError').text(), button)"
+              <p:commandButton id="copyError" icon="ti ti-copy" type="button" title="#{ivy.cm.co('/common/CopyToClipboard')}" onclick="var button=this; copyToClipboard($('#job\\:lastError').text(), button)"
                   styleClass="ui-button-flat rounded-button"/>
             </h:panelGroup>
             <p:outputPanel id="lastError" styleClass="code">#{jobBean.selected.lastError}</p:outputPanel>  

--- a/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
+++ b/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
@@ -29,12 +29,12 @@
           <div class="card">
             <div class="card-header flex-wrap">
               <div class="card-title flex align-items-center">
-                <i class="pr-3 si si-optimization-timer"/>
+                <i class="pr-3 ti ti-calendar-clock"/>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/ProcessExecution')}</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
                     icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{processExecutionBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{processExecutionBean.stop}" update="@form" title="#{ivy.cm.co('/common/StopRecording')}"
-                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notStoppable}" />
+                    icon="ti ti-player-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notStoppable}" />
                 <p:commandButton id="clear" actionListener="#{processExecutionBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/execution/ClearStatistic')}"
                     icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notCleanable}" />
                 <p:commandButton id="refresh" actionListener="#{processExecutionBean.refresh}" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"

--- a/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
+++ b/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="config-link" href="systemconfig.xhtml?filter=ProcessEngine.FiringStatistic" icon="si-cog" 
+      <cc:TopBarItem styleClass="config-link" href="systemconfig.xhtml?filter=ProcessEngine.FiringStatistic" icon="ti-settings" 
         title="#{ivy.cm.co('/monitor/execution/PerformanceTooltip')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}monitor.html#process-execution"/>
     </ui:define>
@@ -32,15 +32,15 @@
                 <i class="pr-3 si si-optimization-timer"/>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/ProcessExecution')}</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
-                    icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{processExecutionBean.notStartable}" />
+                    icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{processExecutionBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{processExecutionBean.stop}" update="@form" title="#{ivy.cm.co('/common/StopRecording')}"
                     icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notStoppable}" />
                 <p:commandButton id="clear" actionListener="#{processExecutionBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/execution/ClearStatistic')}"
-                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notCleanable}" />
+                    icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{processExecutionBean.notCleanable}" />
                 <p:commandButton id="refresh" actionListener="#{processExecutionBean.refresh}" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"
-                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{processExecutionBean.notRefreshable}" />
+                    icon="ti ti-refresh" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{processExecutionBean.notRefreshable}" />
                 <p:commandButton id="export" title="Export statistic" ajax="false"
-                    icon="si si-office-file-xls-1" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" disabled="#{processExecutionBean.notCleanable}">
+                    icon="ti ti-file-type-xls" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" disabled="#{processExecutionBean.notCleanable}">
                   <p:dataExporter type="xlsxstream" target="performanceTable" fileName="#{ivy.cm.co('/monitor/execution/PerformanceStatisticFileName')}"/>
                 </p:commandButton>
               </div>
@@ -56,11 +56,11 @@
               <f:facet name="header">
                 <div class="flex ui-fluid">
                   <div class="ui-input-icon-left filter-container" style="width: 100%;">
-                    <i class="pi pi-search"/>
+                    <i class="ti ti-search"/>
                     <p:inputText id="globalFilter" onkeyup="PF('performanceTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{processExecutionBean.filter}" />
                   </div>
                   <div class="ml-1">
-                    <p:commandButton id="toggler" type="button" icon="si si-layers-grid-settings" 
+                    <p:commandButton id="toggler" type="button" icon="ti ti-layout-grid" 
                       styleClass="ui-button-secondary ui-button-outlined rounded-button"/>
                     <p:columnToggler datasource="performanceTable" trigger="toggler"/>
                   </div>
@@ -248,7 +248,7 @@
           <p:staticMessage severity="warn" detail="#{ivy.cm.co('/monitor/execution/ExecutionHelpText')}" />
           <div class="custom-dialog-footer">
             <p:commandButton id="cancel" type="button" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-            <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="si si-controls-play"
+            <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="ti ti-player-play"
               styleClass="modal-input-button" actionListener="#{processExecutionBean.start}" update="form"/>
           </div>
         </h:form>

--- a/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
+++ b/engine-cockpit/webContent/view/monitorProcessExecution.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="config-link" href="systemconfig.xhtml?filter=ProcessEngine.FiringStatistic" icon="ti-settings" 
+      <cc:TopBarItem styleClass="config-link" href="systemconfig.xhtml?filter=ProcessEngine.FiringStatistic" icon="ti ti-settings" 
         title="#{ivy.cm.co('/monitor/execution/PerformanceTooltip')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}monitor.html#process-execution"/>
     </ui:define>

--- a/engine-cockpit/webContent/view/monitorStartEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorStartEvents.xhtml
@@ -80,7 +80,7 @@
              <p:column styleClass="table-btn-3">
               <p:commandButton id="start" title="#{ivy.cm.co('/monitor/startEvent/StartsTheBean')}" icon="ti ti-player-play"
                 action="#{bean.start()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
-              <p:commandButton id="stop" title="#{ivy.cm.co('/monitor/startEvent/StopsTheBean')}" icon="si si-controls-stop"
+              <p:commandButton id="stop" title="#{ivy.cm.co('/monitor/startEvent/StopsTheBean')}" icon="ti ti-player-stop"
                 action="#{bean.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{! bean.running}"/>
               <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/monitor/startEvent/ScheduleToPollTheBeanNow')}" icon="ti ti-clock-play"
                 action="#{startEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="flex-shrink-0 ml-1 rounded-button" />

--- a/engine-cockpit/webContent/view/monitorStartEvents.xhtml
+++ b/engine-cockpit/webContent/view/monitorStartEvents.xhtml
@@ -27,10 +27,10 @@
        </p:growl>
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-navigation-right-circle-1 card-title-icon"></i>
+          <i class="pr-3 ti ti-circle-arrow-right card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/StartEvents')}</h2>
           <p:commandButton id="refresh" actionListener="#{startEventBean.refresh}" update="form" title="#{ivy.cm.co('/monitor/startEvent/RefreshStartEvents')}"
-              icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-auto rounded-button"/>
+              icon="ti ti-refresh" styleClass="flex-shrink-0 ml-auto rounded-button"/>
 
         </div>
         <h:form id="form" style="overflow: auto;" onkeypress="if (event.keyCode == 13) return false;">
@@ -41,14 +41,14 @@
             emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" onkeyup="PF('beanTable').filter()" value="#{startEventBean.filter}" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}"/>
               </div>
             </f:facet>
 
             <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{bean.beanName}" filterBy="#{bean.beanName}">
               <a href="#{bean.detailUrl}">
-                <i class="si si-navigation-right-circle-1 table-icon"/>
+                <i class="ti ti-circle-arrow-right table-icon"/>
                 <h:outputText value="#{bean.beanName}"/>
               </a>
             </p:column>
@@ -78,11 +78,11 @@
             </p:column>
 
              <p:column styleClass="table-btn-3">
-              <p:commandButton id="start" title="#{ivy.cm.co('/monitor/startEvent/StartsTheBean')}" icon="si si-controls-play"
+              <p:commandButton id="start" title="#{ivy.cm.co('/monitor/startEvent/StartsTheBean')}" icon="ti ti-player-play"
                 action="#{bean.start()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button" disabled="#{bean.running}"/>
               <p:commandButton id="stop" title="#{ivy.cm.co('/monitor/startEvent/StopsTheBean')}" icon="si si-controls-stop"
                 action="#{bean.stop()}" update="@form" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{! bean.running}"/>
-              <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/monitor/startEvent/ScheduleToPollTheBeanNow')}" icon="si si-synchronize-arrow-clock"
+              <p:commandButton id="poll" oncomplete="PF('pollBeanDialog').show();" title="#{ivy.cm.co('/monitor/startEvent/ScheduleToPollTheBeanNow')}" icon="ti ti-clock-play"
                 action="#{startEventBean.setSelected(bean)}" update="pollBeanDialog" styleClass="flex-shrink-0 ml-1 rounded-button" />
             </p:column>
           </p:dataTable>
@@ -93,7 +93,7 @@
             <p:staticMessage severity="warn" detail="#{ivy.cm.co('/monitor/startEvent/SchedulePollTooltip')}"/>
             <div class="custom-dialog-footer">
               <p:commandButton id="cancel" type="button" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-              <p:commandButton id="poll" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/monitor/startEvent/Poll')}" icon="si si-controls-play"
+              <p:commandButton id="poll" onclick="PF('pollBeanDialog').hide();" value="#{ivy.cm.co('/monitor/startEvent/Poll')}" icon="ti ti-player-play"
                   styleClass="modal-input-button" actionListener="#{startEventBean.selected.poll()}" update="form"/>
             </div>
           </h:form>

--- a/engine-cockpit/webContent/view/monitorThreads.xhtml
+++ b/engine-cockpit/webContent/view/monitorThreads.xhtml
@@ -33,7 +33,7 @@
                   <i class="pr-3 ti ti-clock-play" />
                   <h2 class="m-0">#{ivy.cm.co('/common/Threads')}</h2>
                   <p:commandButton id="refresh" icon="ti ti-refresh" action="#{threadBean.refresh()}" title="#{ivy.cm.co('/common/Refresh')}" styleClass="flex-shrink-0 ml-auto rounded-button" update="threadTable"/>
-                  <p:commandButton id="dump" icon="pi pi-arrow-down" ajax="false" title="#{ivy.cm.co('/monitor/thread/SaveThreadDump')}" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button">
+                  <p:commandButton id="dump" icon="ti ti-arrow-down" ajax="false" title="#{ivy.cm.co('/monitor/thread/SaveThreadDump')}" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button">
                     <p:fileDownload value="#{threadBean.dump()}"/>
                   </p:commandButton>
                 </div>

--- a/engine-cockpit/webContent/view/monitorThreads.xhtml
+++ b/engine-cockpit/webContent/view/monitorThreads.xhtml
@@ -30,9 +30,9 @@
             <div class="card">
               <div class="card-header flex-wrap">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-synchronize-arrow-clock" />
+                  <i class="pr-3 ti ti-clock-play" />
                   <h2 class="m-0">#{ivy.cm.co('/common/Threads')}</h2>
-                  <p:commandButton id="refresh" icon="si si-button-refresh-arrows" action="#{threadBean.refresh()}" title="#{ivy.cm.co('/common/Refresh')}" styleClass="flex-shrink-0 ml-auto rounded-button" update="threadTable"/>
+                  <p:commandButton id="refresh" icon="ti ti-refresh" action="#{threadBean.refresh()}" title="#{ivy.cm.co('/common/Refresh')}" styleClass="flex-shrink-0 ml-auto rounded-button" update="threadTable"/>
                   <p:commandButton id="dump" icon="pi pi-arrow-down" ajax="false" title="#{ivy.cm.co('/monitor/thread/SaveThreadDump')}" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button">
                     <p:fileDownload value="#{threadBean.dump()}"/>
                   </p:commandButton>
@@ -45,13 +45,13 @@
                 emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
                 <f:facet name="header">
                   <div class="ui-input-icon-left filter-container">
-                    <i class="pi pi-search"/>
+                    <i class="ti ti-search"/>
                     <p:inputText id="globalFilter" onkeyup="PF('threadTable').filter()" value="#{threadBean.filter}" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}"/>
                   </div>
                 </f:facet>
                 <p:column headerText="#{ivy.cm.co('/common/ID')}" sortBy="#{thread.id}" filterBy="#{thread.id}" width="5%">
                   <p:commandLink oncomplete="PF('threadDialog').show();" title="#{ivy.cm.co('/monitor/thread/ThreadDetail')}" action="#{threadBean.setSelected(thread)}" update="threadDialog">
-                    <i class="pr-3 si si-synchronize-arrow-clock" />
+                    <i class="pr-3 ti ti-clock-play" />
                     <h:outputText value="#{thread.id}"/>
                   </p:commandLink>
                 </p:column>
@@ -63,7 +63,7 @@
                     <h:outputText value="#{thread.state}" class="#{thread.stateColorClass}"/>
                     <p:tooltip for="state" value="#{thread.stateTitle}" position="right"/>
                     <h:panelGroup rendered="#{thread.deadLocked}">
-                      <i h:rendered="#{thread.deadLocked}" class="pr-3 si si-road-sign-warning deadlocked ${thread.stateColorClass}"></i>
+                      <i h:rendered="#{thread.deadLocked}" class="pr-3 ti ti-alert-triangle deadlocked ${thread.stateColorClass}"></i>
                     </h:panelGroup>
                   </h:panelGroup>
                 </p:column>
@@ -136,7 +136,7 @@
               <p:outputPanel id="lockedMonitors" styleClass="code">#{threadBean.selected.lockedMonitors}</p:outputPanel>
               <h:panelGroup>
                 <p:outputLabel for="stackTrace" value="#{ivy.cm.co('/monitor/thread/StackTrace')}"/>
-                <p:commandButton id="copyStack" icon="si si-copy-paste" type="button" title="#{ivy.cm.co('/common/CopyToClipboard')}"
+                <p:commandButton id="copyStack" icon="ti ti-copy" type="button" title="#{ivy.cm.co('/common/CopyToClipboard')}"
                   onclick="var button=this; copyToClipboard($('#thread\\:stackTrace').text(), button)"
                   styleClass="ui-button-flat rounded-button"/>
               </h:panelGroup>

--- a/engine-cockpit/webContent/view/monitorTraceDetail.xhtml
+++ b/engine-cockpit/webContent/view/monitorTraceDetail.xhtml
@@ -35,7 +35,7 @@
                     <i class="pr-3 si si-monitor-heart-beat-search"></i>
                     <h6 class="m-0">#{ivy.cm.co('/monitorTraceDetail/SlowRequestDetail')}</h6>
                     <p:commandButton id="export" title="#{ivy.cm.co('/monitorTraceDetail/ExportSpan')}"
-                      ajax="false" icon="si si-office-file-xls-1"
+                      ajax="false" icon="ti ti-file-type-xls"
                       styleClass="flex-shrink-0 ml-auto ui-button-secondary rounded-button"
                       disabled="#{!spanBean.traceAvailable}">
                       <p:dataExporter type="xlsxstream"
@@ -58,7 +58,7 @@
                 <p:ajax event="select" listener="#{spanBean.nodeSelect}" update="attributesTable" />
                 <p:column headerText="#{ivy.cm.co('/common/Name')}" exportFunction="#{spanBean.exportName(span)}">
                   <h:outputText value="#{span.name}" title="#{span.attributesInfo}">
-                    <i class="si si-time-clock-circle #{span.statusClass} table-icon" title="#{span.statusTooltip}"></i>
+                    <i class="ti ti-clock #{span.statusClass} table-icon" title="#{span.statusTooltip}"></i>
                   </h:outputText>
                 </p:column>
                 <p:column style="width: 130px;" exportFunction="#{traceBean.export}">
@@ -87,7 +87,7 @@
             <div class="card">
               <div class="card-header flex-wrap">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-cog"></i>
+                  <i class="pr-3 ti ti-settings"></i>
                   <h6 class="m-0">#{ivy.cm.co('/common/Attributes')}</h6>
                 </div>
               </div>

--- a/engine-cockpit/webContent/view/monitorTraceDetail.xhtml
+++ b/engine-cockpit/webContent/view/monitorTraceDetail.xhtml
@@ -32,7 +32,7 @@
               <h:form id="form">
                 <div class="card-header flex-wrap">
                   <div class="card-title flex align-items-center">
-                    <i class="pr-3 si si-monitor-heart-beat-search"></i>
+                    <i class="pr-3 ti ti-device-desktop-search"></i>
                     <h6 class="m-0">#{ivy.cm.co('/monitorTraceDetail/SlowRequestDetail')}</h6>
                     <p:commandButton id="export" title="#{ivy.cm.co('/monitorTraceDetail/ExportSpan')}"
                       ajax="false" icon="ti ti-file-type-xls"

--- a/engine-cockpit/webContent/view/monitorTraces.xhtml
+++ b/engine-cockpit/webContent/view/monitorTraces.xhtml
@@ -27,18 +27,18 @@
           <div class="card">
             <div class="card-header flex-wrap">
               <div class="card-title flex align-items-center">
-                <i class="pr-3 si si-alarm-bell-timer"></i>
+                <i class="pr-3 ti ti-bell-plus"></i>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/SlowRequests')}</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
-                    icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
+                    icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{traceBean.stop}" update="@form" title="#{ivy.cm.co('/common/StopRecording')}"
                     icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}" />
                 <p:commandButton id="clear" actionListener="#{traceBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/execution/ClearStatistic')}"
-                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notCleanable}" />
+                    icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notCleanable}" />
                 <p:commandButton id="refresh" actionListener="#{traceBean.refresh}" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"
-                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{traceBean.notRefreshable}" />
+                    icon="ti ti-refresh" styleClass="flex-shrink-0 ml-1 rounded-button" disabled="#{traceBean.notRefreshable}" />
                 <p:commandButton id="export" title="#{ivy.cm.co('/monitor/traces/ExportTraces')}" ajax="false"
-                    icon="si si-office-file-xls-1" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" disabled="#{traceBean.notCleanable}">
+                    icon="ti ti-file-type-xls" styleClass="flex-shrink-0 ml-1 ui-button-secondary rounded-button" disabled="#{traceBean.notCleanable}">
                   <p:dataExporter type="xlsxstream" target="traceTable" fileName="#{ivy.cm.co('/monitor/traces/Traces')}"/>
                 </p:commandButton>
               </div>
@@ -51,7 +51,7 @@
               emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
               <f:facet name="header">
                 <div class="ui-input-icon-left filter-container" style="width: 100%;">
-                  <i class="pi pi-search"/>
+                  <i class="ti ti-search"/>
                   <p:inputText id="globalFilter" onkeyup="PF('traceTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{traceBean.filter}" />
                 </div>
               </f:facet>
@@ -63,7 +63,7 @@
               <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{trace.name}" filterBy="#{trace.name}" exportFunction="#{traceBean.export}" style="width: 100%;">
                 <a href="monitorTraceDetail.xhtml?traceId=#{trace.id}">
                   <h:outputText value="#{trace.name}" title="#{trace.info}" >
-                    <i class="si si-time-clock-circle #{trace.statusClass} table-icon" title="#{trace.statusTooltip}"></i>
+                    <i class="ti ti-clock #{trace.statusClass} table-icon" title="#{trace.statusTooltip}"></i>
                   </h:outputText>
                 </a>
               </p:column>
@@ -96,7 +96,7 @@
           <p:staticMessage severity="warn" detail="#{ivy.cm.co('/monitor/traces/StartTracesHelpText')}" />
           <div class="custom-dialog-footer">
             <p:commandButton id="cancel" type="button" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-            <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="si si-controls-play"
+            <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="ti ti-player-play"
               styleClass="modal-input-button" actionListener="#{traceBean.start}" update="form"/>
           </div>
         </h:form>

--- a/engine-cockpit/webContent/view/monitorTraces.xhtml
+++ b/engine-cockpit/webContent/view/monitorTraces.xhtml
@@ -32,7 +32,7 @@
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
                     icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{traceBean.stop}" update="@form" title="#{ivy.cm.co('/common/StopRecording')}"
-                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}" />
+                    icon="ti ti-player-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}" />
                 <p:commandButton id="clear" actionListener="#{traceBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/execution/ClearStatistic')}"
                     icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notCleanable}" />
                 <p:commandButton id="refresh" actionListener="#{traceBean.refresh}" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"

--- a/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
+++ b/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
@@ -32,7 +32,7 @@
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
                     icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{traceBean.stop}" update="@form" title="#{ivy.cm.co('/common/StopRecording')}"
-                    icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}"/>
+                    icon="ti ti-player-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}"/>
                 <p:commandButton id="clear" actionListener="#{trafficGraphBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/execution/ClearStatistic')}"
                     icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{trafficGraphBean.notClearable}"/>
                 <p:commandButton id="refresh" actionListener="#{trafficGraphBean.refresh}" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"

--- a/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
+++ b/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
@@ -27,7 +27,7 @@
           <div class="card">
             <div class="card-header flex-wrap">
               <div class="card-title flex align-items-center">
-                <i class="pr-3 ti ti ti-eye"></i>
+                <i class="pr-3 ti ti-eye"></i>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/TrafficGraph')}</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
                     icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />

--- a/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
+++ b/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
@@ -27,7 +27,7 @@
           <div class="card">
             <div class="card-header flex-wrap">
               <div class="card-title flex align-items-center">
-                <i class="pr-3 si ti ti-eye"></i>
+                <i class="pr-3 ti ti ti-eye"></i>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/TrafficGraph')}</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
                     icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />

--- a/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
+++ b/engine-cockpit/webContent/view/monitorTrafficGraph.xhtml
@@ -27,16 +27,16 @@
           <div class="card">
             <div class="card-header flex-wrap">
               <div class="card-title flex align-items-center">
-                <i class="pr-3 si si si-view-1"></i>
+                <i class="pr-3 si ti ti-eye"></i>
                 <h2 class="m-0">#{ivy.cm.co('/sidebar/TrafficGraph')}</h2>
                 <p:commandButton id="start" onclick="PF('startRecordingDialog').show();" title="#{ivy.cm.co('/monitor/jfr/StartRecording')}"
-                    icon="si si-controls-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
+                    icon="ti ti-player-play" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" disabled="#{traceBean.notStartable}" />
                 <p:commandButton id="stop" actionListener="#{traceBean.stop}" update="@form" title="#{ivy.cm.co('/common/StopRecording')}"
                     icon="si si-controls-stop" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{traceBean.notStoppable}"/>
                 <p:commandButton id="clear" actionListener="#{trafficGraphBean.clear}" update="@form" title="#{ivy.cm.co('/monitor/execution/ClearStatistic')}"
-                    icon="si si-bin-1" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{trafficGraphBean.notClearable}"/>
+                    icon="ti ti-trash" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" disabled="#{trafficGraphBean.notClearable}"/>
                 <p:commandButton id="refresh" actionListener="#{trafficGraphBean.refresh}" update="@form" title="#{ivy.cm.co('/monitor/session/RefreshStatistic')}"
-                    icon="si si-button-refresh-arrows" styleClass="flex-shrink-0 ml-1 rounded-button"  disabled="#{traceBean.notRefreshable}"/>
+                    icon="ti ti-refresh" styleClass="flex-shrink-0 ml-1 rounded-button"  disabled="#{traceBean.notRefreshable}"/>
               </div>
             </div>
             <p:diagram id="diagram" style="border-right: dotted 1px; border-bottom: dotted 1px; height: #{trafficGraphBean.height}px; width: #{trafficGraphBean.width}px; overflow: hidden;" value="#{trafficGraphBean.model}" styleClass="ui-widget-content" var="system">
@@ -64,7 +64,7 @@
           <p:staticMessage severity="warn" detail="#{ivy.cm.co('/monitor/traces/StartTracesHelpText')}" />
           <div class="custom-dialog-footer">
             <p:commandButton id="cancel" type="button" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Cancel')}" styleClass="ui-button-secondary ui-button-flat modal-input-button"/>
-            <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="si si-controls-play"
+            <p:commandButton id="start" onclick="PF('startRecordingDialog').hide();" value="#{ivy.cm.co('/common/Start')}" icon="ti ti-player-play"
               styleClass="modal-input-button" actionListener="#{traceBean.start}" update="form"/>
           </div>
         </h:form>

--- a/engine-cockpit/webContent/view/notification-channel-detail.xhtml
+++ b/engine-cockpit/webContent/view/notification-channel-detail.xhtml
@@ -29,7 +29,7 @@
           <p:autoUpdate />
         </p:growl>
         <div class="flex align-items-center mb-3">
-          <h:outputText value="#{notificationChannelDetailBean.channel.displayIcon}" class="pr-3 si notification-channel-title-icon" escape="false" /> <!-- contains no user input, contains icon -->
+          <h:outputText value="#{notificationChannelDetailBean.channel.displayIcon}" class="pr-3 ti notification-channel-title-icon" escape="false" /> <!-- contains no user input, contains icon -->
           <h2 class="m-0">#{notificationChannelDetailBean.channel.displayName}</h2>
           <p:commandButton id="open" actionListener="#{notificationChannelDetailBean.open}" title="#{ivy.cm.co('/notificationChannelDetail/UnlockChannel')}"
             icon="ti ti-plug" styleClass="flex-shrink-0 ml-auto rounded-button" update="form" 

--- a/engine-cockpit/webContent/view/notification-channel-detail.xhtml
+++ b/engine-cockpit/webContent/view/notification-channel-detail.xhtml
@@ -35,13 +35,13 @@
             icon="si si-charger" styleClass="flex-shrink-0 ml-auto rounded-button" update="form" 
             rendered="#{notificationChannelDetailBean.channel.push}" disabled="#{not notificationChannelDetailBean.channel.locked}"/>
           <p:commandButton id="resetPush" actionListener="#{notificationChannelDetailBean.onload}" title="#{ivy.cm.co('/notificationChannelDetail/ResetChanges')}"
-            icon="si si-undo" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" update="form"
+            icon="ti ti-arrow-back-up" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" update="form"
             rendered="#{notificationChannelDetailBean.channel.push}"/>
           <p:commandButton id="resetNonPush" actionListener="#{notificationChannelDetailBean.onload}" title="#{ivy.cm.co('/notificationChannelDetail/ResetChanges')}"
-            icon="si si-undo" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" update="form"
+            icon="ti ti-arrow-back-up" styleClass="flex-shrink-0 ml-auto ui-button-danger rounded-button" update="form"
             rendered="#{not notificationChannelDetailBean.channel.push}"/>
           <p:commandButton id="save" actionListener="#{notificationChannelDetailBean.save}" title="#{ivy.cm.co('/common/SaveChanges')}"
-            icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"/>
+            icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-1 ui-button-success rounded-button"/>
         </div>
         <h:form id="form">
           <p:panelGrid columns="2" columnClasses="col-12 md:col-2 lg:col-2, col-12 md:col-10 lg:col-10"
@@ -66,7 +66,7 @@
             <p:column headerText="#{ivy.cm.co('/common/Event')}" sortBy="#{event.displayName}">
               <h:panelGroup id="event">
                 <h:outputText value="#{event.displayName}" styleClass="event-kind" />
-                <i class="si si-question-circle"></i>
+                <i class="ti ti-help-circle"></i>
               </h:panelGroup>
               <p:tooltip for="form:events:#{rowIndex}:event" value="#{event.description}" position="top" styleClass="pre-tooltip" />
             </p:column>

--- a/engine-cockpit/webContent/view/notification-channel-detail.xhtml
+++ b/engine-cockpit/webContent/view/notification-channel-detail.xhtml
@@ -32,7 +32,7 @@
           <h:outputText value="#{notificationChannelDetailBean.channel.displayIcon}" class="pr-3 si notification-channel-title-icon" escape="false" /> <!-- contains no user input, contains icon -->
           <h2 class="m-0">#{notificationChannelDetailBean.channel.displayName}</h2>
           <p:commandButton id="open" actionListener="#{notificationChannelDetailBean.open}" title="#{ivy.cm.co('/notificationChannelDetail/UnlockChannel')}"
-            icon="si si-charger" styleClass="flex-shrink-0 ml-auto rounded-button" update="form" 
+            icon="ti ti-plug" styleClass="flex-shrink-0 ml-auto rounded-button" update="form" 
             rendered="#{notificationChannelDetailBean.channel.push}" disabled="#{not notificationChannelDetailBean.channel.locked}"/>
           <p:commandButton id="resetPush" actionListener="#{notificationChannelDetailBean.onload}" title="#{ivy.cm.co('/notificationChannelDetail/ResetChanges')}"
             icon="ti ti-arrow-back-up" styleClass="flex-shrink-0 ml-1 ui-button-danger rounded-button" update="form"

--- a/engine-cockpit/webContent/view/notification-channel-detail.xhtml
+++ b/engine-cockpit/webContent/view/notification-channel-detail.xhtml
@@ -29,7 +29,7 @@
           <p:autoUpdate />
         </p:growl>
         <div class="flex align-items-center mb-3">
-          <h:outputText value="#{notificationChannelDetailBean.channel.displayIcon}" class="pr-3 ti notification-channel-title-icon" escape="false" /> <!-- contains no user input, contains icon -->
+          <h:outputText value="#{notificationChannelDetailBean.channel.displayIcon}" class="pr-3 notification-channel-title-icon" escape="false" /> <!-- contains no user input, contains icon -->
           <h2 class="m-0">#{notificationChannelDetailBean.channel.displayName}</h2>
           <p:commandButton id="open" actionListener="#{notificationChannelDetailBean.open}" title="#{ivy.cm.co('/notificationChannelDetail/UnlockChannel')}"
             icon="ti ti-plug" styleClass="flex-shrink-0 ml-auto rounded-button" update="form" 

--- a/engine-cockpit/webContent/view/notification-channels.xhtml
+++ b/engine-cockpit/webContent/view/notification-channels.xhtml
@@ -23,7 +23,7 @@
       <div class="card">
         <p:growl id="msgs" showDetail="true" />
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-advertising-megaphone-2 card-title-icon"></i>
+          <i class="pr-3 ti ti-speakerphone card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/NotificationChannels')}</h2>
         </div>
         <cc:SecuritySystemTabs tabChange="#{notificationChannelsBean.onload}" id="securitySystems">

--- a/engine-cockpit/webContent/view/notificationDeliveries.xhtml
+++ b/engine-cockpit/webContent/view/notificationDeliveries.xhtml
@@ -97,7 +97,7 @@
                 </h:panelGroup>
               </p:outputPanel>
               <p:tooltip id="errorDetails" for="error">
-                <h5 class="flex align-items-center"><i class="si si-computer-chip-search"></i><h:outputText value="&#160;"/>#{ivy.cm.co('/notificationDeliveries/ErrorInformation')}</h5>
+                <h5 class="flex align-items-center"><i class="ti ti-settings-search"></i><h:outputText value="&#160;"/>#{ivy.cm.co('/notificationDeliveries/ErrorInformation')}</h5>
                 <p:panelGrid layout="grid" columns="2" columnClasses="ui-g-3, ui-g-9">
                   <p:outputLabel value="#{ivy.cm.co('/notificationDeliveries/FailedDeliverAttemps')}"/>
                   <h:outputText value="#{delivery.numberOfErrors}" />

--- a/engine-cockpit/webContent/view/notificationDeliveries.xhtml
+++ b/engine-cockpit/webContent/view/notificationDeliveries.xhtml
@@ -26,12 +26,12 @@
       <div class="card">
 
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-advertising-megaphone-2 card-title-icon"></i>
+          <i class="pr-3 ti ti-speakerphone card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/notificationDeliveries/Notification')} #{notificationBean.notification.id}</h2>
           <p:commandButton id="reusher" actionListener="#{notificationBean.notification.reusher}" title="#{ivy.cm.co('/notificationDeliveries/ReevaluteDeliveries')}"
-            icon="si si-multiple-actions-add" styleClass="flex-shrink-0 ml-auto rounded-button" update="tableForm"/>
+            icon="ti ti-user-plus" styleClass="flex-shrink-0 ml-auto rounded-button" update="tableForm"/>
           <p:commandButton id="retry" actionListener="#{notificationBean.notification.retry}" title="#{ivy.cm.co('/notificationDeliveries/RetryToDeliver')}"
-            icon="si si-send-email" styleClass="flex-shrink-0 ml-1 rounded-button" update="tableForm"/>
+            icon="ti ti-mail" styleClass="flex-shrink-0 ml-1 rounded-button" update="tableForm"/>
         </div>
 
         <h:form id="tableForm" onkeypress="if (event.keyCode == 13) return false;">
@@ -40,7 +40,7 @@
             <f:facet name="header">
               <div class="flex">
                 <span class="ui-input-icon-left filter-container ui-fluid" style="width: 100%;">
-                  <i class="pi pi-search"/>
+                  <i class="ti ti-search"/>
                   <p:inputText id="globalFilter" onkeyup="PF('deliveryTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{notificationBean.dataModel.filter}" />
                 </span>
               </div>
@@ -88,11 +88,11 @@
             <p:column headerText="#{ivy.cm.co('/notificationDeliveries/Errors')}">
               <p:outputPanel id="error" rendered="#{delivery.numberOfErrors gt 0}">
                 <h:panelGroup>
-                  <i class="si si-delete-1 table-icon state-inactive"></i>
+                  <i class="ti ti-trash table-icon state-inactive"></i>
                   <h:outputText value="#{delivery.numberOfErrors}" />
                 </h:panelGroup>
                 <h:panelGroup rendered="#{not empty delivery.nextRetryAt}">
-                  <i class="si si-synchronize-arrow-clock table-icon"></i>
+                  <i class="ti ti-clock-play table-icon"></i>
                   <h:outputText value="#{delivery.nextRetryIn}" />
                 </h:panelGroup>
               </p:outputPanel>
@@ -117,7 +117,7 @@
             </p:column>
 
             <p:column styleClass="table-btn-1">
-              <p:commandButton id="retry" title="#{ivy.cm.co('/notificationDeliveries/RetryToDeliver')}" icon="si si-send-email" rendered="#{delivery.numberOfErrors gt 0}"
+              <p:commandButton id="retry" title="#{ivy.cm.co('/notificationDeliveries/RetryToDeliver')}" icon="ti ti-mail" rendered="#{delivery.numberOfErrors gt 0}"
                 actionListener="#{delivery.retry}" ajax="true" update="@form" styleClass="rounded-button"/>
             </p:column>
 

--- a/engine-cockpit/webContent/view/notifications.xhtml
+++ b/engine-cockpit/webContent/view/notifications.xhtml
@@ -24,7 +24,7 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-advertising-megaphone-2 card-title-icon"></i>
+          <i class="pr-3 ti ti-speakerphone card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/sidebar/Notifications')}</h2>
         </div>
         <cc:SecuritySystemTabs tabChange="#{notificationsBean.onload}" id="tabs">
@@ -35,7 +35,7 @@
               <f:facet name="header">
                 <div class="flex">
                   <span class="ui-input-icon-left filter-container ui-fluid" style="width: 100%;">
-                    <i class="pi pi-search"/>
+                    <i class="ti ti-search"/>
                     <p:inputText id="globalFilter" onkeyup="PF('notificationTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{notificationsBean.dataModel.filter}" />
                   </span>
                 </div>
@@ -79,7 +79,7 @@
               </p:column>
 
               <p:column styleClass="table-btn-1">
-                <p:commandButton id="showPayload" title="#{ivy.cm.co('/notification/ShowPayload')}" icon="si si-office-file-doc-1"
+                <p:commandButton id="showPayload" title="#{ivy.cm.co('/notification/ShowPayload')}" icon="ti ti-file-type-doc"
                     actionListener="#{notificationPayloadBean.setNotification(notification)}" update="payloadModal" styleClass="rounded-button"
                     oncomplete="PF('payloadModal').show()" />
               </p:column>

--- a/engine-cockpit/webContent/view/notifications.xhtml
+++ b/engine-cockpit/webContent/view/notifications.xhtml
@@ -69,7 +69,7 @@
 
               <p:column headerText="#{ivy.cm.co('/common/PMV')}">
                 <p:link rendered="#{not empty notification.pmvUri}" href="#{notification.pmvUri}">
-                  <i class="si-#{notification.pmvIcon} table-icon"/>
+                  <i class="#{notification.pmvIcon} table-icon"/>
                   <h:outputText value="#{notification.pmv}" />
                 </p:link>
               </p:column>

--- a/engine-cockpit/webContent/view/pmv-detail.xhtml
+++ b/engine-cockpit/webContent/view/pmv-detail.xhtml
@@ -32,7 +32,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-information-circle"></i>
+                  <i class="pr-3 ti ti-info-circle"></i>
                   <h6 class="m-0">#{ivy.cm.co('/pmvDetail/PMVInformation')}</h6>
                 </div>
               </div>
@@ -57,7 +57,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-navigation-up-circle"></i>
+                  <i class="pr-3 ti ti-circle-arrow-up"></i>
                   <h6 class="m-0">#{ivy.cm.co('/pmvDetail/AllPMVsDependingOnPMV')}</h6>
                 </div>
               </div>
@@ -81,7 +81,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-navigation-down-circle"></i>
+                  <i class="pr-3 ti ti-circle-arrow-down"></i>
                   <h6 class="m-0">#{ivy.cm.co('/pmvDetail/AllPMVsRequiredByPMV')}</h6>
                 </div>
               </div>

--- a/engine-cockpit/webContent/view/pmv-detail.xhtml
+++ b/engine-cockpit/webContent/view/pmv-detail.xhtml
@@ -66,7 +66,7 @@
                 <p:column headerText="#{ivy.cm.co('/pmvDetail/PMV')}">
                   <h:outputLink value="#{pmv.detailView}">
                     <h:outputText value="#{pmv.name}" title="#{pmv.libraryId}">
-                      <i class="si si-#{pmv.icon}" style="margin-right: 5px;" />
+                      <i class="#{pmv.icon}" style="margin-right: 5px;" />
                     </h:outputText>
                   </h:outputLink>
                 </p:column>
@@ -91,7 +91,7 @@
                 <p:column headerText="PMV">
                   <h:outputLink value="#{pmv.detailView}">
                     <h:outputText value="#{pmv.name}" title="#{pmv.libraryId}">
-                      <i class="si si-#{pmv.icon}" style="margin-right: 5px;" />
+                      <i class="#{pmv.icon}" style="margin-right: 5px;" />
                     </h:outputText>
                   </h:outputLink>
                 </p:column>

--- a/engine-cockpit/webContent/view/profile.xhtml
+++ b/engine-cockpit/webContent/view/profile.xhtml
@@ -167,7 +167,7 @@
           <p:commandButton
             id="saveBtn"
             value="#{ivy.cm.co('/profile/SaveProfile')}"
-            icon="si si-floppy-disk"
+            icon="ti ti-device-floppy"
             styleClass="modal-input-button"
             action="#{profileBean.save}"
             update="@form" />

--- a/engine-cockpit/webContent/view/restclientdetail.xhtml
+++ b/engine-cockpit/webContent/view/restclientdetail.xhtml
@@ -23,7 +23,7 @@
     <ui:define name="topbar-items">
       <li class="topbar-item help-dialog">
         <a href="#" onclick="PF('helpServicesModal').show();">
-          <i class="topbar-icon si si-question-circle"></i>
+          <i class="topbar-icon ti ti-help-circle"></i>
         </a>
       </li>
     </ui:define>

--- a/engine-cockpit/webContent/view/restclients.xhtml
+++ b/engine-cockpit/webContent/view/restclients.xhtml
@@ -19,7 +19,7 @@
       <div class="card">
         <p:growl id="msgs" />
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-network-share card-title-icon"></i>
+          <i class="pr-3 ti ti-world card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/RestClients')}</h2>
         </div>
         <cc:ApplicationTabs tabChange="#{restClientsBean.reloadRestClients}" id="tabs">
@@ -30,7 +30,7 @@
               filteredValue="#{restClientsBean.filteredRestClients}" lazy="false" id="restClientsTable">
               <f:facet name="header">
                 <div class="ui-input-icon-left filter-container">
-                  <i class="pi pi-search"/>
+                  <i class="ti ti-search"/>
                   <p:inputText id="globalFilter" onkeyup="PF('restClientsTable_#{app.id}').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{restClientsBean.filter}" />
                 </div>
               </f:facet>
@@ -39,7 +39,7 @@
                 styleClass="restclient-name-column">
                 <a href="#{restclient.getViewUrl(app.name)}">
                   <h:outputText value="#{restclient.name}" styleClass="restclient-name">
-                    <i class="si si-network-share table-icon"></i>
+                    <i class="ti ti-world table-icon"></i>
                   </h:outputText>
                 </a>
               </p:column>

--- a/engine-cockpit/webContent/view/restservices.xhtml
+++ b/engine-cockpit/webContent/view/restservices.xhtml
@@ -22,13 +22,13 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-network-share"></i>
+                  <i class="pr-3 ti ti-world"></i>
                   <h2 class="m-0">#{ivy.cm.co('/common/RestServices')}</h2>
                   <p:linkButton id="browseRestAPI" title="#{ivy.cm.co('/restServices/BrowseRestAPIButtonTitle')}"
-                    icon="si si-network-browser" type="button"
+                    icon="ti ti-browser" type="button"
                     href="#{advisorBean.apiBrowserUrl}/index.html?urls.primaryName=#{managerBean.selectedApplicationName}"
                     target="_blank" rel="noopener noreferrer" styleClass="ml-auto rounded-button" />
-                  <p:linkButton id="configRestBackend" title="#{ivy.cm.co('/restServices/ConfigureRestBackendButtonTitle')}" icon="si si-cog" type="button"
+                  <p:linkButton id="configRestBackend" title="#{ivy.cm.co('/restServices/ConfigureRestBackendButtonTitle')}" icon="ti ti-settings" type="button"
                     styleClass="ml-1 ui-button-secondary rounded-button" href="systemconfig.xhtml?filter=REST.Servlet" />
                 </div>
               </div>

--- a/engine-cockpit/webContent/view/roledetail.xhtml
+++ b/engine-cockpit/webContent/view/roledetail.xhtml
@@ -38,7 +38,7 @@
                 title="#{ivy.cm.co('/common/Users')}" />
               <cc:OverviewBox box="blue" count="#{roleDetailBean.userInheritCount}" icon="ti ti-users"
                 title="#{ivy.cm.co('/roleDetail/InheritUsers')}" />
-              <cc:OverviewBox box="gray" count="#{roleDetailBean.runningTaskCount}" icon="si si-briefcase"
+              <cc:OverviewBox box="gray" count="#{roleDetailBean.runningTaskCount}" icon="ti ti-briefcase-2"
                 title="#{ivy.cm.co('/roleDetail/RunningTasks')}" />
               <cc:OverviewBox box="darkgray" count="#{roleDetailBean.directTaskCount}" icon="ti ti-clipboard-list"
                 title="#{ivy.cm.co('/roleDetail/DirectOpenTasks')}" />

--- a/engine-cockpit/webContent/view/roledetail.xhtml
+++ b/engine-cockpit/webContent/view/roledetail.xhtml
@@ -34,13 +34,13 @@
         <div class="grid">
           <div class="col-12">
             <div class="grid">
-              <cc:OverviewBox box="white" count="#{roleDetailBean.userCount}" icon="si si-single-neutral-actions"
+              <cc:OverviewBox box="white" count="#{roleDetailBean.userCount}" icon="ti ti-user-check"
                 title="#{ivy.cm.co('/common/Users')}" />
-              <cc:OverviewBox box="blue" count="#{roleDetailBean.userInheritCount}" icon="si si-multiple-neutral-1"
+              <cc:OverviewBox box="blue" count="#{roleDetailBean.userInheritCount}" icon="ti ti-users"
                 title="#{ivy.cm.co('/roleDetail/InheritUsers')}" />
               <cc:OverviewBox box="gray" count="#{roleDetailBean.runningTaskCount}" icon="si si-briefcase"
                 title="#{ivy.cm.co('/roleDetail/RunningTasks')}" />
-              <cc:OverviewBox box="darkgray" count="#{roleDetailBean.directTaskCount}" icon="si si-task-list-approve"
+              <cc:OverviewBox box="darkgray" count="#{roleDetailBean.directTaskCount}" icon="ti ti-clipboard-list"
                 title="#{ivy.cm.co('/roleDetail/DirectOpenTasks')}" />
             </div>
           </div>

--- a/engine-cockpit/webContent/view/roles.xhtml
+++ b/engine-cockpit/webContent/view/roles.xhtml
@@ -19,14 +19,14 @@
       <div class="card">
         <p:growl id="msgs" />
         <h:form id="form" styleClass="flex align-items-center mb-3">
-          <i class="pr-3 si si-multiple-neutral-1 card-title-icon"></i>
+          <i class="pr-3 ti ti-users card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Roles')} <i id="roleCount">(#{roleBean.roleCount})</i></h2>
           <h:panelGroup id="syncPanel" styleClass="ml-auto">
             <p:splitButton value="#{ivy.cm.co('/roles/Synchronize')}"
-              icon="si si-button-refresh-arrows #{securityBean.syncRunningForSelectedSecuritySystem ? 'si-is-spinning' : ''} spin-icon"
+              icon="ti ti-refresh #{securityBean.syncRunningForSelectedSecuritySystem ? 'spinning' : ''} spin-icon"
               id="syncMoreBtn" rendered="#{!securityBean.ivySecurityForSelectedSecuritySystem}" immediate="true"
               process="@this" actionListener="#{securityBean.triggerSyncForSelectedSecuritySystem}" update="@parent">
-              <p:menuitem id="userSyncLog" value="#{ivy.cm.co('/common/SynchronizationLog')}" icon="si si-common-file-text"
+              <p:menuitem id="userSyncLog" value="#{ivy.cm.co('/common/SynchronizationLog')}" icon="ti ti-file-text"
                 onclick="window.location.href='#{securityBean.synchLogUri}'" />
             </p:splitButton>
             <p:poll widgetVar="logPoller" autoStart="#{securityBean.syncRunningForSelectedSecuritySystem}" interval="2"
@@ -38,15 +38,15 @@
           <h:form id="treeForm">
             <div class="table-search flex ui-fluid">
               <span class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{roleBean.roles.filter}">
                   <p:ajax event="keyup" delay="300" update="@form:tree" />
                 </p:inputText>
               </span>
-              <p:commandButton id="expandAll" icon="si si-move-expand-vertical"
+              <p:commandButton id="expandAll" icon="ti ti-arrows-vertical"
                 actionListener="#{roleBean.roles.expandAllNodes}" update="tree" title="#{ivy.cm.co('/common/ExpandAll')}"
                 styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined expand-all" />
-              <p:commandButton id="collapseAll" icon="si si-move-shrink-vertical"
+              <p:commandButton id="collapseAll" icon="ti ti-arrows-minimize"
                 actionListener="#{roleBean.roles.collapseAllNodes}" update="tree" title="#{ivy.cm.co('/common/CollapseAll')}"
                 styleClass="ml-1 flex-shrink-0 ui-button-secondary rounded-button ui-button-outlined" />
             </div>
@@ -70,7 +70,7 @@
                     actionListener="#{roleBean.increaseShowChildLimitAndReloadTree(1000)}" />
                 </p:treeNode>
                 <p:treeNode type="searchDummy" rendered="#{node.type == 'searchDummy'}">
-                  <i class="si si-navigation-menu-horizontal table-icon"></i>
+                  <i class="ti ti-dots table-icon"></i>
                   <h:outputText value="#{role.name}"
                     title="#{ivy.cm.co('/roles/SearchDummyPerformanceReason')}" />
                 </p:treeNode>

--- a/engine-cockpit/webContent/view/roles.xhtml
+++ b/engine-cockpit/webContent/view/roles.xhtml
@@ -58,7 +58,7 @@
                 <p:treeNode type="role" rendered="#{node.type == 'role'}">
                   <a href="#{role.getViewUrl()}" class="role-name"
                     title="#{role.member ? ivy.cm.co('/roles/Member') : ivy.cm.co('/roles/Role')}">
-                    <i class="si si-multiple-#{role.member ? 'actions-add' : 'neutral-1'} table-icon"></i>
+                    <i class="#{role.member ? 'ti ti-user-plus' : 'ti ti-users'} table-icon"></i>
                     <h:outputText value="#{role.name}" />
                     <h:outputText value=" (#{role.displayName}) " styleClass="addition-row-info" />
                     <h:outputText value="#{ivy.cm.content('/roles/ExternalRoleNameMessage').replace('role', role.externalName).get()}" rendered="#{not empty role.externalName}"

--- a/engine-cockpit/webContent/view/searchindex.xhtml
+++ b/engine-cockpit/webContent/view/searchindex.xhtml
@@ -26,7 +26,7 @@
 
         <div class="card-header">
           <div class="card-title flex align-items-center">
-            <i class="pr-3 si si-information-circle"></i>
+            <i class="pr-3 ti ti-info-circle"></i>
             <h6 class="m-0">#{searchIndexBean.searchIndex.name}</h6>
           </div>
         </div>
@@ -50,7 +50,7 @@
             </p:column>
 
             <p:column styleClass="table-btn-1">
-              <p:commandButton id="showDocument" title="#{ivy.cm.co('/searchIndex/ShowDocument')}" icon="si si-office-file-doc-1"
+              <p:commandButton id="showDocument" title="#{ivy.cm.co('/searchIndex/ShowDocument')}" icon="ti ti-file-type-doc"
                 actionListener="#{searchDocBean.setDoc(doc)}" update="searchDocModal" styleClass="rounded-button"
                 oncomplete="PF('searchDocModal').show()" />
             </p:column>

--- a/engine-cockpit/webContent/view/securitysystem-merge.xhtml
+++ b/engine-cockpit/webContent/view/securitysystem-merge.xhtml
@@ -25,7 +25,7 @@
             <p:autoUpdate />
           </p:growl>
           <div class="flex align-items-center mb-3">
-            <i class="pr-3 si si-move-to-bottom card-title-icon" />
+            <i class="pr-3 si ti-arrow-big-down-lines card-title-icon" />
             <h2 class="m-0">#{ivy.cm.co('/securitySystemMerge/MergeSecuritySystems')}</h2>
           </div>
 
@@ -39,10 +39,10 @@
                 itemLabel="#{securitySystem}" itemValue="#{securitySystem}" />
             </p:selectOneMenu>
 
-            <p:commandButton update="form" id="compare" icon="si si-move-to-bottom" value="#{ivy.cm.co('/securitySystemMerge/CompareButton')}" 
+            <p:commandButton update="form" id="compare" icon="si ti-arrow-big-down-lines" value="#{ivy.cm.co('/securitySystemMerge/CompareButton')}" 
               title="#{ivy.cm.co('/securitySystemMerge/CompareButtonTitle')}"
               actionListener="#{securitySystemCompareBean.run}"
-              oncomplete="var button=this; buttonRemoveSpinner(button, 'si-move-to-bottom');"
+              oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-arrow-big-down-lines');"
               onclick="var button=this; buttonAddSpinner(button);" 
                />
           </p:panelGrid>
@@ -53,13 +53,13 @@
               <p:staticMessage severity="info" detail="#{ivy.cm.co('/securitySystemMerge/ComparisonReportInfo')}" />
 
               <p:commandButton value="#{ivy.cm.co('/securitySystemMerge/ExecuteAllCreateOperationsButton')}" styleClass="mr-2 mb-2 ui-button-success"
-                title="#{ivy.cm.co('/securitySystemMerge/ExecuteAllCreateOperationsButtonTitle')}" update="report" icon="si si-add"
+                title="#{ivy.cm.co('/securitySystemMerge/ExecuteAllCreateOperationsButtonTitle')}" update="report" icon="ti ti-plus"
                 actionListener="#{securitySystemCompareBean.solveCreateIssues()}">
                 <p:confirm header="#{ivy.cm.co('/securitySystemMerge/ExecuteAllCreateOperationsConfirmDialogHeader')}"
                   message="#{ivy.cm.co('/securitySystemMerge/ExecuteAllCreateOperationsConfirmDialogContent')}" icon="ui-icon-alert" />
               </p:commandButton>
 
-              <p:commandButton value="#{ivy.cm.co('/securitySystemMerge/ExecuteAllUpdateOperationsButton')}" styleClass="mr-2 mb-2" icon="si si-navigation-right-circle"
+              <p:commandButton value="#{ivy.cm.co('/securitySystemMerge/ExecuteAllUpdateOperationsButton')}" styleClass="mr-2 mb-2" icon="ti ti-circle-arrow-right"
                 title="#{ivy.cm.co('/securitySystemMerge/ExecuteAllUpdateOperationsButtonTitle')}" update="report"
                 actionListener="#{securitySystemCompareBean.solveUpdateIssues()}">
                 <p:confirm header="#{ivy.cm.co('/securitySystemMerge/ExecuteAllUpdateOperationsConfirmDialogHeader')}"
@@ -67,7 +67,7 @@
                   icon="ui-icon-alert" />
               </p:commandButton>
 
-              <p:commandButton value="#{ivy.cm.co('/securitySystemMerge/ExecuteAllDeleteOperationsButton')}" styleClass="mr-2 mb-2 ui-button-danger" icon="si si-bin-1"
+              <p:commandButton value="#{ivy.cm.co('/securitySystemMerge/ExecuteAllDeleteOperationsButton')}" styleClass="mr-2 mb-2 ui-button-danger" icon="ti ti-trash"
                 title="#{ivy.cm.co('/securitySystemMerge/ExecuteAllDeleteOperationsButtonTitle')}" update="report"
                 actionListener="#{securitySystemCompareBean.solveDeleteIssues()}">
                 <p:confirm header="#{ivy.cm.co('/securitySystemMerge/ExecuteAllDeleteOperationsConfirmDialogHeader')}"

--- a/engine-cockpit/webContent/view/securitysystem-merge.xhtml
+++ b/engine-cockpit/webContent/view/securitysystem-merge.xhtml
@@ -25,7 +25,7 @@
             <p:autoUpdate />
           </p:growl>
           <div class="flex align-items-center mb-3">
-            <i class="pr-3 si ti-arrow-big-down-lines card-title-icon" />
+            <i class="pr-3 ti ti-arrow-big-down-lines card-title-icon" />
             <h2 class="m-0">#{ivy.cm.co('/securitySystemMerge/MergeSecuritySystems')}</h2>
           </div>
 
@@ -39,7 +39,7 @@
                 itemLabel="#{securitySystem}" itemValue="#{securitySystem}" />
             </p:selectOneMenu>
 
-            <p:commandButton update="form" id="compare" icon="si ti-arrow-big-down-lines" value="#{ivy.cm.co('/securitySystemMerge/CompareButton')}" 
+            <p:commandButton update="form" id="compare" icon="ti ti-arrow-big-down-lines" value="#{ivy.cm.co('/securitySystemMerge/CompareButton')}" 
               title="#{ivy.cm.co('/securitySystemMerge/CompareButtonTitle')}"
               actionListener="#{securitySystemCompareBean.run}"
               oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-arrow-big-down-lines');"

--- a/engine-cockpit/webContent/view/securitysystem-merge.xhtml
+++ b/engine-cockpit/webContent/view/securitysystem-merge.xhtml
@@ -42,7 +42,7 @@
             <p:commandButton update="form" id="compare" icon="ti ti-arrow-big-down-lines" value="#{ivy.cm.co('/securitySystemMerge/CompareButton')}" 
               title="#{ivy.cm.co('/securitySystemMerge/CompareButtonTitle')}"
               actionListener="#{securitySystemCompareBean.run}"
-              oncomplete="var button=this; buttonRemoveSpinner(button, 'ti-arrow-big-down-lines');"
+              oncomplete="var button=this; buttonRemoveSpinner(button, 'ti ti-arrow-big-down-lines');"
               onclick="var button=this; buttonAddSpinner(button);" 
                />
           </p:panelGrid>

--- a/engine-cockpit/webContent/view/securitysystem.xhtml
+++ b/engine-cockpit/webContent/view/securitysystem.xhtml
@@ -22,9 +22,9 @@
             <p:autoUpdate />
           </p:growl>
           <div class="flex align-items-center mb-3">
-            <i class="pr-3 si si-lock-1 card-title-icon"></i>
+            <i class="pr-3 ti ti-lock card-title-icon"></i>
             <h2 class="m-0">#{ivy.cm.co('/common/SecuritySystems')}</h2>
-            <p:commandButton styleClass="ml-auto" id="createSecuritySystemBtn" icon="si si-add" type="button" value="#{ivy.cm.co('/common/Add')}"
+            <p:commandButton styleClass="ml-auto" id="createSecuritySystemBtn" icon="ti ti-plus" type="button" value="#{ivy.cm.co('/common/Add')}"
               onclick="PF('newSecuritySystemModal').show();" />
           </div>
           <p:dataTable paginator="true" rows="20" paginatorPosition="bottom" paginatorAlwaysVisible="false"
@@ -33,13 +33,13 @@
             id="securitySystemTable" emptyMessage="#{ivy.cm.co('/common/NoRecordsFound')}">
             <f:facet name="header">
               <div class="ui-input-icon-left filter-container">
-                <i class="pi pi-search"/>
+                <i class="ti ti-search"/>
                 <p:inputText id="globalFilter" onkeyup="PF('securitySystemTable').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{securityBean.filter}" />
               </div>
             </f:facet>
             <p:column headerText="#{ivy.cm.co('/common/Name')}" sortBy="#{system.securitySystemName}" filterBy="#{system.securitySystemName}">
               <h:outputLink value="#{system.link}">
-                <i class="si si-lock-1 table-icon"></i>
+                <i class="ti ti-lock table-icon"></i>
                 <h:outputText value="#{system.securitySystemName}" styleClass="security-name" />
               </h:outputLink>
             </p:column>
@@ -55,7 +55,7 @@
             <p:column headerText="#{ivy.cm.co('/common/Application')}">
               <ui:repeat var="app" value="#{system.apps}" varStatus="status">
                 <a href="#{system.getApplicationDetailLink(app)}">
-                  <i class="si si-module table-icon"></i>#{app.name()}
+                  <i class="ti ti-layout-grid table-icon"></i>#{app.name()}
                 </a>
                 <h:outputText value="#{status.last ? '' : ' / '}" />
               </ui:repeat>

--- a/engine-cockpit/webContent/view/setup.xhtml
+++ b/engine-cockpit/webContent/view/setup.xhtml
@@ -42,18 +42,18 @@
           </h:panelGroup>
 
           <h:panelGroup id="wizardStepButtons" styleClass="wizard-steps mt-4 flex" layout="block">
-            <p:linkButton styleClass="ui-button-outlined rounded-button" type="button" icon="si si-question-circle"
+            <p:linkButton styleClass="ui-button-outlined rounded-button" type="button" icon="ti ti-help-circle"
               href="#{advisorBean.engineGuideBaseUrl}/reference/setup-wizard.html" target="_blank" rel="noopener noreferrer" />
             <p:commandButton id="cancelWizard" onclick="window.location = '/'" value="#{ivy.cm.co('/common/Cancel')}" type="button"
               styleClass="ml-auto ui-button-secondary ui-button-flat wizard-step-button" />
             <p:commandButton id="prevStep" actionListener="#{wizardBean.prevStep()}" value="#{ivy.cm.co('/common/Previous')}" update="wizardStepPage" process="@this" immediate="true"
-              icon="si si-arrow-left-1" styleClass="ml-1 ui-button-secondary wizard-step-button" 
+              icon="ti ti-chevron-left" styleClass="ml-1 ui-button-secondary wizard-step-button" 
               rendered="#{!wizardBean.firstStep}" async="true"/>
             <p:commandButton id="nextStep" actionListener="#{wizardBean.nextStep()}" value="#{ivy.cm.co('/common/Next')}" 
-              update="wizardStepPage" process="@this" immediate="true" icon="si si-arrow-right-1" 
+              update="wizardStepPage" process="@this" immediate="true" icon="ti ti-chevron-right" 
               styleClass="ml-1 wizard-step-button" rendered="#{!wizardBean.lastStep}" async="true"/>
             <p:commandButton id="finishWizard" value="#{ivy.cm.co('/common/Finish')}" oncomplete="PF('finishWizardModel').show();"
-              update="finishWizardModel" icon="si si-check-1" styleClass="ml-1 wizard-step-button" rendered="#{wizardBean.lastStep}" />
+              update="finishWizardModel" icon="ti ti-check" styleClass="ml-1 wizard-step-button" rendered="#{wizardBean.lastStep}" />
           </h:panelGroup>
 
           <p:dialog style="min-width: 300px;" header="#{ivy.cm.co('/setup/FinishSetupWizard')}" id="finishWizardModel"
@@ -76,7 +76,7 @@
               <div class="custom-dialog-footer">
                 <p:commandButton id="finishWizardNo" onclick="PF('finishWizardModel').hide();" value="#{ivy.cm.co('/common/Cancel')}" type="button"
                   styleClass="ui-button-secondary ui-button-flat modal-input-button" />
-                <p:commandButton id="finishWizardYes" oncomplete="window.location = '/'" value="#{ivy.cm.co('/common/OK')}" icon="si si-check-1" 
+                <p:commandButton id="finishWizardYes" oncomplete="window.location = '/'" value="#{ivy.cm.co('/common/OK')}" icon="ti ti-check" 
                   styleClass="modal-input-button" actionListener="#{systemDatabaseBean.saveConfiguration}"/>
               </div>
             </h:form>

--- a/engine-cockpit/webContent/view/systemconfig.xhtml
+++ b/engine-cockpit/webContent/view/systemconfig.xhtml
@@ -20,16 +20,16 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="si-common-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
+      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}system.html#system-configuration" />
     </ui:define>
 
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-cog card-title-icon"></i>
+          <i class="pr-3 ti ti-settings card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/SystemConfiguration')}</h2>
-          <p:commandButton id="reloadConfig" title="#{ivy.cm.co('/systemConfig/ReloadSystemConfiguration')}" icon="si si-button-refresh-arrows" 
+          <p:commandButton id="reloadConfig" title="#{ivy.cm.co('/systemConfig/ReloadSystemConfiguration')}" icon="ti ti-refresh" 
             actionListener="#{systemConfigBean.reloadConfig()}"
             styleClass="flex-shrink-0 ml-auto rounded-button"/>
         </div>

--- a/engine-cockpit/webContent/view/systemconfig.xhtml
+++ b/engine-cockpit/webContent/view/systemconfig.xhtml
@@ -20,7 +20,7 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
+      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="ti ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}system.html#system-configuration" />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/systemdb-info.xhtml
+++ b/engine-cockpit/webContent/view/systemdb-info.xhtml
@@ -17,7 +17,7 @@
           <p:ajax event="load" listener="#{systemDatabaseInfoBean.loadData}"/>
           <f:facet name="loading">
             <div class="ui-message ui-staticmessage ui-message-info ui-widget ui-corner-all">
-              <i id="connectionIcon" class="si si-button-refresh-arrows si-is-spinning"></i>
+              <i id="connectionIcon" class="ti ti-refresh spinning"></i>
               <span class="ui-message-info-summary ml-2">#{ivy.cm.co('/systemDbInfo/LoadDataSummaryMessage')}</span>
               <span class="ui-message-info-detail">#{ivy.cm.co('/systemDbInfo/LoadDataDetailMessage')}</span>
             </div>

--- a/engine-cockpit/webContent/view/systemdb.xhtml
+++ b/engine-cockpit/webContent/view/systemdb.xhtml
@@ -23,14 +23,14 @@
         <div class="flex align-items-center mb-3">
           <i class="pr-3 si si-database-settings card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/SystemDatabase')}</h2>
-          <p:linkButton outcome="systemdb-info" icon="si si-layout-dashboard" value="#{ivy.cm.co('/common/Info')}"
+          <p:linkButton outcome="systemdb-info" icon="ti ti-layout-dashboard" value="#{ivy.cm.co('/common/Info')}"
               styleClass="ml-auto ui-button-secondary" id="infoDb"/>
           <h:panelGroup id="sysDbSaveButtons" styleClass="ml-1">
             <p:commandButton actionListener="#{systemDatabaseBean.saveConfiguration}" value="#{ivy.cm.co('/common/Save')}"
-              icon="si si-floppy-disk" style="width: auto; float: right;" id="saveSystemDbConfig"
+              icon="ti ti-device-floppy" style="width: auto; float: right;" id="saveSystemDbConfig"
               rendered="#{systemDatabaseBean.connectionInfo.successful}" />
             <p:commandButton type="button" onclick="PF('saveUnknownConnectionModel').show()" value="#{ivy.cm.co('/common/Save')}"
-              icon="si si-floppy-disk" style="width: auto; float: right;" id="saveUnknownSystemDbConfig"
+              icon="ti ti-device-floppy" style="width: auto; float: right;" id="saveUnknownSystemDbConfig"
               rendered="#{!systemDatabaseBean.connectionInfo.successful}" />
           </h:panelGroup>
         </div>
@@ -47,7 +47,7 @@
             <p:commandButton id="cancelSaveUnknownConnection" onclick="PF('saveUnknownConnectionModel').hide();"
               value="#{ivy.cm.co('/common/Cancel')}" type="button" styleClass="ui-button-secondary ui-button-flat modal-input-button" />
             <p:commandButton id="saveUnknownConneciton" actionListener="#{systemDatabaseBean.saveConfiguration}"
-              value="#{ivy.cm.co('/common/Save')}" icon="si si-floppy-disk" styleClass="modal-input-button" widgetVar="saveUnknownConneciton"
+              value="#{ivy.cm.co('/common/Save')}" icon="ti ti-device-floppy" styleClass="modal-input-button" widgetVar="saveUnknownConneciton"
               oncomplete="PF('saveUnknownConnectionModel').hide();" />
           </div>
         </h:form>

--- a/engine-cockpit/webContent/view/systemdb.xhtml
+++ b/engine-cockpit/webContent/view/systemdb.xhtml
@@ -21,7 +21,7 @@
       </p:growl>
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-database-settings card-title-icon"></i>
+          <i class="pr-3 ti ti-database-cog card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/SystemDatabase')}</h2>
           <p:linkButton outcome="systemdb-info" icon="ti ti-layout-dashboard" value="#{ivy.cm.co('/common/Info')}"
               styleClass="ml-auto ui-button-secondary" id="infoDb"/>

--- a/engine-cockpit/webContent/view/userdetail.xhtml
+++ b/engine-cockpit/webContent/view/userdetail.xhtml
@@ -33,9 +33,9 @@
         <div class="grid">
           <div class="col-12">
             <div class="grid">
-              <cc:OverviewBox box="white" count="#{userDetailBean.startedCases}" icon="si si-plane-take-off"
+              <cc:OverviewBox box="white" count="#{userDetailBean.startedCases}" icon="ti ti-plane-tilt"
                 title="#{ivy.cm.co('/userDetail/StartedCases')}" />
-              <cc:OverviewBox box="blue" count="#{userDetailBean.workingOn}" icon="si si-briefcase" title="#{ivy.cm.co('/userDetail/WorkingOnTasks')}" />
+              <cc:OverviewBox box="blue" count="#{userDetailBean.workingOn}" icon="ti ti-briefcase-2" title="#{ivy.cm.co('/userDetail/WorkingOnTasks')}" />
               <cc:OverviewBox box="gray" count="#{userDetailBean.personalTasks}" icon="ti ti-checklist"
                 title="#{ivy.cm.co('/userDetail/PersonalTasks')}" />
               <cc:OverviewBox box="darkgray" count="#{userDetailBean.canWorkOn}" icon="ti ti-clipboard-list"

--- a/engine-cockpit/webContent/view/userdetail.xhtml
+++ b/engine-cockpit/webContent/view/userdetail.xhtml
@@ -36,9 +36,9 @@
               <cc:OverviewBox box="white" count="#{userDetailBean.startedCases}" icon="si si-plane-take-off"
                 title="#{ivy.cm.co('/userDetail/StartedCases')}" />
               <cc:OverviewBox box="blue" count="#{userDetailBean.workingOn}" icon="si si-briefcase" title="#{ivy.cm.co('/userDetail/WorkingOnTasks')}" />
-              <cc:OverviewBox box="gray" count="#{userDetailBean.personalTasks}" icon="si si-task-list-edit"
+              <cc:OverviewBox box="gray" count="#{userDetailBean.personalTasks}" icon="ti ti-checklist"
                 title="#{ivy.cm.co('/userDetail/PersonalTasks')}" />
-              <cc:OverviewBox box="darkgray" count="#{userDetailBean.canWorkOn}" icon="si si-task-list-approve"
+              <cc:OverviewBox box="darkgray" count="#{userDetailBean.canWorkOn}" icon="ti ti-clipboard-list"
                 title="#{ivy.cm.co('/userDetail/CanWorkOnTasks')}" />
             </div>
           </div>

--- a/engine-cockpit/webContent/view/users.xhtml
+++ b/engine-cockpit/webContent/view/users.xhtml
@@ -19,22 +19,22 @@
       <div class="card">
         <p:growl id="msgs" showDetail="true" />
         <h:form id="form" class="flex align-items-center mb-3">
-          <i class="pr-3 si si-single-neutral-actions card-title-icon"></i>
+          <i class="pr-3 ti ti-user-check card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Users')} <i id="userCount">(#{userBean.userCount})</i></h2>
           <h:panelGroup id="syncPanel" styleClass="ml-auto">
             <p:splitButton value="#{ivy.cm.co('/common/Synchronize')}"
-              icon="si si-button-refresh-arrows #{securityBean.syncRunningForSelectedSecuritySystem ? 'si-is-spinning' : ''} spin-icon"
+              icon="ti ti-refresh #{securityBean.syncRunningForSelectedSecuritySystem ? 'spinning' : ''} spin-icon"
               id="syncMoreBtn" rendered="#{!securityBean.ivySecurityForSelectedSecuritySystem}" immediate="true"
               process="@this" actionListener="#{securityBean.triggerSyncForSelectedSecuritySystem}" update="@parent">
-              <p:menuitem id="synchUserBtn" value="#{ivy.cm.co('/users/SynchSingleUser')}" icon="si si-button-refresh-arrows"
+              <p:menuitem id="synchUserBtn" value="#{ivy.cm.co('/users/SynchSingleUser')}" icon="ti ti-refresh"
                 onclick="PF('synchUserModal').show()" />
-              <p:menuitem id="userSyncLog" value="#{ivy.cm.co('/common/SynchronizationLog')}" icon="si si-common-file-text"
+              <p:menuitem id="userSyncLog" value="#{ivy.cm.co('/common/SynchronizationLog')}" icon="ti ti-file-text"
                 onclick="window.location.href='#{securityBean.synchLogUri}'" />
               <p:divider style="margin: 0;" />
-              <p:menuitem id="syncNewUserBtn" value="#{ivy.cm.co('/users/AddUser')}" icon="si si-add" onclick="PF('newUserModal').show();" />
+              <p:menuitem id="syncNewUserBtn" value="#{ivy.cm.co('/users/AddUser')}" icon="ti ti-plus" onclick="PF('newUserModal').show();" />
             </p:splitButton>
             <p:poll widgetVar="logPoller" autoStart="#{securityBean.syncRunningForSelectedSecuritySystem}" interval="2" update="@parent" />
-            <p:commandButton id="newUserBtn" value="#{ivy.cm.co('/common/Add')}" icon="si si-add" type="button"
+            <p:commandButton id="newUserBtn" value="#{ivy.cm.co('/common/Add')}" icon="ti ti-plus" type="button"
               onclick="PF('newUserModal').show();" rendered="#{securityBean.ivySecurityForSelectedSecuritySystem}" />
           </h:panelGroup>
         </h:form>

--- a/engine-cockpit/webContent/view/variables.xhtml
+++ b/engine-cockpit/webContent/view/variables.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
+      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="ti ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}configuration.html#global-variables" />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/variables.xhtml
+++ b/engine-cockpit/webContent/view/variables.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:define name="topbar-items">
-      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="si-common-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
+      <cc:TopBarItem styleClass="log-link" href="#{managerBean.configLogUrl}" icon="ti-file-text" title="#{ivy.cm.co('/common/ShowConfigurationLog')}" external="false" />
       <cc:TopBarItem href="#{advisorBean.cockpitEngineGuideUrl}configuration.html#global-variables" />
     </ui:define>
 

--- a/engine-cockpit/webContent/view/variables.xhtml
+++ b/engine-cockpit/webContent/view/variables.xhtml
@@ -26,7 +26,7 @@
           <p:autoUpdate />
         </p:growl>
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-archive-folder card-title-icon"></i>
+          <i class="pr-3 ti ti-archive card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/Variables')}</h2>
         </div>
         <cc:ApplicationTabs tabChange="#{variableBean.reloadVariables}" id="apps">

--- a/engine-cockpit/webContent/view/webserver.xhtml
+++ b/engine-cockpit/webContent/view/webserver.xhtml
@@ -67,7 +67,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-monitor-heart-beat-search"></i>
+                  <i class="pr-3 ti ti-device-desktop-search"></i>
                   <h6 class="m-0">#{ivy.cm.co('/webServer/RequestData')}</h6>
                 </div>
               </div>
@@ -136,7 +136,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-monitor-heart-beat-search"></i>
+                  <i class="pr-3 ti ti-device-desktop-search"></i>
                   <h6 class="m-0">#{ivy.cm.co('/webServer/ResponseHeaders')}</h6>
                 </div>
               </div>

--- a/engine-cockpit/webContent/view/webserver.xhtml
+++ b/engine-cockpit/webContent/view/webserver.xhtml
@@ -25,7 +25,7 @@
             <div class="card">
               <div class="card-header">
                 <div class="card-title flex align-items-center">
-                  <i class="pr-3 si si-network-signal"></i>
+                  <i class="pr-3 ti ti-building-broadcast-tower"></i>
                   <h6 class="m-0">#{ivy.cm.co('/webServer/WebServerConnectors')}</h6>
                 </div>
               </div>
@@ -38,10 +38,10 @@
               <h:form id="baseUrlForm">
                 <div class="card-header">
                   <div class="card-title flex align-items-center">
-                    <i class="pr-3 si si-cog"></i>
+                    <i class="pr-3 ti ti-settings"></i>
                     <h6 class="m-0">#{ivy.cm.co('/webServer/BaseUrlSettings')}</h6>
                     <p:commandButton id="save" actionListener="#{webServerBean.saveBaseUrl}" title="#{ivy.cm.co('/common/SaveChanges')}"
-                      icon="si si-floppy-disk" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
+                      icon="ti ti-device-floppy" styleClass="flex-shrink-0 ml-auto ui-button-success rounded-button" />
                   </div>
                 </div>
                 <p:panelGrid columns="2" columnClasses="col-12 md:col-3 lg:col-12, col-12 md:col-9 lg:col-12" layout="flex" 
@@ -49,7 +49,7 @@
                   <h:panelGroup>
                     <label>#{ivy.cm.co('/webServer/BaseUrl')}</label>
                     <h:panelGroup id="baseUrlHelp" styleClass="label-help-icon">
-                      <i class="si si-question-circle"></i>
+                      <i class="ti ti-help-circle"></i>
                       <p:tooltip for="baseUrlHelp" value="#{ivy.cm.co('/webServer/BaseUrlHelpMessage')}" position="top" />
                     </h:panelGroup>
                   </h:panelGroup>
@@ -80,7 +80,7 @@
                 <h:panelGroup>
                   <label>#{ivy.cm.co('/webServer/ExternalBaseUrl')}</label>
                   <h:panelGroup id="externalUrlHelp" styleClass="label-help-icon">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="externalUrlHelp" value="#{ivy.cm.co('/webServer/ExternalBaseUrlHelpMessage')}" position="top" />
                   </h:panelGroup>
                 </h:panelGroup>
@@ -89,7 +89,7 @@
                 <h:panelGroup>
                   <label>#{ivy.cm.co('/webServer/EvaluatedUrl')}</label>
                   <h:panelGroup id="evaluatedUrlHelp" styleClass="label-help-icon">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="evaluatedUrlHelp" value="#{ivy.cm.co('/webServer/EvaluatedUrlHelpMessage')}" position="top" />
                   </h:panelGroup>
                 </h:panelGroup>
@@ -98,7 +98,7 @@
                 <h:panelGroup>
                   <label>#{ivy.cm.co('/webServer/RemoteAddress')}</label>
                   <h:panelGroup id="remoteAddrHelp" styleClass="label-help-icon">
-                    <i class="si si-question-circle"></i>
+                    <i class="ti ti-help-circle"></i>
                     <p:tooltip for="remoteAddrHelp" value="#{ivy.cm.co('/webServer/RemoteAddressHelpMessage')}" position="top" />
                   </h:panelGroup>
                 </h:panelGroup>
@@ -106,7 +106,7 @@
               </p:panelGrid>
 
               <h:form id="requestForm">
-                <p:commandButton id="showRequestHeaders" value="#{ivy.cm.co('/webServer/ShowRequestHeaders')}" icon="si si-view-1" actionListener="#{webServerBean.setShowRequestHeaders}" 
+                <p:commandButton id="showRequestHeaders" value="#{ivy.cm.co('/webServer/ShowRequestHeaders')}" icon="ti ti-eye" actionListener="#{webServerBean.setShowRequestHeaders}" 
                   update="@form" rendered="#{!webServerBean.showRequestHeaders}" style="margin: 20px 0; width: 250px;" />
 
                 <p:dataTable id="requestHeaderTable" var="data" value="#{webServerBean.requestData}" rendered="#{webServerBean.showRequestHeaders}">
@@ -145,12 +145,12 @@
                 <span class="ui-message-info-icon"></span>
                 <span class="ui-message-info-summary">#{ivy.cm.co('/webServer/MissingSecurityHeadersSummaryMessage')}</span>
                 <span class="ui-message-info-detail">#{ivy.cm.content('/webServer/MissingSecurityHeadersDetailMessage').replace('missingSecurityHeaders', webServerBean.missingSecurityHeaders).get()}
-                  #{ivy.cm.co('/webServer/CheckDocumentLink')} <a href="#{advisorBean.engineGuideBaseUrl}/security/http-headers.html#http-headers"><i class="si si-hyperlink-3" />#{ivy.cm.co('/webServer/Documentation')}</a>
+                  #{ivy.cm.co('/webServer/CheckDocumentLink')} <a href="#{advisorBean.engineGuideBaseUrl}/security/http-headers.html#http-headers"><i class="ti ti-link" />#{ivy.cm.co('/webServer/Documentation')}</a>
                 </span>
               </h:panelGroup>
 
               <h:form id="responseForm">
-                <p:commandButton id="showResponseHeaders" value="#{ivy.cm.co('/webServer/ShowResponseHeaders')}" icon="si si-view-1" actionListener="#{webServerBean.setShowResponseHeaders}" 
+                <p:commandButton id="showResponseHeaders" value="#{ivy.cm.co('/webServer/ShowResponseHeaders')}" icon="ti ti-eye" actionListener="#{webServerBean.setShowResponseHeaders}" 
                   update="@form" rendered="#{!webServerBean.showResponseHeaders}" style="margin: 20px 0; width: 250px;" />
 
                 <p:dataTable id="responseHeaderTable" var="data" value="#{webServerBean.responseData}" rendered="#{webServerBean.showResponseHeaders}"

--- a/engine-cockpit/webContent/view/webservicedetail.xhtml
+++ b/engine-cockpit/webContent/view/webservicedetail.xhtml
@@ -23,7 +23,7 @@
     <ui:define name="topbar-items">
       <li class="topbar-item help-dialog">
         <a href="#" onclick="PF('helpServicesModal').show();">
-          <i class="topbar-icon si si-question-circle"></i>
+          <i class="topbar-icon ti ti-help-circle"></i>
         </a>
       </li>
     </ui:define>

--- a/engine-cockpit/webContent/view/webserviceprocesses.xhtml
+++ b/engine-cockpit/webContent/view/webserviceprocesses.xhtml
@@ -18,7 +18,7 @@
     <ui:define name="content">
       <div class="card">
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-network-arrow card-title-icon"></i>
+          <i class="pr-3 ti ti-network card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/WebServiceProcesses')}</h2>
         </div>
         <cc:ApplicationTabs tabChange="#{managerBean.reloadApplications}" id="tabs">
@@ -28,7 +28,7 @@
               styleClass="ui-fluid webServiceProcessesTable">
               <p:column headerText="#{ivy.cm.co('/webServiceProcesses/WebServiceWSDL')}" filterBy="#{ws.processName}">
                 <p:link href="#{ws.link}" target="_blank" rel="noopener noreferrer">
-                  <i class="si si-network-arrow table-icon"></i> #{ws.processName}?WSDL
+                  <i class="ti ti-network table-icon"></i> #{ws.processName}?WSDL
                 </p:link>
               </p:column>
             </p:dataTable>

--- a/engine-cockpit/webContent/view/webservices.xhtml
+++ b/engine-cockpit/webContent/view/webservices.xhtml
@@ -19,7 +19,7 @@
       <div class="card">
         <p:growl id="msgs" />
         <div class="flex align-items-center mb-3">
-          <i class="pr-3 si si-network-arrow card-title-icon"></i>
+          <i class="pr-3 ti ti-network card-title-icon"></i>
           <h2 class="m-0">#{ivy.cm.co('/common/WebServiceClients')}</h2>
         </div>
         <cc:ApplicationTabs tabChange="#{webserviceBean.reloadWebservices}" id="tabs">
@@ -30,7 +30,7 @@
               filteredValue="#{webserviceBean.filteredWebservices}" lazy="false" id="webservicesTable">
               <f:facet name="header">
                 <div class="ui-input-icon-left filter-container">
-                  <i class="pi pi-search"/>
+                  <i class="ti ti-search"/>
                   <p:inputText id="globalFilter" onkeyup="PF('webservicesTable_#{app.id}').filter()" placeholder="#{ivy.cm.co('/common/SearchPlaceholder')}" value="#{webserviceBean.filter}" />
                 </div>
               </f:facet>
@@ -39,7 +39,7 @@
                 styleClass="webservice-name-column">
                 <a href="#{webservice.getViewUrl(app.name)}">
                   <h:outputText value="#{webservice.name}" styleClass="webservice-name">
-                    <i class="si si-network-arrow table-icon"></i>
+                    <i class="ti ti-network table-icon"></i>
                   </h:outputText>
                 </a>
               </p:column>


### PR DESCRIPTION
Replace depreceated icons with Tabler icons
The old icon libraries are
- Streamline (si)
- FontAwesome (fa)
- PrimeIcons (pi)

The mapping is documented here:
[Migrate to Tabler Icons](https://axon-ivy.atlassian.net/wiki/spaces/XIVY/pages/458752001/Migrate+to+Tabler+icons)

Note: Screenshot tests are failing in 4 instances, due to slight mismatch in icons.