### PR TITLE
Fix livestats icon

### DIFF
--- a/engine-cockpit/webContent/resources/composite/Sidebar.xhtml
+++ b/engine-cockpit/webContent/resources/composite/Sidebar.xhtml
@@ -3,13 +3,12 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui">
 <cc:interface>
-  <cc:attribute name="icon" default="analytics-graph-line" />
   <cc:attribute name="jmxSource" default="" type="java.lang.String" />
 </cc:interface>
 
 <cc:implementation>
   <a href="#" id="layout-config-button" class="layout-config-button" onclick="PF('liveStatePoll').start();">
-    <i class="#{cc.attrs.icon}"></i>
+    <i class="ti ti-chart-histogram"></i>
   </a>
   
   <div id="layout-config" class="layout-config">


### PR DESCRIPTION
old
<img width="61" height="73" alt="image" src="https://github.com/user-attachments/assets/b8f9735b-a289-4bcc-9b85-90f6c2e36e94" />

before
<img width="74" height="83" alt="image" src="https://github.com/user-attachments/assets/a706e7cd-8713-41a6-977d-f90912ef4910" />

after
<img width="70" height="97" alt="image" src="https://github.com/user-attachments/assets/b434716e-fd25-4214-9da4-cca8d1dcab9d" />
