### PR TITLE
fix: duplicated 'Project' key in CMS

### DIFF
--- a/engine-cockpit/cms/cms_de.yaml
+++ b/engine-cockpit/cms/cms_de.yaml
@@ -974,7 +974,6 @@ projectDetail:
   Project: Project
   ProjectInformation: PMV Information
   PMVResolvedForSpecificationMessage: '''${name}'' gefunden für diese Spezifikation'
-  Project: Projekt
   ProjectVersion: Projektversion
   ReleaseState: Freigabezustand
   RequriedPMVTableEmptyMessage: Das PMV '${name}' hat keine erforderlichen PMVs.

--- a/engine-cockpit/cms/cms_ja.yaml
+++ b/engine-cockpit/cms/cms_ja.yaml
@@ -988,7 +988,6 @@ projectDetail:
   LastDeployed: 最終展開
   NoProjectFoundForSpecificationMessage: この仕様ではプロジェクトが見つかりませんでした。
   NotAllDirectIndirectRequiredLibrariesAvailableMessage: システムでは直接的および間接的に必要なライブラリをすべて利用できるとは限りません。
-  Project: Project
   ProjectInformation: PMV 情報
   PMVResolvedForSpecificationMessage: この仕様に解決された '${name}'
   Project: プロジェクト


### PR DESCRIPTION

<img width="1534" height="852" alt="weblate-corrupt" src="https://github.com/user-attachments/assets/223996cd-8386-47d0-9bc0-58790b858d14" />

