### PR TITLE
Fix wrong icon

### DIFF
--- a/engine-cockpit/webContent/view/info.xhtml
+++ b/engine-cockpit/webContent/view/info.xhtml
@@ -93,7 +93,7 @@
                       <i class="ti ti-layout-grid icon-app" />
                     </div>
                     <div class="flex flex-1 justify-content-end">
-                      <p:linkButton href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}" icon="ti ti-settings-play" styleClass="flex-shrink-0 ml-auto rounded-button ui-button-outlined" />
+                      <p:linkButton href="#{app.devWorkflowUrl}" rendered="#{!app.disabled}" icon="ti ti-settings-automation" styleClass="flex-shrink-0 ml-auto rounded-button ui-button-outlined" />
                     </div>
                   </div>
                   


### PR DESCRIPTION
Replace nonexistent icon 'ti ti-settings-play' with 'ti ti-settings-automation'.
icon-replacement-mapping is correct, this was a manual error.